### PR TITLE
feat: integrate CakeBuild into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,33 +227,27 @@ jobs:
             echo "Will create release $TAG"
           fi
 
-      - name: Restore dependencies
+      - name: Build and Package with Cake
         if: steps.release_check.outputs.exists == 'false'
-        run: dotnet restore DivineAscension.sln
+        run: ./build.sh
 
-      - name: Build Release
+      - name: Set package paths
         if: steps.release_check.outputs.exists == 'false'
-        run: dotnet build DivineAscension.sln -c Release --no-restore
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PACKAGE_NAME="divineascension_${VERSION}.zip"
+          PACKAGE_PATH="Releases/${PACKAGE_NAME}"
+
+          echo "Package created: $PACKAGE_PATH"
+          ls -lh "$PACKAGE_PATH"
+
+          echo "package_name=$PACKAGE_NAME" >> $GITHUB_ENV
+          echo "package_path=$PACKAGE_PATH" >> $GITHUB_ENV
 
       - name: Run tests
         if: steps.release_check.outputs.exists == 'false'
         run: dotnet test DivineAscension.sln -c Release --no-build --verbosity normal
         continue-on-error: true  # Don't block release on test issues with stubs
-
-      - name: Package mod
-        if: steps.release_check.outputs.exists == 'false'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          MOD_DIR="DivineAscension/bin/Release/Mods/mod"
-          PACKAGE_NAME="DivineAscension-${VERSION}.zip"
-
-          echo "Creating package: $PACKAGE_NAME"
-
-          cd "$MOD_DIR"
-          zip -r "../../../../$PACKAGE_NAME" .
-
-          echo "package_name=$PACKAGE_NAME" >> $GITHUB_ENV
-          echo "package_path=$PACKAGE_NAME" >> $GITHUB_ENV
 
       - name: Generate release notes
         if: steps.release_check.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

Replaces manual dotnet build/package commands in the GitHub Actions release workflow with CakeBuild execution. This ensures local builds (`./build.sh`) match CI builds exactly.

## Changes Made

- **Replaced manual build steps** with `./build.sh` (CakeBuild)
- **Package path updated** from `DivineAscension-{version}.zip` to `Releases/divineascension_{version}.zip`
- **Package naming** now follows modid convention from modinfo.json

## Benefits

- ✅ **Consistency**: Local and CI builds use identical process
- ✅ **JSON validation**: CakeBuild validates all asset JSON files before packaging
- ✅ **Proper packaging**: Uses CakeBuild's PackageTask for correct mod structure
- ✅ **Simplified workflow**: Single command instead of restore + build + manual zip
- ✅ **CI-ready**: Works with stub assemblies (no VINTAGE_STORY env var needed)

## CakeBuild Pipeline

The `./build.sh` script runs three tasks:
1. **ValidateJsonTask** - Validates all `.json` files in assets/
2. **BuildTask** - Builds Release configuration
3. **PackageTask** - Creates properly structured zip in Releases/

## Testing Plan

1. Merge a commit with `feat:` prefix to trigger version bump PR
2. Merge version bump PR to trigger release workflow
3. Verify:
   - "Build and Package with Cake" step succeeds
   - Package created at `Releases/divineascension_{version}.zip`
   - GitHub Release has correct zip attached
   - Zip contains: divineascension.dll, modinfo.json, assets/

## Related

- Complements commitlint enforcement (#134)
- Uses CI stub assemblies from `lib/ci-stubs/`