### PR TITLE
ci: bump setup-dotnet to 10.0.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -86,7 +86,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Bump `actions/setup-dotnet` from `8.0.x` to `10.0.x` in `release.yml` (1 step) and `build.yml` (2 steps) so CI uses an SDK that matches the post-VS-1.22 `net10.0` target

## Test plan
- [ ] PR CI green
- [ ] Next merge to master cuts a `chore(release):` bump PR and the resulting Release job builds + packages without an SDK mismatch