### PR TITLE
fix: remove legacy code for weightedsum

### DIFF
--- a/DivineAscension/Systems/Patches/CraftPatches.cs
+++ b/DivineAscension/Systems/Patches/CraftPatches.cs
@@ -3,7 +3,6 @@ using DivineAscension.Constants;
 using HarmonyLib;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
-using Vintagestory.API.MathTools;
 
 namespace DivineAscension.Systems.Patches;
 
@@ -24,9 +23,8 @@ public static class CraftPatches
         if (item.Tool == null) return; // Not a tool
 
         // Get tool durability bonus (e.g. 0.10 for 10%)
-        // Handle both FlatSum (base 0) and legacy WeightedSum (base 1.0) registrations
-        double durabilityBonus = byEntity.Stats.GetBlended(VintageStoryStats.ToolDurability);
-        if (durabilityBonus > 1.0) durabilityBonus -= 1.0; // Legacy WeightedSum: subtract base
+        // VS returns 1.0 as base; blessings add to it (1.10 = 10% bonus)
+        double durabilityBonus = byEntity.Stats.GetBlended(VintageStoryStats.ToolDurability) - 1.0;
         if (durabilityBonus <= 0) return;
 
         // Calculate reduction


### PR DESCRIPTION
## Summary

Players do not lose durability unless they are in the Craft domain. 

## Type of Change

<!-- Check the type(s) that apply -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `docs`: Documentation changes
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Dependencies, tooling, or other maintenance

## Changes Made

<!-- List the main changes in this PR -->

- Removed weighted sum legacy check

## Testing

<!-- Describe how you tested these changes -->

- [x] Tested in-game
- [x] Unit tests added/updated
- [x] Existing tests pass

**Test details:**
Mined without craft domain/with wild domain and without a domain too.

## Checklist

- [x] All commits follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat:`, `fix:`)
- [x] Code builds without warnings
- [x] Changes are documented (if applicable)
- [x] No sensitive information (API keys, passwords, etc.) included

## Additional Context

<!-- Add any other context, screenshots, or information that reviewers should know -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #
