### PR TITLE
PR-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,7 @@ jobs:
           ASSEMBLY_FILE="DivineAscension/Properties/AssemblyInfo.cs"
           if [ -f "$ASSEMBLY_FILE" ]; then
             echo "Updating $ASSEMBLY_FILE"
-            sed -i "s/AssemblyVersion(\"[^\"]*\")/AssemblyVersion(\"$NEW_VERSION.0\")/" "$ASSEMBLY_FILE"
-            sed -i "s/AssemblyFileVersion(\"[^\"]*\")/AssemblyFileVersion(\"$NEW_VERSION.0\")/" "$ASSEMBLY_FILE"
+            sed -i "s/Version = \"[^\"]*\",/Version = \"$NEW_VERSION\",/" "$ASSEMBLY_FILE"
           fi
 
       - name: Create Pull Request


### PR DESCRIPTION
PR-based release workflow                                                                                        
                                                                                                                   
  Replaces direct version bumps with automated PRs that respect branch protection:                                 
                                                                                                                   
  - Analyzes conventional commits (feat/fix/BREAKING) to determine version bumps                                   
  - Creates release/vX.Y.Z PRs with updated version files                                                          
  - Generates GitHub releases with packaged mod when PRs merge                                                     
  - Fixes AssemblyInfo.cs pattern to match Vintage Story's ModInfo format 