### PR TITLE
Update UI progress bars on player combat

### DIFF
--- a/PantheonWars/GUI/BlessingDialogEventHandlers.cs
+++ b/PantheonWars/GUI/BlessingDialogEventHandlers.cs
@@ -412,12 +412,13 @@ public partial class BlessingDialog
     /// </summary>
     private void OnPlayerReligionDataUpdated(PlayerReligionDataPacket packet)
     {
-        // Only update if dialog is open and has data loaded
-        if (!_state.IsOpen || _manager == null || !_manager.HasReligion()) return;
+        // Skip if manager is not initialized yet
+        if (_manager == null) return;
 
         _capi!.Logger.Debug($"[PantheonWars] Updating blessing dialog with new favor data: {packet.Favor}, Total: {packet.TotalFavorEarned}");
 
-        // Update manager with new values
+        // Always update manager with new values, even if dialog is closed
+        // This ensures the UI shows correct values when opened
         _manager.CurrentFavor = packet.Favor;
         _manager.CurrentPrestige = packet.Prestige;
         _manager.TotalFavorEarned = packet.TotalFavorEarned;
@@ -435,7 +436,11 @@ public partial class BlessingDialog
         }
 
         // Refresh blessing states in case new blessings became available
-        _manager.RefreshAllBlessingStates();
+        // Only do this if dialog is open to avoid unnecessary processing
+        if (_state.IsOpen && _manager.HasReligion())
+        {
+            _manager.RefreshAllBlessingStates();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Previously, the OnPlayerReligionDataUpdated handler would only update the manager's favor/prestige values if the blessing dialog was open. This caused progress bars to not reflect kills/deaths that occurred while the dialog was closed.

Now the manager always receives updates from the server, ensuring progress bars show current values when the dialog is opened.

Changes:
- Remove _state.IsOpen check from OnPlayerReligionDataUpdated
- Always update manager data when packets arrive from server
- Only refresh blessing states if dialog is actually open