### PR TITLE
fix: use RELEASE_TOKEN PAT for pushing version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for version analysis
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to allow pushing past branch protection rules
+          # Falls back to GITHUB_TOKEN if RELEASE_TOKEN is not set
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Summary

- Use a Personal Access Token (`RELEASE_TOKEN`) instead of `GITHUB_TOKEN` to allow pushing version bump commits past branch protection rules
- Falls back to `GITHUB_TOKEN` if the secret is not configured
