### PR TITLE
Fix Postfix patch duplicating ore drop bonus

### DIFF
--- a/DivineAscension/Systems/Patches/KhorasPatches.cs
+++ b/DivineAscension/Systems/Patches/KhorasPatches.cs
@@ -42,45 +42,7 @@ public static class KhorasPatches
         amount = Math.Max(0, amount - reduceInt);
     }
 
-    // Patch for Ore Yield
-    // Target: Block.GetDrops
-    // Data Source: Checks 'oreYield' stat defined in BlessingDefinitions.cs and applied by BlessingEffectSystem.cs
-    // Logic: Increase stack size of ore drops based on OreYield stat
-    [HarmonyPatch(typeof(Block), "GetDrops")]
-    [HarmonyPostfix]
-    public static void Postfix_GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, ref ItemStack[] __result)
-    {
-        if (byPlayer?.Entity == null || __result == null || __result.Length == 0) return;
-
-        // Get ore yield bonus
-        // Handle both FlatSum (base 0) and legacy WeightedSum (base 1.0) registrations
-        double yieldBonus = byPlayer.Entity.Stats.GetBlended(VintageStoryStats.OreDropRate);
-        if (yieldBonus > 1.0) yieldBonus -= 1.0; // Legacy WeightedSum: subtract base
-        if (yieldBonus <= 0) return;
-
-        // Check if block is an ore block (simple check by code)
-        var block = world.BlockAccessor.GetBlock(pos);
-        if (block == null) return;
-
-        // We only apply to "ore-" blocks to avoid infinite wood/dirt duping
-        if (!block.Code.Path.StartsWith("ore-")) return;
-
-        foreach (var stack in __result)
-        {
-            if (stack == null) continue;
-
-            // Only boost nuggets/chunks/ores
-            if (!stack.Collectible.Code.Path.Contains("ore") &&
-                !stack.Collectible.Code.Path.Contains("nugget") &&
-                !stack.Collectible.Code.Path.Contains("chunk")) continue;
-
-            // Calculate extra
-            var extra = stack.StackSize * (float)yieldBonus;
-            var extraInt = (int)extra;
-
-            if (world.Rand.NextDouble() < extra - extraInt) extraInt++;
-
-            if (extraInt > 0) stack.StackSize += extraInt;
-        }
-    }
+    // Note: Ore yield bonus is handled natively by Vintage Story's oreDropRate stat.
+    // No Harmony patch needed - the stat modifier applied by BlessingEffectSystem
+    // is automatically processed by the game's Block.GetDrops() method.
 }


### PR DESCRIPTION
Remove Postfix_GetDrops patch that was duplicating ore yield bonuses. Vintage Story's engine already processes the oreDropRate stat natively in Block.GetDrops(), so our Harmony patch was applying the bonus twice.

This caused players with the 10% Craftsman's Touch blessing to get ~21% bonus instead of 10%, and higher-tier blessings had even more severe duplication.

The stat modifier is still correctly registered and applied by BlessingEffectSystem - we simply let VS's native code handle it.

Fixes user report of "ridiculous amounts of ore" with first blessing.