### PR TITLE
Pantheon 2.0 Phase 1: per-deity favor + patron rename (#237)

### DIFF
--- a/DivineAscension.Tests/Commands/Blessing/BlessingCommandListTests.cs
+++ b/DivineAscension.Tests/Commands/Blessing/BlessingCommandListTests.cs
@@ -72,10 +72,10 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
         _playerReligionDataManager.Setup(prdm => prdm.GetOrCreatePlayerData(It.IsAny<string>()))
             .Returns(playerData);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(playerBlessings);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(religionBlessings);
 
         var religion = new ReligionData("religion-uid", "Test Religion", DeityDomain.Harvest, "Test Deity", "founder-uid", "Founder");
@@ -92,7 +92,7 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
 
         // Assert
         Assert.Contains(
-            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Harvest.ToLocalizedString()),
+            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Craft.ToLocalizedString()),
             result.StatusMessage);
         Assert.Contains(FormatStringConstants.HeaderPlayerBlessings, result.StatusMessage);
         Assert.Contains("✓ Divine Strike", result.StatusMessage); // Localized format
@@ -158,10 +158,10 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
         _playerReligionDataManager.Setup(prdm => prdm.GetOrCreatePlayerData(It.IsAny<string>()))
             .Returns(playerData);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(new List<DivineAscension.Models.Blessing>());
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(new List<DivineAscension.Models.Blessing>());
 
         // Act
@@ -169,7 +169,7 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
 
         // Assert
         Assert.Contains(
-            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Harvest.ToLocalizedString()),
+            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Craft.ToLocalizedString()),
             result.StatusMessage);
         Assert.Contains(FormatStringConstants.HeaderPlayerBlessings, result.StatusMessage);
         Assert.Contains(FormatStringConstants.HeaderReligionBlessings, result.StatusMessage);
@@ -195,10 +195,10 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
         _playerReligionDataManager.Setup(prdm => prdm.GetOrCreatePlayerData(It.IsAny<string>()))
             .Returns(playerData);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(new List<DivineAscension.Models.Blessing>());
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(new List<DivineAscension.Models.Blessing>());
 
         // Act
@@ -206,7 +206,7 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
 
         // Assert
         Assert.Contains(
-            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Harvest.ToLocalizedString()),
+            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Craft.ToLocalizedString()),
             result.StatusMessage);
         Assert.Contains(FormatStringConstants.HeaderPlayerBlessings, result.StatusMessage);
         Assert.Contains(FormatStringConstants.HeaderReligionBlessings, result.StatusMessage);
@@ -244,11 +244,11 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
             .Returns(playerData);
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(religionBlessings);
 
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(new List<DivineAscension.Models.Blessing>());
 
         var religion = new ReligionData("religion-uid", "Test Religion", DeityDomain.Harvest, "Test Deity", "founder-uid", "Founder");
@@ -262,7 +262,7 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
 
         // Assert
         Assert.Contains(
-            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Harvest.ToLocalizedString()),
+            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Craft.ToLocalizedString()),
             result.StatusMessage);
         Assert.Contains(FormatStringConstants.HeaderReligionBlessings, result.StatusMessage);
         Assert.Contains("✓ Sacred Flame", result.StatusMessage); // Localized format
@@ -299,10 +299,10 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
         _playerReligionDataManager.Setup(prdm => prdm.GetOrCreatePlayerData(It.IsAny<string>()))
             .Returns(playerData);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(playerBlessings);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(new List<DivineAscension.Models.Blessing>());
 
         // Act
@@ -345,10 +345,10 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
         _playerReligionDataManager.Setup(prdm => prdm.GetOrCreatePlayerData(It.IsAny<string>()))
             .Returns(playerData);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(new List<DivineAscension.Models.Blessing>());
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(religionBlessings);
 
         var religion = new ReligionData("religion-uid", "Test Religion", DeityDomain.Harvest, "Test Deity", "founder-uid", "Founder");
@@ -396,10 +396,10 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
         _playerReligionDataManager.Setup(prdm => prdm.GetOrCreatePlayerData(It.IsAny<string>()))
             .Returns(playerData);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(playerBlessings);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(new List<DivineAscension.Models.Blessing>());
 
         // Act
@@ -456,10 +456,10 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
         _playerReligionDataManager.Setup(prdm => prdm.GetOrCreatePlayerData(It.IsAny<string>()))
             .Returns(playerData);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Player))
+            .Returns(DeityDomain.Craft);
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Player))
             .Returns(playerBlessings);
-        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Harvest, BlessingKind.Religion))
+        _blessingRegistry.Setup(pr => pr.GetBlessingsForDeity(DeityDomain.Craft, BlessingKind.Religion))
             .Returns(religionBlessings);
 
         var religion = new ReligionData("religion-uid", "Test Religion", DeityDomain.Harvest, "Test Deity", "founder-uid", "Founder");
@@ -475,7 +475,7 @@ public class BlessingCommandListTests : BlessingCommandsTestHelpers
 
         // Header
         Assert.Contains(
-            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Harvest.ToLocalizedString()),
+            string.Format(FormatStringConstants.HeaderBlessingsForDeity, DeityDomain.Craft.ToLocalizedString()),
             message);
 
         // Player blessings section

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandAdminTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandAdminTests.cs
@@ -25,7 +25,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, 5000, 10000);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 5000, 10000);
         var args = CreateAdminCommandArgs(mockPlayer.Object);
         SetupParsers(args, new object[] { null });
 
@@ -34,7 +34,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
+            .Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnResetFavor(args);
@@ -44,7 +44,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Equal(EnumCommandStatus.Success, result.Status);
         Assert.Contains("reset to 0", result.StatusMessage);
         Assert.Contains("5,000", result.StatusMessage); // Old value
-        Assert.Equal(0, playerData.Favor);
+        Assert.Equal(0, playerData.GetFavor(DeityDomain.Craft));
     }
 
     #endregion
@@ -56,7 +56,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, 100, 500);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 100, 500);
         var args = CreateAdminCommandArgs(mockPlayer.Object);
         SetupParsers(args, new object[] { null });
 
@@ -73,7 +73,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Equal(EnumCommandStatus.Success, result.Status);
         Assert.Contains("99,999", result.StatusMessage);
         Assert.Contains("100", result.StatusMessage); // Old value
-        Assert.Equal(99999, playerData.Favor);
+        Assert.Equal(99999, playerData.GetFavor(DeityDomain.Craft));
     }
 
     #endregion
@@ -85,7 +85,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.None);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft);
         var argsReset = CreateAdminCommandArgs(mockPlayer.Object);
         SetupParsers(argsReset, new object[] { null });
         var argsMax = CreateAdminCommandArgs(mockPlayer.Object);
@@ -113,7 +113,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Wild, 100, 500);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 100, 500);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "50", "TargetPlayer");
         SetupParsers(args, 50, "TargetPlayer");
@@ -123,8 +123,8 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("admin-1")).Returns(adminData);
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-2")).Returns(targetData);
-        _playerReligionDataManager.Setup(m => m.AddFavor("player-2", 50, It.IsAny<string>()))
-            .Callback(() => targetData.Favor += 50);
+        _playerReligionDataManager.Setup(m => m.AddFavor("player-2", DeityDomain.Craft, 50, It.IsAny<string>()))
+            .Callback(() => targetData.AddFavor(DeityDomain.Craft, 50));
 
         _religionManager.Setup(pr => pr.GetPlayerReligion("admin-1"))
             .Returns(TestFixtures.CreateTestReligion());
@@ -132,7 +132,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Wild);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnAddFavor(args);
@@ -144,7 +144,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Contains("TargetPlayer", result.StatusMessage);
         Assert.Contains("100", result.StatusMessage);
         Assert.Contains("150", result.StatusMessage);
-        Assert.Equal(150, targetData.Favor);
+        Assert.Equal(150, targetData.GetFavor(DeityDomain.Craft));
     }
 
     #endregion
@@ -159,7 +159,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Stone, 200, 500);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 200, 500);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "50", "TargetPlayer");
         SetupParsers(args, 50, "TargetPlayer");
@@ -169,8 +169,8 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("admin-1")).Returns(adminData);
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-2")).Returns(targetData);
-        _playerReligionDataManager.Setup(m => m.RemoveFavor("player-2", 50, It.IsAny<string>()))
-            .Callback(() => targetData.Favor = Math.Max(0, targetData.Favor - 50))
+        _playerReligionDataManager.Setup(m => m.RemoveFavor("player-2", DeityDomain.Craft, 50, It.IsAny<string>()))
+            .Callback(() => targetData.SetFavor(DeityDomain.Craft, Math.Max(0, targetData.GetFavor(DeityDomain.Craft) - 50)))
             .Returns(true);
 
         _religionManager.Setup(pr => pr.GetPlayerReligion("admin-1"))
@@ -179,7 +179,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Stone);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnRemoveFavor(args);
@@ -191,7 +191,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Contains("TargetPlayer", result.StatusMessage);
         Assert.Contains("200", result.StatusMessage);
         Assert.Contains("150", result.StatusMessage);
-        Assert.Equal(150, targetData.Favor);
+        Assert.Equal(150, targetData.GetFavor(DeityDomain.Craft));
     }
 
     #endregion
@@ -206,7 +206,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Harvest, 5000, 10000);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 5000, 10000);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "TargetPlayer");
         SetupParsers(args, "TargetPlayer");
@@ -223,7 +223,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Harvest);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnResetFavor(args);
@@ -234,7 +234,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Contains("reset to 0", result.StatusMessage);
         Assert.Contains("TargetPlayer", result.StatusMessage);
         Assert.Contains("5,000", result.StatusMessage);
-        Assert.Equal(0, targetData.Favor);
+        Assert.Equal(0, targetData.GetFavor(DeityDomain.Craft));
     }
 
     #endregion
@@ -249,7 +249,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Wild, 100, 500);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 100, 500);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "TargetPlayer");
         SetupParsers(args, "TargetPlayer");
@@ -266,7 +266,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Wild);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnMaxFavor(args);
@@ -277,7 +277,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Contains("99,999", result.StatusMessage);
         Assert.Contains("TargetPlayer", result.StatusMessage);
         Assert.Contains("100", result.StatusMessage);
-        Assert.Equal(99999, targetData.Favor);
+        Assert.Equal(99999, targetData.GetFavor(DeityDomain.Craft));
     }
 
     #endregion
@@ -295,8 +295,8 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
 
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-1")).Returns(playerData);
-        _playerReligionDataManager.Setup(m => m.AddFavor("player-1", 50, It.IsAny<string>()))
-            .Callback(() => playerData.Favor += 50);
+        _playerReligionDataManager.Setup(m => m.AddFavor("player-1", DeityDomain.Craft, 50, It.IsAny<string>()))
+            .Callback(() => playerData.AddFavor(DeityDomain.Craft, 50));
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
@@ -347,14 +347,14 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Wild, favor: 200, totalFavor: 500);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, favor: 200, totalFavor: 500);
         var args = CreateAdminCommandArgs(mockPlayer.Object, "50");
         SetupParsers(args, 50, (string)null);
 
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-1")).Returns(playerData);
-        _playerReligionDataManager.Setup(m => m.RemoveFavor("player-1", 50, It.IsAny<string>()))
-            .Callback(() => playerData.Favor = Math.Max(0, playerData.Favor - 50))
+        _playerReligionDataManager.Setup(m => m.RemoveFavor("player-1", DeityDomain.Craft, 50, It.IsAny<string>()))
+            .Callback(() => playerData.SetFavor(DeityDomain.Craft, Math.Max(0, playerData.GetFavor(DeityDomain.Craft) - 50)))
             .Returns(true);
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
@@ -377,13 +377,13 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, favor: 50, totalFavor: 500);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, favor: 50, totalFavor: 500);
         var args = CreateAdminCommandArgs(mockPlayer.Object, "100");
         SetupParsers(args, 100, (string)null);
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-1")).Returns(playerData);
-        _playerReligionDataManager.Setup(m => m.RemoveFavor("player-1", 100, It.IsAny<string>()))
-            .Callback(() => playerData.Favor = 0)
+        _playerReligionDataManager.Setup(m => m.RemoveFavor("player-1", DeityDomain.Craft, 100, It.IsAny<string>()))
+            .Callback(() => playerData.SetFavor(DeityDomain.Craft, 0))
             .Returns(true);
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
@@ -433,7 +433,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, 100, 100,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 100, 100,
             FavorRank.Initiate);
         var args = CreateAdminCommandArgs(mockPlayer.Object, "5000");
         SetupParsers(args, 5000, (string)null);
@@ -443,17 +443,17 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
+            .Returns(DeityDomain.Craft);
 
         _playerReligionDataManager
-            .Setup(m => m.GetPlayerFavorRank("player-1"))
+            .Setup(m => m.GetPlayerFavorRank("player-1", DeityDomain.Craft))
             .Returns(() =>
             {
                 // Calculate rank based on current TotalFavorEarned
-                if (playerData.TotalFavorEarned >= 10000) return FavorRank.Avatar;
-                if (playerData.TotalFavorEarned >= 5000) return FavorRank.Champion;
-                if (playerData.TotalFavorEarned >= 2000) return FavorRank.Zealot;
-                if (playerData.TotalFavorEarned >= 500) return FavorRank.Disciple;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 10000) return FavorRank.Avatar;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 5000) return FavorRank.Champion;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 2000) return FavorRank.Zealot;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 500) return FavorRank.Disciple;
                 return FavorRank.Initiate;
             });
 
@@ -466,7 +466,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Contains("5,000", result.StatusMessage);
         Assert.Contains("100", result.StatusMessage); // Old total
         Assert.Contains("Rank updated", result.StatusMessage);
-        Assert.Equal(5000, playerData.TotalFavorEarned);
+        Assert.Equal(5000, playerData.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
@@ -474,7 +474,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Stone, 100, 600,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 100, 600,
             FavorRank.Disciple);
         var args = CreateAdminCommandArgs(mockPlayer.Object, "700");
         SetupParsers(args, 700, (string)null);
@@ -484,17 +484,17 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Stone);
+            .Returns(DeityDomain.Craft);
 
         _playerReligionDataManager
-            .Setup(m => m.GetPlayerFavorRank("player-1"))
+            .Setup(m => m.GetPlayerFavorRank("player-1", DeityDomain.Craft))
             .Returns(() =>
             {
                 // Calculate rank based on current TotalFavorEarned
-                if (playerData.TotalFavorEarned >= 10000) return FavorRank.Avatar;
-                if (playerData.TotalFavorEarned >= 5000) return FavorRank.Champion;
-                if (playerData.TotalFavorEarned >= 2000) return FavorRank.Zealot;
-                if (playerData.TotalFavorEarned >= 500) return FavorRank.Disciple;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 10000) return FavorRank.Avatar;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 5000) return FavorRank.Champion;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 2000) return FavorRank.Zealot;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 500) return FavorRank.Disciple;
                 return FavorRank.Initiate;
             });
 
@@ -506,7 +506,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Equal(EnumCommandStatus.Success, result.Status);
         Assert.Contains("Rank unchanged", result.StatusMessage);
         Assert.Contains("Disciple", result.StatusMessage);
-        Assert.Equal(700, playerData.TotalFavorEarned);
+        Assert.Equal(700, playerData.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
@@ -566,7 +566,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Harvest, 100, 100, FavorRank.Initiate);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 100, 100, FavorRank.Initiate);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "5000", "TargetPlayer");
         SetupParsers(args, 5000, "TargetPlayer");
@@ -583,17 +583,17 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Harvest);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         _playerReligionDataManager
-            .Setup(m => m.GetPlayerFavorRank("player-2"))
+            .Setup(m => m.GetPlayerFavorRank("player-2", DeityDomain.Craft))
             .Returns(() =>
             {
                 // Calculate rank based on current TotalFavorEarned
-                if (targetData.TotalFavorEarned >= 10000) return FavorRank.Avatar;
-                if (targetData.TotalFavorEarned >= 5000) return FavorRank.Champion;
-                if (targetData.TotalFavorEarned >= 2000) return FavorRank.Zealot;
-                if (targetData.TotalFavorEarned >= 500) return FavorRank.Disciple;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 10000) return FavorRank.Avatar;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 5000) return FavorRank.Champion;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 2000) return FavorRank.Zealot;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 500) return FavorRank.Disciple;
                 return FavorRank.Initiate;
             });
 
@@ -606,7 +606,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Contains("5,000", result.StatusMessage);
         Assert.Contains("100", result.StatusMessage); // Old total
         Assert.Contains("Rank updated", result.StatusMessage);
-        Assert.Equal(5000, targetData.TotalFavorEarned);
+        Assert.Equal(5000, targetData.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
@@ -617,7 +617,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Wild, 100, 600, FavorRank.Disciple);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 100, 600, FavorRank.Disciple);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "700", "TargetPlayer");
         SetupParsers(args, 700, "TargetPlayer");
@@ -634,17 +634,17 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Wild);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         _playerReligionDataManager
-            .Setup(m => m.GetPlayerFavorRank("player-2"))
+            .Setup(m => m.GetPlayerFavorRank("player-2", DeityDomain.Craft))
             .Returns(() =>
             {
                 // Calculate rank based on current TotalFavorEarned
-                if (targetData.TotalFavorEarned >= 10000) return FavorRank.Avatar;
-                if (targetData.TotalFavorEarned >= 5000) return FavorRank.Champion;
-                if (targetData.TotalFavorEarned >= 2000) return FavorRank.Zealot;
-                if (targetData.TotalFavorEarned >= 500) return FavorRank.Disciple;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 10000) return FavorRank.Avatar;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 5000) return FavorRank.Champion;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 2000) return FavorRank.Zealot;
+                if (targetData.GetTotalFavorEarned(DeityDomain.Craft) >= 500) return FavorRank.Disciple;
                 return FavorRank.Initiate;
             });
 
@@ -658,7 +658,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Contains("600", result.StatusMessage); // Old total
         Assert.Contains("Rank unchanged", result.StatusMessage);
         Assert.Contains("Disciple", result.StatusMessage);
-        Assert.Equal(700, targetData.TotalFavorEarned);
+        Assert.Equal(700, targetData.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
@@ -696,7 +696,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.None, 0, 0);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 0, 0);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "5000", "TargetPlayer");
         SetupParsers(args, 5000, "TargetPlayer");
@@ -714,6 +714,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.None);
+        _religionManager.Setup(pr => pr.GetPlayerReligion("player-2")).Returns((DivineAscension.Data.ReligionData?)null);
 
         // Act
         var result = _sut!.OnSetTotalFavor(args);
@@ -732,7 +733,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Stone, 100, 100);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 100, 100);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "1000", "targetplayer"); // lowercase
         SetupParsers(args, 1000, "targetplayer");
@@ -749,7 +750,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Stone);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnSetTotalFavor(args);
@@ -758,7 +759,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.NotNull(result);
         Assert.Equal(EnumCommandStatus.Success, result.Status);
         Assert.Contains("1,000", result.StatusMessage);
-        Assert.Equal(1000, targetData.TotalFavorEarned);
+        Assert.Equal(1000, targetData.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     #endregion
@@ -773,7 +774,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         var targetPlayer = CreateMockPlayer("player-2", "TargetPlayer");
 
         var adminData = CreatePlayerData("admin-1", DeityDomain.Craft, 1000, 2000);
-        var targetData = CreatePlayerData("player-2", DeityDomain.Harvest, 100, 500);
+        var targetData = CreatePlayerData("player-2", DeityDomain.Craft, 100, 500);
 
         var args = CreateAdminCommandArgs(adminPlayer.Object, "5000", "TargetPlayer");
         SetupParsers(args, 5000, "TargetPlayer");
@@ -791,7 +792,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
             .Returns(TestFixtures.CreateTestReligion());
 
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("admin-1")).Returns(DeityDomain.Craft);
-        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Harvest);
+        _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain("player-2")).Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnSetFavor(args);
@@ -801,7 +802,7 @@ public class FavorCommandAdminTests : FavorCommandsTestHelpers
         Assert.Equal(EnumCommandStatus.Success, result.Status);
         Assert.Contains("5,000", result.StatusMessage);
         Assert.Contains("TargetPlayer", result.StatusMessage);
-        Assert.Equal(5000, targetData.Favor);
+        Assert.Equal(5000, targetData.GetFavor(DeityDomain.Craft));
     }
 
     [Fact]

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandCheckTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandCheckTests.cs
@@ -25,7 +25,7 @@ public class FavorCommandCheckTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.None);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft);
         var args = CreateCommandArgs(mockPlayer.Object);
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-1")).Returns(playerData);
@@ -60,14 +60,14 @@ public class FavorCommandCheckTests : FavorCommandsTestHelpers
             .Returns(DeityDomain.Craft);
 
         _playerReligionDataManager
-            .Setup(m => m.GetPlayerFavorRank("player-1"))
+            .Setup(m => m.GetPlayerFavorRank("player-1", DeityDomain.Craft))
             .Returns(() =>
             {
                 // Calculate rank based on current TotalFavorEarned
-                if (playerData.TotalFavorEarned >= 10000) return FavorRank.Avatar;
-                if (playerData.TotalFavorEarned >= 5000) return FavorRank.Champion;
-                if (playerData.TotalFavorEarned >= 2000) return FavorRank.Zealot;
-                if (playerData.TotalFavorEarned >= 500) return FavorRank.Disciple;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 10000) return FavorRank.Avatar;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 5000) return FavorRank.Champion;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 2000) return FavorRank.Zealot;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 500) return FavorRank.Disciple;
                 return FavorRank.Initiate;
             });
 
@@ -88,7 +88,7 @@ public class FavorCommandCheckTests : FavorCommandsTestHelpers
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
         var playerData =
-            CreatePlayerData("player-1", DeityDomain.Wild, 0, 0, FavorRank.Initiate);
+            CreatePlayerData("player-1", DeityDomain.Craft, 0, 0, FavorRank.Initiate);
         var args = CreateCommandArgs(mockPlayer.Object);
 
 
@@ -96,7 +96,7 @@ public class FavorCommandCheckTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Wild);
+            .Returns(DeityDomain.Craft);
         // Act
         var result = _sut!.OnCheckFavor(args);
 
@@ -104,7 +104,7 @@ public class FavorCommandCheckTests : FavorCommandsTestHelpers
         Assert.NotNull(result);
         Assert.Equal(EnumCommandStatus.Success, result.Status);
         Assert.Contains("0 favor", result.StatusMessage);
-        Assert.Contains("Wild", result.StatusMessage);
+        Assert.Contains("Craft", result.StatusMessage);
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class FavorCommandCheckTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, 7000, 15000,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 7000, 15000,
             FavorRank.Avatar);
         var args = CreateCommandArgs(mockPlayer.Object);
 
@@ -121,17 +121,17 @@ public class FavorCommandCheckTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
+            .Returns(DeityDomain.Craft);
 
         _playerReligionDataManager
-            .Setup(m => m.GetPlayerFavorRank("player-1"))
+            .Setup(m => m.GetPlayerFavorRank("player-1", DeityDomain.Craft))
             .Returns(() =>
             {
                 // Calculate rank based on current TotalFavorEarned
-                if (playerData.TotalFavorEarned >= 10000) return FavorRank.Avatar;
-                if (playerData.TotalFavorEarned >= 5000) return FavorRank.Champion;
-                if (playerData.TotalFavorEarned >= 2000) return FavorRank.Zealot;
-                if (playerData.TotalFavorEarned >= 500) return FavorRank.Disciple;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 10000) return FavorRank.Avatar;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 5000) return FavorRank.Champion;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 2000) return FavorRank.Zealot;
+                if (playerData.GetTotalFavorEarned(DeityDomain.Craft) >= 500) return FavorRank.Disciple;
                 return FavorRank.Initiate;
             });
 

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandInfoTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandInfoTests.cs
@@ -25,7 +25,7 @@ public class FavorCommandInfoTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.None);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft);
         var args = CreateCommandArgs(mockPlayer.Object);
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-1")).Returns(playerData);
@@ -77,7 +77,7 @@ public class FavorCommandInfoTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Wild, 5000, 15000,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 5000, 15000,
             FavorRank.Avatar);
         var args = CreateCommandArgs(mockPlayer.Object);
 
@@ -86,7 +86,7 @@ public class FavorCommandInfoTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Wild);
+            .Returns(DeityDomain.Craft);
         // Act
         var result = _sut!.OnFavorInfo(args);
 
@@ -102,7 +102,7 @@ public class FavorCommandInfoTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, 1000, 2000,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 1000, 2000,
             FavorRank.Zealot);
         var args = CreateCommandArgs(mockPlayer.Object);
 
@@ -111,7 +111,7 @@ public class FavorCommandInfoTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
+            .Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnFavorInfo(args);

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandSetTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandSetTests.cs
@@ -42,7 +42,7 @@ public class FavorCommandSetTests : FavorCommandsTestHelpers
         Assert.NotNull(result);
         Assert.Equal(EnumCommandStatus.Success, result.Status);
         Assert.Contains("1,000", result.StatusMessage);
-        Assert.Equal(1000, playerData.Favor);
+        Assert.Equal(1000, playerData.GetFavor(DeityDomain.Craft));
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class FavorCommandSetTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Wild, favor: 5000, totalFavor: 5000);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, favor: 5000, totalFavor: 5000);
         var args = CreateAdminCommandArgs(mockPlayer.Object, "0");
         SetupParsers(args, 0, null);
 
@@ -59,14 +59,14 @@ public class FavorCommandSetTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Wild);
+            .Returns(DeityDomain.Craft);
         // Act
         var result = _sut!.OnSetFavor(args);
 
         // Assert
         Assert.NotNull(result);
         Assert.Equal(EnumCommandStatus.Success, result.Status);
-        Assert.Equal(0, playerData.Favor);
+        Assert.Equal(0, playerData.GetFavor(DeityDomain.Craft));
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class FavorCommandSetTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft);
         var args = CreateAdminCommandArgs(mockPlayer.Object, "999999");
         SetupParsers(args, 999999, null);
 
@@ -83,7 +83,7 @@ public class FavorCommandSetTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
+            .Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnSetFavor(args);
@@ -91,7 +91,7 @@ public class FavorCommandSetTests : FavorCommandsTestHelpers
         // Assert
         Assert.NotNull(result);
         Assert.Equal(EnumCommandStatus.Success, result.Status);
-        Assert.Equal(999999, playerData.Favor);
+        Assert.Equal(999999, playerData.GetFavor(DeityDomain.Craft));
     }
 
     #endregion
@@ -152,7 +152,7 @@ public class FavorCommandSetTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.None);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft);
         var args = CreateAdminCommandArgs(mockPlayer.Object, "100");
         SetupParsers(args, 100, null);
 

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandStatsTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandStatsTests.cs
@@ -25,7 +25,7 @@ public class FavorCommandStatsTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.None);
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft);
         var args = CreateCommandArgs(mockPlayer.Object);
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-1")).Returns(playerData);
@@ -76,7 +76,7 @@ public class FavorCommandStatsTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Wild, 100, 100,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 100, 100,
             FavorRank.Initiate);
         var args = CreateCommandArgs(mockPlayer.Object);
 
@@ -85,7 +85,7 @@ public class FavorCommandStatsTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Wild);
+            .Returns(DeityDomain.Craft);
 
         // Act
         var result = _sut!.OnFavorStats(args);
@@ -102,7 +102,7 @@ public class FavorCommandStatsTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, 5000, 12000,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 5000, 12000,
             FavorRank.Avatar);
         var args = CreateCommandArgs(mockPlayer.Object);
 
@@ -127,7 +127,7 @@ public class FavorCommandStatsTests : FavorCommandsTestHelpers
     {
         // Arrange
         var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
-        var playerData = CreatePlayerData("player-1", DeityDomain.Harvest, 600, 600,
+        var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 600, 600,
             FavorRank.Disciple);
         var args = CreateCommandArgs(mockPlayer.Object);
 
@@ -136,7 +136,7 @@ public class FavorCommandStatsTests : FavorCommandsTestHelpers
         _religionManager.Setup(pr => pr.GetPlayerReligion("player-1"))
             .Returns(TestFixtures.CreateTestReligion());
         _religionManager.Setup(pr => pr.GetPlayerActiveDeityDomain(It.IsAny<string>()))
-            .Returns(DeityDomain.Harvest);
+            .Returns(DeityDomain.Craft);
         // Act
         var result = _sut!.OnFavorStats(args);
 

--- a/DivineAscension.Tests/Commands/Helpers/FavorCommandsTestHelpers.cs
+++ b/DivineAscension.Tests/Commands/Helpers/FavorCommandsTestHelpers.cs
@@ -118,11 +118,10 @@ public class FavorCommandsTestHelpers
         int totalFavor = 0,
         FavorRank rank = FavorRank.Initiate)
     {
-        return new PlayerProgressionData(playerUID)
-        {
-            Favor = favor,
-            TotalFavorEarned = totalFavor,
-        };
+        var data = new PlayerProgressionData(playerUID);
+        if (favor > 0) data.SetFavor(deity, favor);
+        if (totalFavor > 0) data.SetTotalFavorEarned(deity, totalFavor);
+        return data;
     }
 
     /// <summary>

--- a/DivineAscension.Tests/Commands/Religion/ReligionCommandAdminTests.cs
+++ b/DivineAscension.Tests/Commands/Religion/ReligionCommandAdminTests.cs
@@ -195,7 +195,7 @@ public class ReligionCommandAdminTests : ReligionCommandsTestHelpers
         Assert.Contains("Successfully added Player to religion NewReligion", result.StatusMessage);
         _playerProgressionDataManager.Verify(m => m.LeaveReligion("player-1"), Times.Once);
         _playerProgressionDataManager.Verify(m => m.JoinReligion("player-1", "new-religion"), Times.Once);
-        _playerProgressionDataManager.Verify(m => m.HandleReligionSwitch("player-1"), Times.Never);
+        _playerProgressionDataManager.Verify(m => m.HandleReligionSwitch("player-1", DeityDomain.Craft), Times.Never);
     }
 
     [Fact]

--- a/DivineAscension.Tests/Commands/Religion/ReligionCommandJoinTests.cs
+++ b/DivineAscension.Tests/Commands/Religion/ReligionCommandJoinTests.cs
@@ -106,7 +106,7 @@ public class ReligionCommandJoinTests : ReligionCommandsTestHelpers
         _sut!.OnJoinReligion(args);
 
         // Assert
-        _playerProgressionDataManager.Verify(m => m.HandleReligionSwitch(It.IsAny<string>()), Times.Never);
+        _playerProgressionDataManager.Verify(m => m.HandleReligionSwitch(It.IsAny<string>(), It.IsAny<DeityDomain>()), Times.Never);
     }
 
     #endregion

--- a/DivineAscension.Tests/Commands/Religion/ReligionCommandMembersTests.cs
+++ b/DivineAscension.Tests/Commands/Religion/ReligionCommandMembersTests.cs
@@ -68,10 +68,10 @@ public class ReligionCommandMembersTests : ReligionCommandsTestHelpers
 
         var playerData = CreatePlayerData("player-1");
         var founderData = CreatePlayerData("founder-1");
-        founderData.Favor = 100;
+        founderData.SetFavor(DeityDomain.Craft, 100);
 
         var memberData = CreatePlayerData("member-1");
-        memberData.Favor = 50;
+        memberData.SetFavor(DeityDomain.Craft, 50);
 
         var religion = CreateReligion("religion-1", "TestReligion", DeityDomain.Craft, "founder-1");
         religion.AddMember("member-1", "Test Member");

--- a/DivineAscension.Tests/Data/ReligionDataTests.cs
+++ b/DivineAscension.Tests/Data/ReligionDataTests.cs
@@ -18,7 +18,7 @@ public class ReligionDataTests
         // Assert
         Assert.Empty(religion.ReligionUID);
         Assert.Empty(religion.ReligionName);
-        Assert.Equal(DeityDomain.None, religion.Domain);
+        Assert.Equal(DeityDomain.None, religion.PatronDomain);
         Assert.Empty(religion.FounderUID);
         Assert.Empty(religion.MemberUIDs);
         Assert.Equal(PrestigeRank.Fledgling, religion.PrestigeRank);
@@ -44,7 +44,7 @@ public class ReligionDataTests
         // Assert
         Assert.Equal(religionUID, religion.ReligionUID);
         Assert.Equal(religionName, religion.ReligionName);
-        Assert.Equal(deity, religion.Domain);
+        Assert.Equal(deity, religion.PatronDomain);
         Assert.Equal(founderUID, religion.FounderUID);
         Assert.Single(religion.MemberUIDs);
         Assert.Contains(founderUID, religion.MemberUIDs);

--- a/DivineAscension.Tests/Helpers/TestFixtures.cs
+++ b/DivineAscension.Tests/Helpers/TestFixtures.cs
@@ -178,11 +178,10 @@ public static class TestFixtures
         int favor = 100,
         int totalFavorEarned = 500)
     {
-        return new PlayerProgressionData(playerUID)
-        {
-            Favor = favor,
-            TotalFavorEarned = totalFavorEarned
-        };
+        var data = new PlayerProgressionData(playerUID);
+        if (favor > 0) data.SetFavor(deity, favor);
+        if (totalFavorEarned > 0) data.SetTotalFavorEarned(deity, totalFavorEarned);
+        return data;
     }
 
     /// <summary>

--- a/DivineAscension.Tests/Services/BlessingLoaderTests.cs
+++ b/DivineAscension.Tests/Services/BlessingLoaderTests.cs
@@ -117,6 +117,39 @@ public class BlessingLoaderTests
         Assert.Single(blessing.StatModifiers);
         Assert.Equal(0.10f, blessing.StatModifiers["toolDurability"]);
         Assert.Empty(blessing.SpecialEffects!);
+        Assert.False(blessing.RequiresPatron); // default
+    }
+
+    [Fact]
+    public void LoadBlessings_WithRequiresPatronTrue_MapsField()
+    {
+        var json = @"{
+            ""domain"": ""Craft"",
+            ""version"": 1,
+            ""blessings"": [
+                {
+                    ""blessingId"": ""patron_capstone"",
+                    ""name"": ""Capstone"",
+                    ""description"": ""x"",
+                    ""kind"": ""Player"",
+                    ""category"": ""Utility"",
+                    ""iconName"": ""x"",
+                    ""requiredFavorRank"": 3,
+                    ""requiredPrestigeRank"": 0,
+                    ""prerequisiteBlessings"": [],
+                    ""statModifiers"": {},
+                    ""specialEffects"": [],
+                    ""requiresPatron"": true
+                }
+            ]
+        }";
+        SetupMockAsset("config/blessings/craft.json", json);
+        var loader = new BlessingLoader(_mockApi.Object, _mockLogger.Object);
+
+        var result = loader.LoadBlessings();
+
+        Assert.Single(result);
+        Assert.True(result[0].RequiresPatron);
     }
 
     #endregion

--- a/DivineAscension.Tests/Services/RitualContributionServiceTests.cs
+++ b/DivineAscension.Tests/Services/RitualContributionServiceTests.cs
@@ -294,7 +294,7 @@ public class RitualContributionServiceTests
         {
             ReligionUID = "religion1",
             ReligionName = "Test Religion",
-            Domain = domain,
+            PatronDomain = domain,
             FounderUID = "founder1",
             FounderName = "Founder"
         };

--- a/DivineAscension.Tests/Systems/Altar/Pipeline/Steps/ReligionValidationStepTests.cs
+++ b/DivineAscension.Tests/Systems/Altar/Pipeline/Steps/ReligionValidationStepTests.cs
@@ -38,8 +38,8 @@ public class ReligionValidationStepTests
         {
             ReligionUID = uid,
             ReligionName = "Test Religion",
-            DeityName = "Test Deity",
-            Domain = domain,
+            PatronName = "Test Deity",
+            PatronDomain = domain,
             FounderUID = "founder1",
             FounderName = "Founder"
         };

--- a/DivineAscension.Tests/Systems/Altar/Pipeline/Steps/RewardCalculationStepTests.cs
+++ b/DivineAscension.Tests/Systems/Altar/Pipeline/Steps/RewardCalculationStepTests.cs
@@ -36,8 +36,8 @@ public class RewardCalculationStepTests
             {
                 ReligionUID = "religion1",
                 ReligionName = "Test",
-                DeityName = "Deity",
-                Domain = DeityDomain.Craft,
+                PatronName = "Deity",
+                PatronDomain = DeityDomain.Craft,
                 FounderUID = "founder1",
                 FounderName = "Founder"
             }

--- a/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
@@ -484,7 +484,7 @@ public class BlessingRegistryTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.AddFavor(100); // Enough for cost of 50
+        playerData.AddFavor(DeityDomain.Craft, 100); // Enough for cost of 50
 
         var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Craft, BlessingKind.Player);
         blessing.RequiredFavorRank = 0;
@@ -723,7 +723,7 @@ public class BlessingRegistryTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.AddFavor(200);
+        playerData.AddFavor(DeityDomain.Craft, 200);
         // Player committed to "Forge" branch, locking "Endurance"
         playerData.CommitToBranch(DeityDomain.Craft, "Forge", new[] { "Endurance" });
 
@@ -747,7 +747,7 @@ public class BlessingRegistryTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.AddFavor(200);
+        playerData.AddFavor(DeityDomain.Craft, 200);
         // Player committed to "Forge" branch
         playerData.CommitToBranch(DeityDomain.Craft, "Forge", new[] { "Endurance" });
 
@@ -770,7 +770,7 @@ public class BlessingRegistryTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.AddFavor(200);
+        playerData.AddFavor(DeityDomain.Craft, 200);
         // Player committed to "Forge" branch
         playerData.CommitToBranch(DeityDomain.Craft, "Forge", new[] { "Endurance" });
 
@@ -793,7 +793,7 @@ public class BlessingRegistryTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.AddFavor(200);
+        playerData.AddFavor(DeityDomain.Craft, 200);
         // Player committed to "Forge" branch
         playerData.CommitToBranch(DeityDomain.Craft, "Forge", new[] { "Endurance" });
 
@@ -816,7 +816,7 @@ public class BlessingRegistryTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Wild, "religion-uid");
-        playerData.AddFavor(200);
+        playerData.AddFavor(DeityDomain.Craft, 200);
         // Player committed to "Forge" branch in CRAFT domain
         playerData.CommitToBranch(DeityDomain.Craft, "Forge", new[] { "Endurance" });
 
@@ -839,7 +839,7 @@ public class BlessingRegistryTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.AddFavor(200);
+        playerData.AddFavor(DeityDomain.Craft, 200);
         // No branch commitment yet
 
         var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Craft, BlessingKind.Player);

--- a/DivineAscension.Tests/Systems/FavorSystemIntegrationTests.cs
+++ b/DivineAscension.Tests/Systems/FavorSystemIntegrationTests.cs
@@ -85,7 +85,7 @@ public class FavorSystemIntegrationTests
 
         // Assert - Should not award any favor
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never()
         );
     }
@@ -147,7 +147,7 @@ public class FavorSystemIntegrationTests
 
         // Assert - Should remove 50 favor (DEATH_PENALTY_FAVOR)
         _mockPlayerReligionDataManager.Verify(
-            m => m.RemoveFavor("player-uid", 10, "Death penalty"),
+            m => m.RemoveFavor("player-uid", DeityDomain.Craft, 10, "Death penalty"),
             Times.Once()
         );
     }
@@ -173,7 +173,7 @@ public class FavorSystemIntegrationTests
 
         // Assert - Should not call RemoveFavor when favor is 0
         _mockPlayerReligionDataManager.Verify(
-            m => m.RemoveFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.RemoveFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never()
         );
     }
@@ -238,7 +238,7 @@ public class FavorSystemIntegrationTests
 
         // Assert
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor("player-uid", 15, "test action"),
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 15, "test action"),
             Times.Once()
         );
     }
@@ -263,7 +263,7 @@ public class FavorSystemIntegrationTests
 
         // Assert
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never()
         );
     }

--- a/DivineAscension.Tests/Systems/FavorSystemTests.cs
+++ b/DivineAscension.Tests/Systems/FavorSystemTests.cs
@@ -251,7 +251,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never
         );
     }
@@ -317,7 +317,8 @@ public class FavorSystemTests
         var mockPlayerReligionDataManager = new Mock<IPlayerProgressionDataManager>();
         var mockReligionManager = new Mock<IReligionManager>();
 
-        var playerData = new PlayerProgressionData { Favor = 10 };
+        var playerData = new PlayerProgressionData();
+        playerData.SetFavor(DeityDomain.Craft, 10);
 
         var mockPlayer = new Mock<IServerPlayer>();
         mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
@@ -339,7 +340,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.RemoveFavor("player-uid", 10, "Death penalty"),
+            m => m.RemoveFavor("player-uid", DeityDomain.Craft, 10, "Death penalty"),
             Times.Once
         );
     }
@@ -375,7 +376,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.RemoveFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.RemoveFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never
         );
     }
@@ -390,7 +391,8 @@ public class FavorSystemTests
         var mockPlayerReligionDataManager = new Mock<IPlayerProgressionDataManager>();
         var mockReligionManager = new Mock<IReligionManager>();
 
-        var playerData = new PlayerProgressionData { Favor = 0 };
+        var playerData = new PlayerProgressionData();
+        playerData.SetFavor(DeityDomain.Craft, 0);
 
         var mockPlayer = new Mock<IServerPlayer>();
         mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
@@ -411,7 +413,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.RemoveFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.RemoveFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never
         );
     }
@@ -504,7 +506,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor("player-uid", 15, "test action"),
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 15, "test action"),
             Times.Once
         );
     }
@@ -540,7 +542,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never
         );
     }
@@ -588,7 +590,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor("player-uid", It.IsAny<float>(), "Passive devotion"),
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, It.IsAny<float>(), "Passive devotion"),
             Times.Once
         );
     }
@@ -624,7 +626,7 @@ public class FavorSystemTests
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor(It.IsAny<string>(), It.IsAny<float>(), It.IsAny<string>()),
+            m => m.AddFractionalFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<float>(), It.IsAny<string>()),
             Times.Never
         );
     }
@@ -643,10 +645,8 @@ public class FavorSystemTests
         {
         };
 
-        var playerDataAvatar = new PlayerProgressionData()
-        {
-            TotalFavorEarned = 10000
-        };
+        var playerDataAvatar = new PlayerProgressionData();
+        playerDataAvatar.SetTotalFavorEarned(DeityDomain.Craft, 10000);
 
         var mockPlayer = new Mock<IServerPlayer>();
         mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
@@ -656,7 +656,7 @@ public class FavorSystemTests
             .Returns((ReligionData?)null);
 
         mockPlayerReligionDataManager
-            .SetupSequence(m => m.GetPlayerFavorRank("player-uid"))
+            .SetupSequence(m => m.GetPlayerFavorRank("player-uid", DeityDomain.Craft))
             .Returns(FavorRank.Initiate) // First call with 0 favor
             .Returns(FavorRank.Avatar); // Second call with 10000 favor
 
@@ -668,8 +668,8 @@ public class FavorSystemTests
             mockReligionManager.Object);
 
         // Act
-        var multiplierInitiate = favorSystem.CalculatePassiveFavorMultiplier(mockPlayer.Object, playerDataInitiate);
-        var multiplierAvatar = favorSystem.CalculatePassiveFavorMultiplier(mockPlayer.Object, playerDataAvatar);
+        var multiplierInitiate = favorSystem.CalculatePassiveFavorMultiplier(mockPlayer.Object, playerDataInitiate, DeityDomain.Craft);
+        var multiplierAvatar = favorSystem.CalculatePassiveFavorMultiplier(mockPlayer.Object, playerDataAvatar, DeityDomain.Craft);
 
         // Assert
         Assert.Equal(1.0f, multiplierInitiate);
@@ -686,10 +686,8 @@ public class FavorSystemTests
         var mockPlayerReligionDataManager = new Mock<IPlayerProgressionDataManager>();
         var mockReligionManager = new Mock<IReligionManager>();
 
-        var playerData = new PlayerProgressionData
-        {
-            TotalFavorEarned = 0
-        };
+        var playerData = new PlayerProgressionData();
+        playerData.SetTotalFavorEarned(DeityDomain.Craft, 0);
 
         var religion = new ReligionData
         {
@@ -714,7 +712,7 @@ public class FavorSystemTests
             mockReligionManager.Object);
 
         // Act
-        var multiplier = favorSystem.CalculatePassiveFavorMultiplier(mockPlayer.Object, playerData);
+        var multiplier = favorSystem.CalculatePassiveFavorMultiplier(mockPlayer.Object, playerData, DeityDomain.Craft);
 
         // Assert
         Assert.Equal(1.5f, multiplier); // 1.0 (Initiate) * 1.5 (Mythic)
@@ -820,7 +818,8 @@ public class FavorSystemTests
         var mockPlayerReligionDataManager = new Mock<IPlayerProgressionDataManager>();
         var mockReligionManager = new Mock<IReligionManager>();
 
-        var victimData = new PlayerProgressionData() { Favor = 50 };
+        var victimData = new PlayerProgressionData();
+        victimData.SetFavor(DeityDomain.Craft, 50);
 
         var mockVictim = new Mock<IServerPlayer>();
         mockVictim.Setup(p => p.PlayerUID).Returns("victim-uid");
@@ -849,11 +848,11 @@ public class FavorSystemTests
 
         // Assert - Only penalty, no reward
         mockPlayerReligionDataManager.Verify(
-            m => m.RemoveFavor("victim-uid", It.IsAny<int>(), It.IsAny<string>()),
+            m => m.RemoveFavor("victim-uid", DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Once
         );
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never
         );
     }
@@ -916,7 +915,8 @@ public class FavorSystemTests
         var mockPlayerReligionDataManager = new Mock<IPlayerProgressionDataManager>();
         var mockReligionManager = new Mock<IReligionManager>();
 
-        var playerData = new PlayerProgressionData { Favor = 10 };
+        var playerData = new PlayerProgressionData();
+        playerData.SetFavor(DeityDomain.Craft, 10);
 
         var mockPlayer = new Mock<IServerPlayer>();
         mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
@@ -996,11 +996,11 @@ public class FavorSystemTests
 
         // Assert - Both players should receive favor
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor("player1-uid", It.IsAny<float>(), It.IsAny<string>()),
+            m => m.AddFractionalFavor("player1-uid", DeityDomain.Craft, It.IsAny<float>(), It.IsAny<string>()),
             Times.Once
         );
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor("player2-uid", It.IsAny<float>(), It.IsAny<string>()),
+            m => m.AddFractionalFavor("player2-uid", DeityDomain.Craft, It.IsAny<float>(), It.IsAny<string>()),
             Times.Once
         );
     }
@@ -1038,7 +1038,7 @@ public class FavorSystemTests
 
         // Assert - No favor awarded
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor(It.IsAny<string>(), It.IsAny<float>(), It.IsAny<string>()),
+            m => m.AddFractionalFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<float>(), It.IsAny<string>()),
             Times.Never
         );
     }
@@ -1064,8 +1064,8 @@ public class FavorSystemTests
         {
             ReligionUID = "conquest-religion-uid",
             ReligionName = "Warriors of War",
-            Domain = DeityDomain.Conquest,
-            DeityName = "Ares",
+            PatronDomain = DeityDomain.Conquest,
+            PatronName = "Ares",
             FounderUID = "player-uid"
         };
 
@@ -1123,8 +1123,8 @@ public class FavorSystemTests
         {
             ReligionUID = "test-religion-uid",
             ReligionName = "Test Religion",
-            Domain = DeityDomain.Conquest,
-            DeityName = "TestDeity",
+            PatronDomain = DeityDomain.Conquest,
+            PatronName = "TestDeity",
             FounderUID = "player-uid"
         };
 

--- a/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
@@ -50,10 +50,10 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.TotalFavorEarned = 500; // Should be Disciple rank
+        data.SetTotalFavorEarned(DeityDomain.Craft, 500); // Should be Disciple rank
 
         // Act
-        var rank = _sut.GetPlayerFavorRank("player-uid");
+        var rank = _sut.GetPlayerFavorRank("player-uid", DeityDomain.Craft);
 
         // Assert
         Assert.Equal(FavorRank.Disciple, rank);
@@ -106,7 +106,7 @@ public class PlayerProgressionDataManagerTests
 
         // Assert
         Assert.NotNull(data);
-        Assert.Equal(0, data.Favor);
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
     }
 
     [Fact]
@@ -114,14 +114,14 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var firstCall = _sut.GetOrCreatePlayerData("player-uid");
-        firstCall.Favor = 100;
+        firstCall.SetFavor(DeityDomain.Craft, 100);
 
         // Act
         var secondCall = _sut.GetOrCreatePlayerData("player-uid");
 
         // Assert
         Assert.Same(firstCall, secondCall);
-        Assert.Equal(100, secondCall.Favor);
+        Assert.Equal(100, secondCall.GetFavor(DeityDomain.Craft));
     }
 
     [Fact]
@@ -147,21 +147,21 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.Favor = 50;
+        data.SetFavor(DeityDomain.Craft, 50);
 
         // Act
-        _sut.AddFavor("player-uid", 25, "Test reason");
+        _sut.AddFavor("player-uid", DeityDomain.Craft, 25, "Test reason");
 
         // Assert
-        Assert.Equal(75, data.Favor);
-        Assert.Equal(25, data.TotalFavorEarned); // Total also increased
+        Assert.Equal(75, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(25, data.GetTotalFavorEarned(DeityDomain.Craft)); // Total also increased
     }
 
     [Fact]
     public void AddFavor_WithReason_LogsDebugMessage()
     {
         // Act
-        _sut.AddFavor("player-uid", 10, "PvP kill");
+        _sut.AddFavor("player-uid", DeityDomain.Craft, 10, "PvP kill");
 
         // Assert
         _mockLogger.Verify(
@@ -175,7 +175,7 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.TotalFavorEarned = 490; // Close to Disciple threshold (500)
+        data.SetTotalFavorEarned(DeityDomain.Craft, 490); // Close to Disciple threshold (500)
 
         var eventFired = false;
         _sut.OnPlayerDataChanged += (playerUID) => eventFired = true;
@@ -184,10 +184,10 @@ public class PlayerProgressionDataManagerTests
         _mockAPI.Setup(a => a.World).Returns(mockWorld.Object);
 
         // Act
-        _sut.AddFavor("player-uid", 20); // Should rank up
+        _sut.AddFavor("player-uid", DeityDomain.Craft, 20); // Should rank up
 
         // Assert
-        Assert.Equal(FavorRank.Disciple, _sut.GetPlayerFavorRank("player-uid"));
+        Assert.Equal(FavorRank.Disciple, _sut.GetPlayerFavorRank("player-uid", DeityDomain.Craft));
         Assert.True(eventFired);
     }
 
@@ -199,7 +199,7 @@ public class PlayerProgressionDataManagerTests
         _sut.OnPlayerDataChanged += (playerUID) => firedPlayerUID = playerUID;
 
         // Act
-        _sut.AddFavor("player-uid", 10);
+        _sut.AddFavor("player-uid", DeityDomain.Craft, 10);
 
         // Assert
         Assert.Equal("player-uid", firedPlayerUID);
@@ -216,13 +216,13 @@ public class PlayerProgressionDataManagerTests
         var data = _sut.GetOrCreatePlayerData("player-uid");
 
         // Act
-        _sut.AddFractionalFavor("player-uid", 0.3f);
-        _sut.AddFractionalFavor("player-uid", 0.3f);
-        _sut.AddFractionalFavor("player-uid", 0.5f); // Should award 1 favor
+        _sut.AddFractionalFavor("player-uid", DeityDomain.Craft, 0.3f);
+        _sut.AddFractionalFavor("player-uid", DeityDomain.Craft, 0.3f);
+        _sut.AddFractionalFavor("player-uid", DeityDomain.Craft, 0.5f); // Should award 1 favor
 
         // Assert
-        Assert.Equal(1, data.Favor);
-        Assert.True(data.AccumulatedFractionalFavor < 1.0f);
+        Assert.Equal(1, data.GetFavor(DeityDomain.Craft));
+        Assert.True(data.GetAccumulatedFractionalFavor(DeityDomain.Craft) < 1.0f);
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public class PlayerProgressionDataManagerTests
         _sut.OnPlayerDataChanged += (_) => eventFired = true;
 
         // Act - Add enough fractional favor to award 1 full favor
-        _sut.AddFractionalFavor("player-uid", 1.2f);
+        _sut.AddFractionalFavor("player-uid", DeityDomain.Craft, 1.2f);
 
         // Assert
         Assert.True(eventFired);
@@ -247,7 +247,7 @@ public class PlayerProgressionDataManagerTests
         _sut.OnPlayerDataChanged += (_) => eventFired = true;
 
         // Act - Add fractional favor that doesn't reach 1.0
-        _sut.AddFractionalFavor("player-uid", 0.3f);
+        _sut.AddFractionalFavor("player-uid", DeityDomain.Craft, 0.3f);
 
         // Assert
         Assert.False(eventFired);
@@ -262,14 +262,14 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.Favor = 50;
+        data.SetFavor(DeityDomain.Craft, 50);
 
         // Act
-        var success = _sut.RemoveFavor("player-uid", 20, "Blessing unlock");
+        var success = _sut.RemoveFavor("player-uid", DeityDomain.Craft, 20, "Blessing unlock");
 
         // Assert
         Assert.True(success);
-        Assert.Equal(30, data.Favor);
+        Assert.Equal(30, data.GetFavor(DeityDomain.Craft));
     }
 
     [Fact]
@@ -277,14 +277,14 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.Favor = 10;
+        data.SetFavor(DeityDomain.Craft, 10);
 
         // Act
-        var success = _sut.RemoveFavor("player-uid", 20);
+        var success = _sut.RemoveFavor("player-uid", DeityDomain.Craft, 20);
 
         // Assert
         Assert.False(success);
-        Assert.Equal(10, data.Favor); // Unchanged
+        Assert.Equal(10, data.GetFavor(DeityDomain.Craft)); // Unchanged
     }
 
     [Fact]
@@ -292,13 +292,13 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.Favor = 50;
+        data.SetFavor(DeityDomain.Craft, 50);
 
         var eventFired = false;
         _sut.OnPlayerDataChanged += (_) => eventFired = true;
 
         // Act
-        _sut.RemoveFavor("player-uid", 10);
+        _sut.RemoveFavor("player-uid", DeityDomain.Craft, 10);
 
         // Assert
         Assert.True(eventFired);
@@ -309,10 +309,10 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.Favor = 50;
+        data.SetFavor(DeityDomain.Craft, 50);
 
         // Act
-        _sut.RemoveFavor("player-uid", 10, "Blessing unlock");
+        _sut.RemoveFavor("player-uid", DeityDomain.Craft, 10, "Blessing unlock");
 
         // Assert
         _mockLogger.Verify(
@@ -445,7 +445,7 @@ public class PlayerProgressionDataManagerTests
 
         var data = _sut.GetOrCreatePlayerData("player-uid");
         _sut.JoinReligion("player-uid", "religion-uid");
-        data.Favor = 100;
+        data.SetFavor(DeityDomain.Craft, 100);
         int count = 0;
         _sut.OnPlayerLeavesReligion += (player, uid) => count++;
 
@@ -453,9 +453,9 @@ public class PlayerProgressionDataManagerTests
         _sut.LeaveReligion("player-uid");
 
         // AsserT
-        Assert.Equal(0, data.Favor);
-        Assert.Equal(0, data.TotalFavorEarned);
-        Assert.Equal(FavorRank.Initiate, _sut.GetPlayerFavorRank("player-uid"));
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(0, data.GetTotalFavorEarned(DeityDomain.Craft));
+        Assert.Equal(FavorRank.Initiate, _sut.GetPlayerFavorRank("player-uid", DeityDomain.Craft));
     }
 
     [Fact]
@@ -489,14 +489,14 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.Favor = 100;
+        data.SetFavor(DeityDomain.Craft, 100);
         data.UnlockBlessing("blessing1");
 
         // Act
-        _sut.HandleReligionSwitch("player-uid");
+        _sut.HandleReligionSwitch("player-uid", DeityDomain.Craft);
 
         // Assert
-        Assert.Equal(0, data.Favor);
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
         Assert.Empty(data.UnlockedBlessings); // All blessings locked
     }
 
@@ -504,7 +504,7 @@ public class PlayerProgressionDataManagerTests
     public void HandleReligionSwitch_LogsNotification()
     {
         // Act
-        _sut.HandleReligionSwitch("player-uid");
+        _sut.HandleReligionSwitch("player-uid", DeityDomain.Craft);
 
         // Assert
         _mockLogger.Verify(
@@ -612,13 +612,13 @@ public class PlayerProgressionDataManagerTests
         _mockAPI.Setup(a => a.World).Returns(mockWorld.Object);
 
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.TotalFavorEarned = 490; // Close to Disciple threshold (500)
+        data.SetTotalFavorEarned(DeityDomain.Craft, 490); // Close to Disciple threshold (500)
 
         // Act & Assert - Should not throw
-        _sut.AddFavor("player-uid", 20);
+        _sut.AddFavor("player-uid", DeityDomain.Craft, 20);
 
         // Verify rank changed
-        Assert.Equal(FavorRank.Disciple, _sut.GetPlayerFavorRank("player-uid"));
+        Assert.Equal(FavorRank.Disciple, _sut.GetPlayerFavorRank("player-uid", DeityDomain.Craft));
     }
 
     [Fact]
@@ -626,16 +626,16 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.TotalFavorEarned = 495; // Close to Disciple threshold (500)
+        data.SetTotalFavorEarned(DeityDomain.Craft, 495); // Close to Disciple threshold (500)
 
         var mockWorld = new Mock<IServerWorldAccessor>();
         _mockAPI.Setup(a => a.World).Returns(mockWorld.Object);
 
         // Act
-        _sut.AddFractionalFavor("player-uid", 10.5f); // Should award 10 favor and rank up
+        _sut.AddFractionalFavor("player-uid", DeityDomain.Craft, 10.5f); // Should award 10 favor and rank up
 
         // Assert
-        Assert.Equal(FavorRank.Disciple, _sut.GetPlayerFavorRank("player-uid"));
+        Assert.Equal(FavorRank.Disciple, _sut.GetPlayerFavorRank("player-uid", DeityDomain.Craft));
     }
 
     #endregion
@@ -678,7 +678,7 @@ public class PlayerProgressionDataManagerTests
     {
         // Arrange
         var data = _sut.GetOrCreatePlayerData("player-uid");
-        data.Favor = 100;
+        data.SetFavor(DeityDomain.Craft, 100);
 
         // Act
         _sut.SavePlayerData("player-uid");
@@ -687,7 +687,7 @@ public class PlayerProgressionDataManagerTests
         var loadedData =
             _fakePersistenceService.Load<PlayerProgressionData>("divineascension_playerprogressiondata_player-uid");
         Assert.NotNull(loadedData);
-        Assert.Equal(100, loadedData.Favor);
+        Assert.Equal(100, loadedData.GetFavor(DeityDomain.Craft));
         _mockLogger.Verify(
             l => l.Debug(It.Is<string>(s => s.Contains("Saved religion data") && s.Contains("player-uid"))),
             Times.Once()
@@ -731,11 +731,9 @@ public class PlayerProgressionDataManagerTests
     public void LoadPlayerData_WithExistingData_LoadsSuccessfully()
     {
         // Arrange - Save data to fake persistence service first
-        var savedData = new PlayerProgressionData("player-uid")
-        {
-            Favor = 150,
-            TotalFavorEarned = 200
-        };
+        var savedData = new PlayerProgressionData("player-uid");
+        savedData.SetFavor(DeityDomain.Craft, 150);
+        savedData.SetTotalFavorEarned(DeityDomain.Craft, 200);
         _fakePersistenceService.Save("divineascension_playerprogressiondata_player-uid", savedData);
 
         // Act
@@ -743,10 +741,10 @@ public class PlayerProgressionDataManagerTests
 
         // Assert
         var loadedData = _sut.GetOrCreatePlayerData("player-uid");
-        Assert.Equal(150, loadedData.Favor);
-        Assert.Equal(200, loadedData.TotalFavorEarned);
+        Assert.Equal(150, loadedData.GetFavor(DeityDomain.Craft));
+        Assert.Equal(200, loadedData.GetTotalFavorEarned(DeityDomain.Craft));
         _mockLogger.Verify(
-            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v5"))),
+            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v6"))),
             Times.Once()
         );
     }
@@ -842,7 +840,8 @@ public class PlayerProgressionDataManagerTests
         var mockPlayer = new Mock<IServerPlayer>();
         mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
 
-        var savedData = new PlayerProgressionData("player-uid") { Favor = 50 };
+        var savedData = new PlayerProgressionData("player-uid");
+        savedData.SetFavor(DeityDomain.Craft, 50);
         _fakePersistenceService.Save("divineascension_playerprogressiondata_player-uid", savedData);
 
         // Act
@@ -850,7 +849,7 @@ public class PlayerProgressionDataManagerTests
 
         // Assert
         var loadedData = _sut.GetOrCreatePlayerData("player-uid");
-        Assert.Equal(50, loadedData.Favor);
+        Assert.Equal(50, loadedData.GetFavor(DeityDomain.Craft));
     }
 
     [Fact]

--- a/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
@@ -31,10 +31,10 @@ public class PlayerProgressionDataTests
 
         // Assert
         Assert.Equal(string.Empty, data.Id);
-        Assert.Equal(0, data.Favor);
-        Assert.Equal(0, data.TotalFavorEarned);
-        Assert.Equal(0f, data.AccumulatedFractionalFavor);
-        Assert.Equal(5, data.DataVersion); // v5: DateTime-based cooldowns
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(0, data.GetTotalFavorEarned(DeityDomain.Craft));
+        Assert.Equal(0f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft));
+        Assert.Equal(6, data.DataVersion); // v6: per-deity favor (Pantheon 2.0)
         Assert.Empty(data.UnlockedBlessings);
     }
 
@@ -172,82 +172,74 @@ public class PlayerProgressionDataTests
         var data = new PlayerProgressionData("player-123");
 
         // Act
-        data.AddFavor(100);
+        data.AddFavor(DeityDomain.Craft, 100);
 
         // Assert
-        Assert.Equal(100, data.Favor);
-        Assert.Equal(100, data.TotalFavorEarned);
+        Assert.Equal(100, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(100, data.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
     public void AddFavor_WithNegativeAmount_DoesNothing()
     {
         // Arrange
-        var data = new PlayerProgressionData("player-123")
-        {
-            Favor = 50,
-            TotalFavorEarned = 50
-        };
+        var data = new PlayerProgressionData("player-123");
+        data.SetFavor(DeityDomain.Craft, 50);
+        data.SetTotalFavorEarned(DeityDomain.Craft, 50);
 
         // Act
-        data.AddFavor(-10);
+        data.AddFavor(DeityDomain.Craft, -10);
 
         // Assert
-        Assert.Equal(50, data.Favor);
-        Assert.Equal(50, data.TotalFavorEarned);
+        Assert.Equal(50, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(50, data.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
     public void AddFavor_WithZero_DoesNothing()
     {
         // Arrange
-        var data = new PlayerProgressionData("player-123")
-        {
-            Favor = 50,
-            TotalFavorEarned = 50
-        };
+        var data = new PlayerProgressionData("player-123");
+        data.SetFavor(DeityDomain.Craft, 50);
+        data.SetTotalFavorEarned(DeityDomain.Craft, 50);
 
         // Act
-        data.AddFavor(0);
+        data.AddFavor(DeityDomain.Craft, 0);
 
         // Assert
-        Assert.Equal(50, data.Favor);
-        Assert.Equal(50, data.TotalFavorEarned);
+        Assert.Equal(50, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(50, data.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
     public void RemoveFavor_WithSufficientFavor_RemovesAndReturnsTrue()
     {
         // Arrange
-        var data = new PlayerProgressionData("player-123")
-        {
-            Favor = 100
-        };
+        var data = new PlayerProgressionData("player-123");
+        data.SetFavor(DeityDomain.Craft, 100);
 
         // Act
-        var result = data.RemoveFavor(50);
+        var result = data.RemoveFavor(DeityDomain.Craft, 50);
 
         // Assert
         Assert.True(result);
-        Assert.Equal(50, data.Favor);
-        Assert.Equal(0, data.TotalFavorEarned); // TotalFavorEarned should not decrease
+        Assert.Equal(50, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(0, data.GetTotalFavorEarned(DeityDomain.Craft)); // TotalFavorEarned should not decrease
     }
 
     [Fact]
     public void RemoveFavor_WithInsufficientFavor_ReturnsFalse()
     {
         // Arrange
-        var data = new PlayerProgressionData("player-123")
-        {
-            Favor = 30
-        };
+        var data = new PlayerProgressionData("player-123");
+        data.SetFavor(DeityDomain.Craft, 30);
 
         // Act
-        var result = data.RemoveFavor(50);
+        var result = data.RemoveFavor(DeityDomain.Craft, 50);
 
         // Assert
         Assert.False(result);
-        Assert.Equal(30, data.Favor); // Favor should not change
+        Assert.Equal(30, data.GetFavor(DeityDomain.Craft)); // Favor should not change
     }
 
     [Fact]
@@ -257,40 +249,124 @@ public class PlayerProgressionDataTests
         var data = new PlayerProgressionData("player-123");
 
         // Act
-        data.AddFractionalFavor(0.3f);
-        Assert.Equal(0, data.Favor);
-        Assert.Equal(0.3f, data.AccumulatedFractionalFavor, precision: 5);
+        data.AddFractionalFavor(DeityDomain.Craft, 0.3f);
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(0.3f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft), precision: 5);
 
-        data.AddFractionalFavor(0.4f);
-        Assert.Equal(0, data.Favor);
-        Assert.Equal(0.7f, data.AccumulatedFractionalFavor, precision: 5);
+        data.AddFractionalFavor(DeityDomain.Craft, 0.4f);
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(0.7f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft), precision: 5);
 
-        data.AddFractionalFavor(0.5f); // Total: 1.2
-        Assert.Equal(1, data.Favor);
-        Assert.Equal(0.2f, data.AccumulatedFractionalFavor, precision: 5);
-        Assert.Equal(1, data.TotalFavorEarned);
+        data.AddFractionalFavor(DeityDomain.Craft, 0.5f); // Total: 1.2
+        Assert.Equal(1, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(0.2f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft), precision: 5);
+        Assert.Equal(1, data.GetTotalFavorEarned(DeityDomain.Craft));
     }
 
     [Fact]
     public void ApplySwitchPenalty_ResetsFavorAndBlessings()
     {
         // Arrange
-        var data = new PlayerProgressionData("player-123")
-        {
-            Favor = 100,
-            TotalFavorEarned = 2500 // Champion rank
-        };
+        var data = new PlayerProgressionData("player-123");
+        data.SetFavor(DeityDomain.Craft, 100);
+        data.SetTotalFavorEarned(DeityDomain.Craft, 2500); // Champion rank
         data.UnlockBlessing("blessing1");
         data.UnlockBlessing("blessing2");
 
         // Act
-        data.ApplySwitchPenalty();
+        data.ApplySwitchPenalty(DeityDomain.Craft);
 
         // Assert
-        Assert.Equal(0, data.Favor);
-        Assert.Equal(2500, data.TotalFavorEarned); // Should not change
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(2500, data.GetTotalFavorEarned(DeityDomain.Craft)); // Should not change
         // Note: FavorRank is now calculated by the manager, not the data model
         Assert.Empty(data.UnlockedBlessings);
+    }
+
+    #endregion
+
+    #region Per-Deity Isolation Tests (Pantheon 2.0)
+
+    [Fact]
+    public void AddFavor_IsolatedPerDeity()
+    {
+        var data = new PlayerProgressionData("player-1");
+
+        data.AddFavor(DeityDomain.Craft, 100);
+        data.AddFavor(DeityDomain.Wild, 250);
+
+        Assert.Equal(100, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(250, data.GetFavor(DeityDomain.Wild));
+        Assert.Equal(0, data.GetFavor(DeityDomain.Conquest));
+        Assert.Equal(100, data.GetTotalFavorEarned(DeityDomain.Craft));
+        Assert.Equal(250, data.GetTotalFavorEarned(DeityDomain.Wild));
+    }
+
+    [Fact]
+    public void RemoveFavor_OnlyAffectsTargetDeity()
+    {
+        var data = new PlayerProgressionData("player-1");
+        data.AddFavor(DeityDomain.Craft, 100);
+        data.AddFavor(DeityDomain.Wild, 100);
+
+        var removed = data.RemoveFavor(DeityDomain.Craft, 40);
+
+        Assert.True(removed);
+        Assert.Equal(60, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(100, data.GetFavor(DeityDomain.Wild));
+    }
+
+    [Fact]
+    public void AddFractionalFavor_AccumulatesPerDeity()
+    {
+        var data = new PlayerProgressionData("player-1");
+
+        data.AddFractionalFavor(DeityDomain.Craft, 0.4f);
+        data.AddFractionalFavor(DeityDomain.Wild, 0.6f);
+        data.AddFractionalFavor(DeityDomain.Craft, 0.7f); // Craft now 1.1 → award 1
+
+        Assert.Equal(1, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(0, data.GetFavor(DeityDomain.Wild));
+        Assert.InRange(data.GetAccumulatedFractionalFavor(DeityDomain.Craft), 0.099f, 0.101f);
+        Assert.InRange(data.GetAccumulatedFractionalFavor(DeityDomain.Wild), 0.599f, 0.601f);
+    }
+
+    [Fact]
+    public void ApplySwitchPenalty_ClearsOnlyAbandonedDeity()
+    {
+        var data = new PlayerProgressionData("player-1");
+        data.AddFavor(DeityDomain.Craft, 500);
+        data.AddFavor(DeityDomain.Wild, 700);
+        data.AddFractionalFavor(DeityDomain.Craft, 0.5f);
+        data.UnlockBlessing("test_blessing");
+
+        data.ApplySwitchPenalty(DeityDomain.Craft);
+
+        Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
+        Assert.Equal(700, data.GetFavor(DeityDomain.Wild));
+        Assert.Equal(0f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft));
+        Assert.Empty(data.UnlockedBlessings); // blessings always cleared on switch
+    }
+
+    [Fact]
+    public void ProtoBuf_RoundTrip_PreservesPerDeityFavor()
+    {
+        var data = new PlayerProgressionData("player-roundtrip");
+        data.AddFavor(DeityDomain.Craft, 123);
+        data.AddFavor(DeityDomain.Wild, 456);
+        data.AddFavor(DeityDomain.Conquest, 789);
+        data.AddFractionalFavor(DeityDomain.Wild, 0.3f);
+
+        using var ms = new System.IO.MemoryStream();
+        ProtoBuf.Serializer.Serialize(ms, data);
+        ms.Position = 0;
+        var roundTripped = ProtoBuf.Serializer.Deserialize<PlayerProgressionData>(ms);
+
+        Assert.Equal(123, roundTripped.GetFavor(DeityDomain.Craft));
+        Assert.Equal(456, roundTripped.GetFavor(DeityDomain.Wild));
+        Assert.Equal(789, roundTripped.GetFavor(DeityDomain.Conquest));
+        Assert.Equal(123, roundTripped.GetTotalFavorEarned(DeityDomain.Craft));
+        Assert.InRange(roundTripped.GetAccumulatedFractionalFavor(DeityDomain.Wild), 0.299f, 0.301f);
     }
 
     #endregion
@@ -495,15 +571,13 @@ public class PlayerProgressionDataTests
     public void ApplySwitchPenalty_ClearsBranchCommitments()
     {
         // Arrange
-        var data = new PlayerProgressionData("player-123")
-        {
-            Favor = 100
-        };
+        var data = new PlayerProgressionData("player-123");
+        data.SetFavor(DeityDomain.Craft, 100);
         data.UnlockBlessing("blessing1");
         data.CommitToBranch(DeityDomain.Craft, "Forge", new[] { "Endurance" });
 
         // Act
-        data.ApplySwitchPenalty();
+        data.ApplySwitchPenalty(DeityDomain.Craft);
 
         // Assert
         Assert.Null(data.GetCommittedBranch(DeityDomain.Craft));

--- a/DivineAscension.Tests/Systems/PvPManagerTests.cs
+++ b/DivineAscension.Tests/Systems/PvPManagerTests.cs
@@ -105,7 +105,7 @@ public class PvPManagerTests
 
         // Assert - Should award favor
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor("player-uid", 10, "test action"),
+            m => m.AddFavor("player-uid", DeityDomain.Craft, 10, "test action"),
             Times.Once()
         );
 
@@ -145,7 +145,7 @@ public class PvPManagerTests
 
         // Assert - Should not award favor
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never()
         );
 
@@ -174,7 +174,7 @@ public class PvPManagerTests
 
         // Assert - Should not award anything
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never()
         );
 
@@ -207,7 +207,7 @@ public class PvPManagerTests
 
         // Assert - Should not award favor
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never()
         );
 
@@ -241,7 +241,7 @@ public class PvPManagerTests
 
         // Assert - Should award favor
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor("player-uid", 10, "test action"),
+            m => m.AddFavor("player-uid", DeityDomain.Craft, 10, "test action"),
             Times.Once()
         );
 
@@ -306,7 +306,7 @@ public class PvPManagerTests
 
         // Assert - Base favor should be 10
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor("attacker-uid", 10, It.IsAny<string>()),
+            m => m.AddFavor("attacker-uid", DeityDomain.Craft, 10, It.IsAny<string>()),
             Times.Once()
         );
     }
@@ -350,7 +350,7 @@ public class PvPManagerTests
 
         // Assert - Full favor (no same-deity penalty)
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor("attacker-uid", 10, It.IsAny<string>()),
+            m => m.AddFavor("attacker-uid", DeityDomain.Craft, 10, It.IsAny<string>()),
             Times.Once()
         );
     }
@@ -487,7 +487,7 @@ public class PvPManagerTests
 
         // Should not award any rewards
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
             Times.Never()
         );
     }
@@ -526,7 +526,7 @@ public class PvPManagerTests
 
         // Assert - Attacker should get rewards even if victim has no religion
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor("attacker-uid", 10, It.IsAny<string>()),
+            m => m.AddFavor("attacker-uid", DeityDomain.Craft, 10, It.IsAny<string>()),
             Times.Once()
         );
 
@@ -592,7 +592,7 @@ public class PvPManagerTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.Favor = 100;
+        playerData.SetFavor(DeityDomain.Craft, 100);
 
         _mockPlayerReligionDataManager
             .Setup(m => m.GetOrCreatePlayerData("player-uid"))
@@ -613,7 +613,7 @@ public class PvPManagerTests
         _pvpManager.ProcessDeathPenalty(mockPlayer.Object);
 
         // Assert - Should have removed 50 favor (100 - 50 = 50)
-        Assert.Equal(50, playerData.Favor);
+        Assert.Equal(50, playerData.GetFavor(DeityDomain.Craft));
 
         // Should send notification
         mockPlayer.Verify(
@@ -632,7 +632,7 @@ public class PvPManagerTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.Favor = 30;
+        playerData.SetFavor(DeityDomain.Craft, 30);
 
         _mockPlayerReligionDataManager
             .Setup(m => m.GetOrCreatePlayerData("player-uid"))
@@ -653,7 +653,7 @@ public class PvPManagerTests
         _pvpManager.ProcessDeathPenalty(mockPlayer.Object);
 
         // Assert - Should have removed only 30 favor (all available, since penalty is 50 but only 30 available)
-        Assert.Equal(0, playerData.Favor);
+        Assert.Equal(0, playerData.GetFavor(DeityDomain.Craft));
 
         // Should send notification with 30 favor
         mockPlayer.Verify(
@@ -672,7 +672,7 @@ public class PvPManagerTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
-        playerData.Favor = 0;
+        playerData.SetFavor(DeityDomain.Craft, 0);
 
         _mockPlayerReligionDataManager
             .Setup(m => m.GetOrCreatePlayerData("player-uid"))
@@ -700,7 +700,7 @@ public class PvPManagerTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.None, null);
-        playerData.Favor = 10;
+        playerData.SetFavor(DeityDomain.Craft, 10);
 
         _mockPlayerReligionDataManager
             .Setup(m => m.GetOrCreatePlayerData("player-uid"))
@@ -712,7 +712,7 @@ public class PvPManagerTests
         _pvpManager.ProcessDeathPenalty(mockPlayer.Object);
 
         // Assert - Favor should remain unchanged
-        Assert.Equal(10, playerData.Favor);
+        Assert.Equal(10, playerData.GetFavor(DeityDomain.Craft));
 
         // Should not send notification
         mockPlayer.Verify(
@@ -731,7 +731,7 @@ public class PvPManagerTests
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, null);
-        playerData.Favor = 10;
+        playerData.SetFavor(DeityDomain.Craft, 10);
 
         _mockPlayerReligionDataManager
             .Setup(m => m.GetOrCreatePlayerData("player-uid"))
@@ -743,7 +743,7 @@ public class PvPManagerTests
         _pvpManager.ProcessDeathPenalty(mockPlayer.Object);
 
         // Assert - Favor should remain unchanged
-        Assert.Equal(10, playerData.Favor);
+        Assert.Equal(10, playerData.GetFavor(DeityDomain.Craft));
 
         // Should not send notification
         mockPlayer.Verify(

--- a/DivineAscension.Tests/Systems/ReligionManagerTests.cs
+++ b/DivineAscension.Tests/Systems/ReligionManagerTests.cs
@@ -74,7 +74,7 @@ public class ReligionManagerTests
 
         // Assert
         Assert.Equal(2, khorasReligions.Count);
-        Assert.All(khorasReligions, r => Assert.Equal(DeityDomain.Craft, r.Domain));
+        Assert.All(khorasReligions, r => Assert.Equal(DeityDomain.Craft, r.PatronDomain));
     }
 
     #endregion
@@ -376,7 +376,7 @@ public class ReligionManagerTests
         // Assert
         Assert.NotNull(religion);
         Assert.Equal("Test Religion", religion.ReligionName);
-        Assert.Equal(DeityDomain.Craft, religion.Domain);
+        Assert.Equal(DeityDomain.Craft, religion.PatronDomain);
         Assert.Equal("founder-uid", religion.FounderUID);
         Assert.True(religion.IsPublic);
         Assert.Contains("founder-uid", religion.MemberUIDs);

--- a/DivineAscension.Tests/ThreadSafety/PlayerProgressionConcurrencyTests.cs
+++ b/DivineAscension.Tests/ThreadSafety/PlayerProgressionConcurrencyTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Models.Enum;
 using DivineAscension.Systems;
 
 namespace DivineAscension.Tests.ThreadSafety;
@@ -31,15 +32,15 @@ public class PlayerProgressionConcurrencyTests
                     {
                         if (threadIndex % 2 == 0)
                         {
-                            data.AddFavor(10);
+                            data.AddFavor(DeityDomain.Craft, 10);
                         }
                         else
                         {
-                            data.RemoveFavor(5);
+                            data.RemoveFavor(DeityDomain.Craft, 5);
                         }
                         // Read during modifications
-                        _ = data.Favor;
-                        _ = data.TotalFavorEarned;
+                        _ = data.GetFavor(DeityDomain.Craft);
+                        _ = data.GetTotalFavorEarned(DeityDomain.Craft);
                     }
                 }
                 catch (Exception ex)
@@ -133,10 +134,10 @@ public class PlayerProgressionConcurrencyTests
                 {
                     for (int i = 0; i < operationsPerThread; i++)
                     {
-                        data.AddFractionalFavor(0.1f);
+                        data.AddFractionalFavor(DeityDomain.Craft, 0.1f);
                         // Read during modifications
-                        _ = data.AccumulatedFractionalFavor;
-                        _ = data.Favor;
+                        _ = data.GetAccumulatedFractionalFavor(DeityDomain.Craft);
+                        _ = data.GetFavor(DeityDomain.Craft);
                     }
                 }
                 catch (Exception ex)
@@ -163,7 +164,7 @@ public class PlayerProgressionConcurrencyTests
         // Arrange
         var data = new PlayerProgressionData("player-1");
         // Pre-populate
-        data.AddFavor(1000);
+        data.AddFavor(DeityDomain.Craft, 1000);
         for (int i = 0; i < 50; i++)
         {
             data.UnlockBlessing($"blessing-{i}");
@@ -186,11 +187,11 @@ public class PlayerProgressionConcurrencyTests
                     {
                         if (threadIndex % 4 == 0)
                         {
-                            data.ApplySwitchPenalty();
+                            data.ApplySwitchPenalty(DeityDomain.Craft);
                         }
                         else if (threadIndex % 4 == 1)
                         {
-                            data.AddFavor(10);
+                            data.AddFavor(DeityDomain.Craft, 10);
                         }
                         else if (threadIndex % 4 == 2)
                         {
@@ -199,7 +200,7 @@ public class PlayerProgressionConcurrencyTests
                         else
                         {
                             // Reader
-                            _ = data.Favor;
+                            _ = data.GetFavor(DeityDomain.Craft);
                             var snapshot = data.UnlockedBlessings.ToList();
                             _ = snapshot.Count;
                         }

--- a/DivineAscension/Commands/BlessingCommands.cs
+++ b/DivineAscension/Commands/BlessingCommands.cs
@@ -495,7 +495,7 @@ public class BlessingCommands(
 
         var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(playerUid);
         var religion = _religionManager.GetPlayerReligion(playerUid);
-        var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(playerUid);
+        var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(playerUid, blessing.Domain);
 
         // Skip cost check here - we'll handle it atomically below
         var (canUnlock, reason) = _blessingRegistry.CanUnlockBlessing(playerUid, playerFavorRank, playerData, religion, blessing, skipCostCheck: true);
@@ -510,10 +510,10 @@ public class BlessingCommands(
                     LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_NOT_IN_RELIGION));
 
             // Atomically deduct favor cost (includes sufficiency check)
-            if (blessing.Cost > 0 && !playerData.RemoveFavor(blessing.Cost))
+            if (blessing.Cost > 0 && !playerData.RemoveFavor(blessing.Domain, blessing.Cost))
                 return TextCommandResult.Error(
                     LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_INSUFFICIENT_FAVOR,
-                        blessing.Cost, playerData.Favor));
+                        blessing.Cost, playerData.GetFavor(blessing.Domain)));
 
             var success = _playerProgressionDataManager.UnlockPlayerBlessing(playerUid, blessingId);
             if (!success)

--- a/DivineAscension/Commands/CivilizationCommands.cs
+++ b/DivineAscension/Commands/CivilizationCommands.cs
@@ -505,7 +505,7 @@ public class CivilizationCommands(
         foreach (var civ in civilizations)
         {
             var religions = _civilizationManager.GetCivReligions(civ.CivId);
-            var deities = religions.Select(r => r.Domain.ToString()).Distinct().ToList();
+            var deities = religions.Select(r => r.PatronDomain.ToString()).Distinct().ToList();
 
             // Apply deity filter if specified
             if (!string.IsNullOrEmpty(deityFilter) &&
@@ -581,7 +581,7 @@ public class CivilizationCommands(
                 ? LocalizationService.Instance.Get(LocalizationKeys.CMD_CIV_LABEL_FOUNDER)
                 : "";
             sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_CIV_FORMAT_MEMBER_RELIGION,
-                religion.ReligionName, religion.Domain, religion.MemberUIDs.Count, isFounder));
+                religion.ReligionName, religion.PatronDomain, religion.MemberUIDs.Count, isFounder));
         }
 
         // Show pending invites only to founder
@@ -740,10 +740,10 @@ public class CivilizationCommands(
         var duplicateDeities = new List<DeityDomain>();
         foreach (var religion in religions)
         {
-            if (!deitySet.Add(religion.Domain))
+            if (!deitySet.Add(religion.PatronDomain))
             {
-                if (!duplicateDeities.Contains(religion.Domain))
-                    duplicateDeities.Add(religion.Domain);
+                if (!duplicateDeities.Contains(religion.PatronDomain))
+                    duplicateDeities.Add(religion.PatronDomain);
             }
         }
 

--- a/DivineAscension/Commands/FavorCommands.cs
+++ b/DivineAscension/Commands/FavorCommands.cs
@@ -128,14 +128,14 @@ public class FavorCommands
     /// <summary>
     ///     Formats the result message for total favor changes
     /// </summary>
-    private string FormatTotalFavorResult(string playerUID, PlayerProgressionData playerData, int newAmount, int oldTotal,
+    private string FormatTotalFavorResult(string playerUID, DeityDomain domain, PlayerProgressionData playerData, int newAmount, int oldTotal,
         FavorRank oldRank)
     {
         var sb = new StringBuilder();
         sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_TOTAL_SET,
             newAmount.ToString("N0"), oldTotal.ToString("N0")));
 
-        var newRank = _playerProgressionDataManager.GetPlayerFavorRank(playerUID);
+        var newRank = _playerProgressionDataManager.GetPlayerFavorRank(playerUID, domain);
         if (oldRank != newRank)
             sb.Append(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_RANK_UPDATE,
                 oldRank.ToLocalizedString(), newRank.ToLocalizedString()));
@@ -168,8 +168,8 @@ public class FavorCommands
         var deityName = deity.ToString();
 
         return TextCommandResult.Success(
-            LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_CHECK, playerProgressionData!.Favor,
-                deityName, _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID).ToLocalizedString())
+            LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_CHECK, playerProgressionData!.GetFavor(deity),
+                deityName, _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, deity).ToLocalizedString())
         );
     }
 
@@ -191,16 +191,17 @@ public class FavorCommands
         var domainLocalized = deityDomain.ToLocalizedString();
 
         // Get current rank based on total favor
-        var currentRank = GetCurrentFavorRank(playerProgressionData!.TotalFavorEarned);
+        var totalForDomain = playerProgressionData!.GetTotalFavorEarned(deityDomain);
+        var currentRank = GetCurrentFavorRank(totalForDomain);
         var currentRankName = RankRequirements.GetFavorRankName(currentRank);
 
         var sb = new StringBuilder();
         sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_HEADER_INFO));
         sb.AppendLine($"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_DOMAIN)} {domainLocalized}");
         sb.AppendLine(
-            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_CURRENT)} {playerProgressionData.Favor:N0}");
+            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_CURRENT)} {playerProgressionData.GetFavor(deityDomain):N0}");
         sb.AppendLine(
-            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_TOTAL_EARNED)} {playerProgressionData.TotalFavorEarned:N0}");
+            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_TOTAL_EARNED)} {totalForDomain:N0}");
         sb.AppendLine(
             $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_CURRENT_RANK)} {currentRankName}");
 
@@ -214,8 +215,8 @@ public class FavorCommands
             sb.AppendLine(
                 $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_NEXT_RANK)} {nextRankName} ({nextThreshold:N0} total favor required)");
 
-            var remaining = nextThreshold - playerProgressionData.TotalFavorEarned;
-            var progress = (float)playerProgressionData.TotalFavorEarned / nextThreshold * 100f;
+            var remaining = nextThreshold - totalForDomain;
+            var progress = (float)totalForDomain / nextThreshold * 100f;
             sb.AppendLine(
                 $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_PROGRESS)} {progress:F1}% ({remaining:N0} favor needed)");
         }
@@ -246,16 +247,17 @@ public class FavorCommands
         var deityName = deity.ToLocalizedString();
 
         // Get current rank based on total favor
-        var currentRank = GetCurrentFavorRank(playerProgressionData!.TotalFavorEarned);
+        var totalForDeity = playerProgressionData!.GetTotalFavorEarned(deity);
+        var currentRank = GetCurrentFavorRank(totalForDeity);
         var currentRankName = RankRequirements.GetFavorRankName(currentRank);
 
         var sb = new StringBuilder();
         sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_HEADER_STATS));
         sb.AppendLine($"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_DOMAIN)} {deityName}");
         sb.AppendLine(
-            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_CURRENT)} {playerProgressionData.Favor:N0}");
+            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_CURRENT)} {playerProgressionData.GetFavor(deity):N0}");
         sb.AppendLine(
-            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_TOTAL_EARNED)} {playerProgressionData.TotalFavorEarned:N0}");
+            $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_TOTAL_EARNED)} {totalForDeity:N0}");
         sb.AppendLine(
             $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_DEVOTION_RANK)} {currentRankName}");
 
@@ -265,7 +267,7 @@ public class FavorCommands
             var nextRank = currentRank + 1;
             var nextRankName = RankRequirements.GetFavorRankName(nextRank);
             var nextThreshold = RankRequirements.GetRequiredFavorForNextRank(currentRank);
-            var remaining = nextThreshold - playerProgressionData.TotalFavorEarned;
+            var remaining = nextThreshold - totalForDeity;
 
             sb.AppendLine();
             sb.AppendLine(
@@ -336,7 +338,9 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        playerData.Favor = amount;
+        var targetUID = targetPlayer?.PlayerUID ?? player.PlayerUID;
+        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetUID);
+        playerData.SetFavor(targetDeity, amount);
 
         var targetName = targetPlayerName != null ? $" for {targetPlayer?.PlayerName}" : "";
         return TextCommandResult.Success(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_SET,
@@ -374,13 +378,14 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var oldFavor = playerData.Favor;
-        _playerProgressionDataManager.AddFavor(targetPlayer.PlayerUID, amount);
+        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetPlayer.PlayerUID);
+        var oldFavor = playerData.GetFavor(targetDeity);
+        _playerProgressionDataManager.AddFavor(targetPlayer.PlayerUID, targetDeity, amount);
 
         var targetName = targetPlayerName != null ? $" for {targetPlayer.PlayerName}" : "";
         return TextCommandResult.Success(
             LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_ADD, amount.ToString("N0"), targetName,
-                oldFavor.ToString("N0"), playerData.Favor.ToString("N0")));
+                oldFavor.ToString("N0"), playerData.GetFavor(targetDeity).ToString("N0")));
     }
 
     /// <summary>
@@ -414,14 +419,15 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var oldFavor = playerData.Favor;
-        _playerProgressionDataManager.RemoveFavor(targetPlayer.PlayerUID, amount);
-        var actualRemoved = oldFavor - playerData.Favor;
+        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetPlayer.PlayerUID);
+        var oldFavor = playerData.GetFavor(targetDeity);
+        _playerProgressionDataManager.RemoveFavor(targetPlayer.PlayerUID, targetDeity, amount);
+        var actualRemoved = oldFavor - playerData.GetFavor(targetDeity);
 
         var targetName = targetPlayerName != null ? $" for {targetPlayer.PlayerName}" : "";
         return TextCommandResult.Success(
             LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_REMOVE, actualRemoved.ToString("N0"),
-                targetName, oldFavor.ToString("N0"), playerData.Favor.ToString("N0")));
+                targetName, oldFavor.ToString("N0"), playerData.GetFavor(targetDeity).ToString("N0")));
     }
 
     /// <summary>
@@ -446,8 +452,10 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var oldFavor = playerData.Favor;
-        playerData.Favor = 0;
+        var targetUID = targetPlayer?.PlayerUID ?? player.PlayerUID;
+        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetUID);
+        var oldFavor = playerData.GetFavor(targetDeity);
+        playerData.SetFavor(targetDeity, 0);
 
         var targetName = targetPlayerName != null ? $" for {targetPlayer?.PlayerName}" : "";
         return TextCommandResult.Success(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_RESET,
@@ -476,8 +484,10 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var oldFavor = playerData.Favor;
-        playerData.Favor = 99999;
+        var targetUID = targetPlayer?.PlayerUID ?? player.PlayerUID;
+        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetUID);
+        var oldFavor = playerData.GetFavor(targetDeity);
+        playerData.SetFavor(targetDeity, 99999);
 
         var targetName = targetPlayerName != null ? $" for {targetPlayer?.PlayerName}" : "";
         return TextCommandResult.Success(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_MAX,
@@ -560,12 +570,13 @@ public class FavorCommands
                 return TextCommandResult.Error(
                     LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_TARGET_NO_RELIGION));
 
-            var oldTotal = targetProgressionData.TotalFavorEarned;
-            var oldRank = _playerProgressionDataManager.GetPlayerFavorRank(serverPlayer.PlayerUID);
+            var targetDeity = _religionManager.GetPlayerActiveDeityDomain(serverPlayer.PlayerUID);
+            var oldTotal = targetProgressionData.GetTotalFavorEarned(targetDeity);
+            var oldRank = _playerProgressionDataManager.GetPlayerFavorRank(serverPlayer.PlayerUID, targetDeity);
 
-            targetProgressionData.TotalFavorEarned = amount;
+            targetProgressionData.SetTotalFavorEarned(targetDeity, amount);
 
-            return TextCommandResult.Success(FormatTotalFavorResult(serverPlayer.PlayerUID, targetProgressionData, amount, oldTotal, oldRank));
+            return TextCommandResult.Success(FormatTotalFavorResult(serverPlayer.PlayerUID, targetDeity, targetProgressionData, amount, oldTotal, oldRank));
         }
 
         // Handle setting own favor
@@ -578,12 +589,13 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var callerOldTotal = religionData.TotalFavorEarned;
-        var callerOldRank = _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID);
+        var callerDeity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+        var callerOldTotal = religionData.GetTotalFavorEarned(callerDeity);
+        var callerOldRank = _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, callerDeity);
 
-        religionData.TotalFavorEarned = amount;
+        religionData.SetTotalFavorEarned(callerDeity, amount);
 
-        return TextCommandResult.Success(FormatTotalFavorResult(player.PlayerUID, religionData, amount, callerOldTotal, callerOldRank));
+        return TextCommandResult.Success(FormatTotalFavorResult(player.PlayerUID, callerDeity, religionData, amount, callerOldTotal, callerOldRank));
     }
 
     #endregion

--- a/DivineAscension/Commands/ReligionCommands.cs
+++ b/DivineAscension/Commands/ReligionCommands.cs
@@ -293,7 +293,11 @@ public class ReligionCommands(
 
         // Apply switching penalty if needed
         if (_religionManager.HasReligion(player.PlayerUID))
-            _playerProgressionDataManager.HandleReligionSwitch(player.PlayerUID);
+        {
+            var oldReligion = _religionManager.GetPlayerReligion(player.PlayerUID);
+            if (oldReligion != null)
+                _playerProgressionDataManager.HandleReligionSwitch(player.PlayerUID, oldReligion.PatronDomain);
+        }
 
         // Join the religion
         _playerProgressionDataManager.JoinReligion(player.PlayerUID, religion.ReligionUID);
@@ -303,7 +307,7 @@ public class ReligionCommands(
 
         return TextCommandResult.Success(
             LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_SUCCESS_JOINED,
-                religion.ReligionName, religion.Domain.ToLocalizedString()));
+                religion.ReligionName, religion.PatronDomain.ToLocalizedString()));
     }
 
     /// <summary>
@@ -371,7 +375,7 @@ public class ReligionCommands(
             sb.AppendLine(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_FORMAT_LIST_ENTRY,
                     religion.ReligionName,
-                    religion.Domain.ToLocalizedString(),
+                    religion.PatronDomain.ToLocalizedString(),
                     visibility,
                     religion.GetMemberCount(),
                     religion.PrestigeRank.ToLocalizedString()));
@@ -417,7 +421,7 @@ public class ReligionCommands(
         sb.AppendLine(
             LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_HEADER_INFO, religion.ReligionName));
         sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_FORMAT_DEITY,
-            religion.Domain.ToLocalizedString()));
+            religion.PatronDomain.ToLocalizedString()));
         var visibility = religion.IsPublic
             ? LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_FORMAT_VISIBILITY_PUBLIC)
             : LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_FORMAT_VISIBILITY_PRIVATE);
@@ -476,7 +480,7 @@ public class ReligionCommands(
                 : LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_FORMAT_ROLE_MEMBER);
 
             sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_RELIGION_FORMAT_MEMBER,
-                memberName, role, _playerProgressionDataManager.GetPlayerFavorRank(memberUID).ToLocalizedString(), memberData.Favor));
+                memberName, role, _playerProgressionDataManager.GetPlayerFavorRank(memberUID, religion.PatronDomain).ToLocalizedString(), memberData.GetFavor(religion.PatronDomain)));
         }
 
         return TextCommandResult.Success(sb.ToString());

--- a/DivineAscension/Commands/RoleCommands.cs
+++ b/DivineAscension/Commands/RoleCommands.cs
@@ -215,7 +215,7 @@ public class RoleCommands(
                 var memberData = _playerProgressionDataManager.GetOrCreatePlayerData(memberUID);
 
                 sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_ROLE_FORMAT_MEMBER_INFO,
-                    memberName, _playerProgressionDataManager.GetPlayerFavorRank(memberUID).ToLocalizedString(), memberData.Favor));
+                    memberName, _playerProgressionDataManager.GetPlayerFavorRank(memberUID, religion.PatronDomain).ToLocalizedString(), memberData.GetFavor(religion.PatronDomain)));
             }
 
         return TextCommandResult.Success(sb.ToString());

--- a/DivineAscension/Data/ReligionData.cs
+++ b/DivineAscension/Data/ReligionData.cs
@@ -32,13 +32,13 @@ public class ReligionData
     /// <summary>
     ///     Creates a new religion with the specified parameters
     /// </summary>
-    public ReligionData(string religionUID, string religionName, DeityDomain domain, string deityName,
+    public ReligionData(string religionUID, string religionName, DeityDomain patronDomain, string patronName,
         string founderUID, string founderName)
     {
         ReligionUID = religionUID;
         ReligionName = religionName;
-        Domain = domain;
-        DeityName = deityName;
+        PatronDomain = patronDomain;
+        PatronName = patronName;
         FounderUID = founderUID;
         FounderName = founderName;
         _memberUIDs = new List<string> { founderUID }; // Founder is first member
@@ -69,10 +69,12 @@ public class ReligionData
     public string ReligionName { get; set; } = string.Empty;
 
     /// <summary>
-    ///     The deity this religion serves (permanent, cannot be changed)
+    ///     The patron deity's domain (permanent, cannot be changed).
+    ///     Renamed from Domain in Pantheon 2.0 for clarity — religions have a primary patron,
+    ///     but players may accumulate favor with secondary deities.
     /// </summary>
     [ProtoMember(3)]
-    public DeityDomain Domain { get; set; } = DeityDomain.None;
+    public DeityDomain PatronDomain { get; set; } = DeityDomain.None;
 
     /// <summary>
     ///     Player UID of the religion founder
@@ -327,11 +329,11 @@ public class ReligionData
     public string FounderName { get; set; } = string.Empty;
 
     /// <summary>
-    ///     The custom name of the deity this religion worships (required).
-    ///     This allows religions with the same domain to have uniquely named deities.
+    ///     The custom name of the patron deity this religion worships (required).
+    ///     Allows religions with the same patron domain to have uniquely named deities.
     /// </summary>
     [ProtoMember(18)]
-    public string DeityName { get; set; } = string.Empty;
+    public string PatronName { get; set; } = string.Empty;
 
     /// <summary>
     ///     Backing field for activity log (serialized)

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -355,7 +355,7 @@ public class DivineAscensionModSystem : ModSystem
             // Send notification to founder
             var message = LocalizationService.Instance.Get(
                 LocalizationKeys.MIGRATION_DEITY_NAME_NOTICE,
-                religion.DeityName);
+                religion.PatronName);
 
             player.SendMessage(0, message, EnumChatType.Notification);
 

--- a/DivineAscension/Models/Blessing.cs
+++ b/DivineAscension/Models/Blessing.cs
@@ -108,4 +108,10 @@ public class Blessing
     ///     For example, unlocking a "Forge" branch blessing might lock the "Endurance" branch.
     /// </summary>
     public List<string>? ExclusiveBranches { get; set; }
+
+    /// <summary>
+    ///     When true, this blessing requires the player's religion to have the matching patron domain.
+    ///     Used to gate Pantheon 2.0 capstones (avatars + religion pantheons) behind patron commitment.
+    /// </summary>
+    public bool RequiresPatron { get; set; }
 }

--- a/DivineAscension/Models/Dto/BlessingJsonDto.cs
+++ b/DivineAscension/Models/Dto/BlessingJsonDto.cs
@@ -100,4 +100,10 @@ public class BlessingJsonDto
     /// </summary>
     [JsonPropertyName("exclusiveBranches")]
     public List<string>? ExclusiveBranches { get; set; }
+
+    /// <summary>
+    ///     When true, this blessing requires the player's religion to have the matching patron domain.
+    /// </summary>
+    [JsonPropertyName("requiresPatron")]
+    public bool RequiresPatron { get; set; }
 }

--- a/DivineAscension/Services/BlessingLoader.cs
+++ b/DivineAscension/Services/BlessingLoader.cs
@@ -181,7 +181,8 @@ public class BlessingLoader : IBlessingLoader
             SpecialEffects = dto.SpecialEffects ?? new List<string>(),
             Cost = dto.Cost,
             Branch = dto.Branch,
-            ExclusiveBranches = dto.ExclusiveBranches
+            ExclusiveBranches = dto.ExclusiveBranches,
+            RequiresPatron = dto.RequiresPatron
         };
 
         // Log warning for unknown stat keys (but still include them)

--- a/DivineAscension/Services/RitualContributionService.cs
+++ b/DivineAscension/Services/RitualContributionService.cs
@@ -82,7 +82,7 @@ public class RitualContributionService : IRitualContributionService
         }
 
         // Calculate reduced favor/prestige (50% of normal offering value)
-        var ritualOfferingBonus = _offeringEvaluator.CalculateOfferingValue(offering, religion.Domain, tier);
+        var ritualOfferingBonus = _offeringEvaluator.CalculateOfferingValue(offering, religion.PatronDomain, tier);
         int reducedFavor = ritualOfferingBonus > 0
             ? (int)Math.Round(ritualOfferingBonus * RITUAL_CONTRIBUTION_MULTIPLIER)
             : 0;
@@ -99,7 +99,7 @@ public class RitualContributionService : IRitualContributionService
                 holySite.ReligionUID,
                 reducedFavor,
                 reducedFavor, // 1:1 ratio
-                religion.Domain,
+                religion.PatronDomain,
                 ritualActivityMsg);
         }
 
@@ -135,7 +135,7 @@ public class RitualContributionService : IRitualContributionService
         var targetTier = currentTier + 1;
 
         // Find ritual for this tier upgrade
-        var ritual = _ritualLoader.GetRitualForTierUpgrade(religion.Domain, currentTier, targetTier);
+        var ritual = _ritualLoader.GetRitualForTierUpgrade(religion.PatronDomain, currentTier, targetTier);
         if (ritual == null)
             return null;
 
@@ -173,7 +173,7 @@ public class RitualContributionService : IRitualContributionService
 
         // Calculate reduced favor/prestige
         var tier = holySite.GetTier();
-        var ritualOfferingBonus = _offeringEvaluator.CalculateOfferingValue(offering, religion.Domain, tier);
+        var ritualOfferingBonus = _offeringEvaluator.CalculateOfferingValue(offering, religion.PatronDomain, tier);
         int reducedFavor = ritualOfferingBonus > 0
             ? (int)Math.Round(ritualOfferingBonus * RITUAL_CONTRIBUTION_MULTIPLIER)
             : 0;
@@ -188,7 +188,7 @@ public class RitualContributionService : IRitualContributionService
                 holySite.ReligionUID,
                 reducedFavor,
                 reducedFavor,
-                religion.Domain,
+                religion.PatronDomain,
                 activityMsg);
         }
 

--- a/DivineAscension/Systems/Altar/Pipeline/Steps/OfferingEvaluationStep.cs
+++ b/DivineAscension/Systems/Altar/Pipeline/Steps/OfferingEvaluationStep.cs
@@ -20,7 +20,7 @@ public class OfferingEvaluationStep(IOfferingEvaluator offeringEvaluator) : IPra
 
         var value = offeringEvaluator.CalculateOfferingValue(
             context.Offering,
-            context.Religion!.Domain,
+            context.Religion!.PatronDomain,
             context.HolySiteTier);
 
         if (value == -1)

--- a/DivineAscension/Systems/Altar/Pipeline/Steps/ReligionValidationStep.cs
+++ b/DivineAscension/Systems/Altar/Pipeline/Steps/ReligionValidationStep.cs
@@ -26,7 +26,7 @@ public class ReligionValidationStep(IReligionManager religionManager) : IPrayerS
             return;
         }
 
-        context.Domain = context.Religion.Domain;
+        context.Domain = context.Religion.PatronDomain;
 
         // Check if player can pray at this holy site:
         // 1. Same religion (member of the religion that owns the holy site)
@@ -35,9 +35,9 @@ public class ReligionValidationStep(IReligionManager religionManager) : IPrayerS
         {
             // Not a member - check if same domain allows prayer
             var holySiteOwnerReligion = religionManager.GetReligion(context.HolySite.ReligionUID);
-            var holySiteDomain = holySiteOwnerReligion?.Domain ?? DeityDomain.None;
+            var holySiteDomain = holySiteOwnerReligion?.PatronDomain ?? DeityDomain.None;
 
-            if (context.Religion.Domain != holySiteDomain || holySiteDomain == DeityDomain.None)
+            if (context.Religion.PatronDomain != holySiteDomain || holySiteDomain == DeityDomain.None)
             {
                 context.Success = false;
                 context.Message = LocalizationService.Instance.Get(LocalizationKeys.PRAYER_WRONG_DOMAIN);

--- a/DivineAscension/Systems/BlessingRegistry.cs
+++ b/DivineAscension/Systems/BlessingRegistry.cs
@@ -155,8 +155,8 @@ public class BlessingRegistry : IBlessingRegistry
             }
 
             // Check deity matches
-            if (religionData!.Domain != blessing.Domain)
-                return (false, $"Requires deity: {blessing.Domain} (Current: {religionData!.Domain})");
+            if (religionData!.PatronDomain != blessing.Domain)
+                return (false, $"Requires deity: {blessing.Domain} (Current: {religionData!.PatronDomain})");
 
             // Check branch exclusivity (only for player blessings with a branch)
             if (!string.IsNullOrEmpty(blessing.Branch))
@@ -201,8 +201,8 @@ public class BlessingRegistry : IBlessingRegistry
             }
 
             // Check favor cost (skip if cost will be deducted atomically)
-            if (!skipCostCheck && blessing.Cost > 0 && playerData.Favor < blessing.Cost)
-                return (false, $"Insufficient favor: requires {blessing.Cost}, have {playerData.Favor}");
+            if (!skipCostCheck && blessing.Cost > 0 && playerData.GetFavor(blessing.Domain) < blessing.Cost)
+                return (false, $"Insufficient favor: requires {blessing.Cost}, have {playerData.GetFavor(blessing.Domain)}");
 
             return (true, "Can unlock");
         }
@@ -223,8 +223,8 @@ public class BlessingRegistry : IBlessingRegistry
         }
 
         // Check deity matches
-        if (religionData.Domain != blessing.Domain)
-            return (false, $"Religion deity mismatch (Blessing: {blessing.Domain}, Religion: {religionData.Domain})");
+        if (religionData.PatronDomain != blessing.Domain)
+            return (false, $"Religion deity mismatch (Blessing: {blessing.Domain}, Religion: {religionData.PatronDomain})");
 
         // Check prerequisites
         if (blessing.PrerequisiteBlessings != null)

--- a/DivineAscension/Systems/CivilizationManager.cs
+++ b/DivineAscension/Systems/CivilizationManager.cs
@@ -349,9 +349,9 @@ public class CivilizationManager : ICivilizationManager
 
                 // Check deity diversity (no duplicate deities)
                 var civDeities = GetCivDeityTypes_Unlocked(civId);
-                if (civDeities.Contains(targetReligion.Domain))
+                if (civDeities.Contains(targetReligion.PatronDomain))
                 {
-                    _logger.Warning($"[DivineAscension] Civilization already has a {targetReligion.Domain} religion");
+                    _logger.Warning($"[DivineAscension] Civilization already has a {targetReligion.PatronDomain} religion");
                     return false;
                 }
 
@@ -948,7 +948,7 @@ public class CivilizationManager : ICivilizationManager
         foreach (var religionId in civ.GetMemberReligionIdsSnapshot())
         {
             var religion = _religionManager.GetReligion(religionId);
-            if (religion != null) deities.Add(religion.Domain);
+            if (religion != null) deities.Add(religion.PatronDomain);
         }
 
         return deities;

--- a/DivineAscension/Systems/FavorSystem.cs
+++ b/DivineAscension/Systems/FavorSystem.cs
@@ -238,14 +238,14 @@ public class FavorSystem : IFavorSystem
         if (attackerReligion is null || victimReligion is null) return;
 
         // Calculate favor reward
-        var favorReward = CalculateFavorReward(attackerReligion.Domain, victimReligion.Domain);
+        var favorReward = CalculateFavorReward(attackerReligion.PatronDomain, victimReligion.PatronDomain);
 
         // Award favor
-        _playerProgressionDataManager.AddFavor(attacker.PlayerUID, favorReward,
+        _playerProgressionDataManager.AddFavor(attacker.PlayerUID, attackerReligion.PatronDomain, favorReward,
             $"PvP kill against {victim.PlayerName}");
 
         // Get deity for display
-        var deityName = attackerReligion.DeityName;
+        var deityName = attackerReligion.PatronName;
 
         // Notify attacker
         attacker.SendMessage(
@@ -255,9 +255,9 @@ public class FavorSystem : IFavorSystem
         );
 
         // Notify victim
-        if (victimReligion.Domain != DeityDomain.None)
+        if (victimReligion.PatronDomain != DeityDomain.None)
         {
-            var victimDeityName = victimReligion.DeityName;
+            var victimDeityName = victimReligion.PatronName;
             victim.SendMessage(
                 GlobalConstants.GeneralChatGroup,
                 $"[Divine Favor] {victimDeityName} is displeased by your defeat.",
@@ -279,10 +279,10 @@ public class FavorSystem : IFavorSystem
         if (deityType == DeityDomain.None) return;
 
         // Remove favor as penalty (minimum 0)
-        var penalty = Math.Min(_config.DeathPenalty, religionData.Favor);
+        var penalty = Math.Min(_config.DeathPenalty, religionData.GetFavor(deityType));
         if (penalty > 0)
         {
-            _playerProgressionDataManager.RemoveFavor(player.PlayerUID, penalty, "Death penalty");
+            _playerProgressionDataManager.RemoveFavor(player.PlayerUID, deityType, penalty, "Death penalty");
 
             player.SendMessage(
                 GlobalConstants.GeneralChatGroup,
@@ -400,7 +400,7 @@ public class FavorSystem : IFavorSystem
         }
 
         // 1. Award favor (now with multiplier applied)
-        _playerProgressionDataManager.AddFractionalFavor(playerUid, amount, actionType);
+        _playerProgressionDataManager.AddFractionalFavor(playerUid, deityDomain, amount, actionType);
 
         // 2. Check if player is in religion and should receive prestige
         var playerReligion = _religionManager.GetPlayerReligion(playerUid);
@@ -483,7 +483,8 @@ public class FavorSystem : IFavorSystem
     {
         var religionData = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
 
-        if (_religionManager.GetPlayerActiveDeityDomain(player.PlayerUID) == DeityDomain.None) return;
+        var deity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+        if (deity == DeityDomain.None) return;
 
         // Calculate in-game hours elapsed this tick
         // dt is in real-time seconds, convert to in-game hours
@@ -493,22 +494,22 @@ public class FavorSystem : IFavorSystem
         var baseFavor = _config.PassiveFavorRate * inGameHoursElapsed;
 
         // Apply multipliers
-        var finalFavor = baseFavor * CalculatePassiveFavorMultiplier(player, religionData);
+        var finalFavor = baseFavor * CalculatePassiveFavorMultiplier(player, religionData, deity);
 
         // Award favor using fractional accumulation
         if (finalFavor >= 0.01f) // Only award when we have at least 0.01 favor
-            _playerProgressionDataManager.AddFractionalFavor(player.PlayerUID, finalFavor, "Passive devotion");
+            _playerProgressionDataManager.AddFractionalFavor(player.PlayerUID, deity, finalFavor, "Passive devotion");
     }
 
     /// <summary>
     ///     Calculates the total multiplier for passive favor generation
     /// </summary>
-    internal float CalculatePassiveFavorMultiplier(IServerPlayer player, PlayerProgressionData playerProgressionData)
+    internal float CalculatePassiveFavorMultiplier(IServerPlayer player, PlayerProgressionData playerProgressionData, DeityDomain deity)
     {
         var multiplier = 1.0f;
 
         // Favor rank bonuses (higher ranks gain passive favor faster)
-        var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID);
+        var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, deity);
         multiplier *= playerFavorRank switch
         {
             FavorRank.Initiate => _config.InitiateMultiplier,

--- a/DivineAscension/Systems/Interfaces/IPlayerProgressionDataManager.cs
+++ b/DivineAscension/Systems/Interfaces/IPlayerProgressionDataManager.cs
@@ -28,9 +28,9 @@ public interface IPlayerProgressionDataManager : IDisposable
     bool TryGetPlayerData(string playerUID, out PlayerProgressionData? data);
 
     /// <summary>
-    ///     Adds favor to a player
+    ///     Adds favor to a player for a specific deity.
     /// </summary>
-    void AddFavor(string playerUID, int amount, string reason = "");
+    void AddFavor(string playerUID, DeityDomain domain, int amount, string reason = "");
 
     /// <summary>
     ///     Unlocks a player blessing
@@ -59,9 +59,10 @@ public interface IPlayerProgressionDataManager : IDisposable
     void LeaveReligion(string playerUID);
 
     /// <summary>
-    ///     Applies switching penalty when changing religions
+    ///     Applies switching penalty when leaving the religion serving the given deity
+    ///     (clears favor + blessings for that deity only).
     /// </summary>
-    void HandleReligionSwitch(string playerUID);
+    void HandleReligionSwitch(string playerUID, DeityDomain abandonedDomain);
 
     /// <summary>
     ///     Removes favor from the player
@@ -70,7 +71,7 @@ public interface IPlayerProgressionDataManager : IDisposable
     /// <param name="amount"></param>
     /// <param name="reason"></param>
     /// <returns></returns>
-    bool RemoveFavor(string playerUID, int amount, string reason = "");
+    bool RemoveFavor(string playerUID, DeityDomain domain, int amount, string reason = "");
 
     /// <summary>
     ///     Adds fractional favor to a player (for passive favor generation)
@@ -78,7 +79,7 @@ public interface IPlayerProgressionDataManager : IDisposable
     /// <param name="playerUID">Player unique identifier</param>
     /// <param name="amount">Amount of favor to add</param>
     /// <param name="reason">Reason for adding favor (optional)</param>
-    void AddFractionalFavor(string playerUID, float amount, string reason = "");
+    void AddFractionalFavor(string playerUID, DeityDomain domain, float amount, string reason = "");
 
     /// <summary>
     ///     Triggers the OnPlayerDataChanged event for the specified player.
@@ -117,7 +118,7 @@ public interface IPlayerProgressionDataManager : IDisposable
     /// <returns>
     /// The <see cref="FavorRank"/> representing the player's current favor rank.
     /// </returns>
-    public FavorRank GetPlayerFavorRank(string playerUID);
+    public FavorRank GetPlayerFavorRank(string playerUID, DeityDomain domain);
 
     /// <summary>
     /// [DEPRECATED] Gets the timestamp when the player is next allowed to pray (elapsed milliseconds).
@@ -163,11 +164,4 @@ public interface IPlayerProgressionDataManager : IDisposable
     /// <param name="completionTimeUtc">UTC DateTime when patrol was completed</param>
     void SetLastPatrolCompletionTimeUtc(string playerUID, DateTime completionTimeUtc);
 
-    /// <summary>
-    /// Migrates player branch commitments from existing unlocked blessings.
-    /// Called for players with DataVersion &lt; 4 to infer branch commitments.
-    /// </summary>
-    /// <param name="playerUID">Player unique identifier</param>
-    /// <param name="blessingRegistry">Blessing registry to look up blessing branch info</param>
-    void MigrateBranchCommitments(string playerUID, IBlessingRegistry blessingRegistry);
 }

--- a/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
@@ -79,7 +79,7 @@ public class BlessingNetworkHandler : IServerNetworkHandler
             {
                 var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(fromPlayer.PlayerUID);
                 var religion = _religionManager.GetPlayerReligion(fromPlayer.PlayerUID);
-                var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(fromPlayer.PlayerUID);
+                var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(fromPlayer.PlayerUID, blessing.Domain);
 
                 // Skip cost check here - we'll handle it atomically below
                 var (canUnlock, reason) = _blessingRegistry.CanUnlockBlessing(fromPlayer.PlayerUID, playerFavorRank, playerData, religion, blessing, skipCostCheck: true);
@@ -100,11 +100,11 @@ public class BlessingNetworkHandler : IServerNetworkHandler
                         else
                         {
                             // Atomically deduct favor cost (includes sufficiency check)
-                            if (blessing.Cost > 0 && !playerData.RemoveFavor(blessing.Cost))
+                            if (blessing.Cost > 0 && !playerData.RemoveFavor(blessing.Domain, blessing.Cost))
                             {
                                 message = LocalizationService.Instance.Get(
                                     LocalizationKeys.CMD_BLESSING_ERROR_INSUFFICIENT_FAVOR,
-                                    blessing.Cost, playerData.Favor);
+                                    blessing.Cost, playerData.GetFavor(blessing.Domain));
                             }
                             else
                             {
@@ -206,9 +206,6 @@ public class BlessingNetworkHandler : IServerNetworkHandler
         {
             var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(fromPlayer.PlayerUID);
 
-            // Run branch commitment migration for players with older data versions
-            _playerProgressionDataManager.MigrateBranchCommitments(fromPlayer.PlayerUID, _blessingRegistry);
-
             var religion = _religionManager.GetPlayerReligion(fromPlayer.PlayerUID);
             var deity = _playerProgressionDataManager.GetPlayerDeityType(fromPlayer.PlayerUID);
             if (religion == null || deity == DeityDomain.None)
@@ -222,12 +219,12 @@ public class BlessingNetworkHandler : IServerNetworkHandler
             response.ReligionUID = religion.ReligionUID;
             response.ReligionName = religion.ReligionName;
             response.Domain = deity.ToString();
-            response.DeityName = religion.DeityName;
-            response.FavorRank = (int)_playerProgressionDataManager.GetPlayerFavorRank(fromPlayer.PlayerUID);
+            response.DeityName = religion.PatronName;
+            response.FavorRank = (int)_playerProgressionDataManager.GetPlayerFavorRank(fromPlayer.PlayerUID, deity);
             response.PrestigeRank = (int)religion.PrestigeRank;
-            response.CurrentFavor = playerData.Favor;
+            response.CurrentFavor = playerData.GetFavor(deity);
             response.CurrentPrestige = religion.Prestige;
-            response.TotalFavorEarned = playerData.TotalFavorEarned;
+            response.TotalFavorEarned = playerData.GetTotalFavorEarned(deity);
 
             // Get player blessings for this deity
             var playerBlessings = _blessingRegistry.GetBlessingsForDeity(deity, BlessingKind.Player);

--- a/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
@@ -61,7 +61,7 @@ public class CivilizationNetworkHandler(
         foreach (var civ in civilizations)
         {
             var religions = civilizationManager.GetCivReligions(civ.CivId);
-            var deities = religions.Select(r => r.Domain.ToString()).Distinct().ToList();
+            var deities = religions.Select(r => r.PatronDomain.ToString()).Distinct().ToList();
             var religionNames = religions.Select(r => r.ReligionName).ToList();
 
             // Apply deity filter if specified
@@ -69,7 +69,7 @@ public class CivilizationNetworkHandler(
             {
                 // Check if any religion in this civilization has the filtered deity
                 var hasFilteredDeity = religions.Any(r =>
-                    string.Equals(r.Domain.ToString(), packet.FilterDeity, StringComparison.OrdinalIgnoreCase));
+                    string.Equals(r.PatronDomain.ToString(), packet.FilterDeity, StringComparison.OrdinalIgnoreCase));
 
                 if (!hasFilteredDeity) continue; // Skip this civilization if it doesn't have the filtered deity
             }
@@ -194,8 +194,8 @@ public class CivilizationNetworkHandler(
             {
                 ReligionId = religion.ReligionUID,
                 ReligionName = religion.ReligionName,
-                Domain = religion.Domain.ToString(),
-                DeityName = religion.DeityName,
+                Domain = religion.PatronDomain.ToString(),
+                DeityName = religion.PatronName,
                 FounderReligionUID = civ.FounderReligionUID,
                 FounderUID = religion.FounderUID,
                 FounderName = religionFounderName,

--- a/DivineAscension/Systems/Networking/Server/HolySiteNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/HolySiteNetworkHandler.cs
@@ -176,7 +176,7 @@ public class HolySiteNetworkHandler : IServerNetworkHandler
 
         // Find the appropriate ritual
         var sourceTier = site.GetTier();
-        var ritual = _ritualLoader.GetRitualForTierUpgrade(religion.Domain, sourceTier, targetTier);
+        var ritual = _ritualLoader.GetRitualForTierUpgrade(religion.PatronDomain, sourceTier, targetTier);
         if (ritual == null)
         {
             SendRitualError(fromPlayer, $"No ritual found for upgrading from Tier {sourceTier} to Tier {targetTier}");
@@ -340,7 +340,7 @@ public class HolySiteNetworkHandler : IServerNetworkHandler
                 .Where(site =>
                 {
                     var religion = _religionManager.GetReligion(site.ReligionUID);
-                    return religion != null && religion.Domain.ToString() == domainFilter;
+                    return religion != null && religion.PatronDomain.ToString() == domainFilter;
                 })
                 .ToList();
         }
@@ -422,7 +422,7 @@ public class HolySiteNetworkHandler : IServerNetworkHandler
             SiteName = site.SiteName,
             ReligionUID = site.ReligionUID,
             ReligionName = religion.ReligionName,
-            Domain = religion.Domain.ToString(),
+            Domain = religion.PatronDomain.ToString(),
             Tier = tier,
             Volume = site.GetTotalVolume(),
             AreaCount = site.Areas.Count,
@@ -464,7 +464,7 @@ public class HolySiteNetworkHandler : IServerNetworkHandler
             SiteName = site.SiteName,
             ReligionUID = site.ReligionUID,
             ReligionName = religion.ReligionName,
-            Domain = religion.Domain.ToString(),
+            Domain = religion.PatronDomain.ToString(),
             FounderUID = site.FounderUID,
             FounderName = site.FounderName,
             CreationDate = site.CreationDate,

--- a/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
@@ -100,12 +100,12 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
             var packet = new PlayerReligionDataPacket(
                 religionData.ReligionName,
                 deity.ToString(),
-                religionData.DeityName,
-                playerReligionData!.Favor,
-                _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID).ToString(),
+                religionData.PatronName,
+                playerReligionData!.GetFavor(deity),
+                _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, deity).ToString(),
                 religionData.Prestige,
                 religionData.PrestigeRank.ToString(),
-                playerReligionData.TotalFavorEarned
+                playerReligionData.GetTotalFavorEarned(deity)
             )
             {
                 // Send config thresholds so client UI displays correct values

--- a/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
@@ -92,8 +92,8 @@ public class ReligionNetworkHandler : IServerNetworkHandler
         {
             ReligionUID = r.ReligionUID,
             ReligionName = r.ReligionName,
-            Domain = r.Domain.ToString(),
-            DeityName = r.DeityName,
+            Domain = r.PatronDomain.ToString(),
+            DeityName = r.PatronName,
             MemberCount = r.MemberUIDs.Count,
             Prestige = r.Prestige,
             PrestigeRank = r.PrestigeRank.ToString(),
@@ -126,8 +126,8 @@ public class ReligionNetworkHandler : IServerNetworkHandler
             response.HasReligion = true;
             response.ReligionUID = religion.ReligionUID;
             response.ReligionName = religion.ReligionName;
-            response.Domain = religion.Domain.ToString();
-            response.DeityName = religion.DeityName;
+            response.Domain = religion.PatronDomain.ToString();
+            response.DeityName = religion.PatronName;
             response.FounderUID = religion.FounderUID;
             response.FounderName = religion.FounderName;
             response.Prestige = religion.Prestige;
@@ -162,8 +162,8 @@ public class ReligionNetworkHandler : IServerNetworkHandler
                 {
                     PlayerUID = member.Key,
                     PlayerName = memberName,
-                    FavorRank = _playerProgressionDataManager!.GetPlayerFavorRank(member.Key).ToString(),
-                    Favor = memberPlayerData.Favor,
+                    FavorRank = _playerProgressionDataManager!.GetPlayerFavorRank(member.Key, religion.PatronDomain).ToString(),
+                    Favor = memberPlayerData.GetFavor(religion.PatronDomain),
                     IsFounder = roleId == RoleDefaults.FOUNDER_ROLE_ID,
                     RoleName = roleName,
                     RoleId = roleId
@@ -240,8 +240,8 @@ public class ReligionNetworkHandler : IServerNetworkHandler
         // Build response with religion details
         response.ReligionUID = religion.ReligionUID;
         response.ReligionName = religion.ReligionName;
-        response.Domain = religion.Domain.ToString();
-        response.DeityName = religion.DeityName;
+        response.Domain = religion.PatronDomain.ToString();
+        response.DeityName = religion.PatronName;
         response.Description = religion.Description;
         response.Prestige = religion.Prestige;
         response.PrestigeRank = religion.PrestigeRank.ToString();
@@ -261,8 +261,8 @@ public class ReligionNetworkHandler : IServerNetworkHandler
             {
                 PlayerUID = member.Key,
                 PlayerName = memberName,
-                FavorRank = _playerProgressionDataManager!.GetPlayerFavorRank(member.Key).ToString(),
-                Favor = memberPlayerData.Favor
+                FavorRank = _playerProgressionDataManager!.GetPlayerFavorRank(member.Key, religion.PatronDomain).ToString(),
+                Favor = memberPlayerData.GetFavor(religion.PatronDomain)
             });
         }
 

--- a/DivineAscension/Systems/PlayerProgressionData.cs
+++ b/DivineAscension/Systems/PlayerProgressionData.cs
@@ -58,16 +58,16 @@ public class PlayerProgressionData
 
 
     /// <summary>
-    ///     Current favor points
+    ///     Current favor points per deity domain.
     /// </summary>
     [ProtoMember(101)]
-    public int Favor { get; set; }
+    public Dictionary<DeityDomain, int> FavorByDeity { get; set; } = new();
 
     /// <summary>
-    ///     Total favor earned (lifetime stat, persists across religion changes)
+    ///     Total favor earned per deity domain (lifetime stat, persists across religion changes).
     /// </summary>
     [ProtoMember(102)]
-    public int TotalFavorEarned { get; set; }
+    public Dictionary<DeityDomain, int> TotalFavorEarnedByDeity { get; set; } = new();
 
     /// <summary>
     ///     Read-only view of unlocked player blessings.
@@ -87,19 +87,16 @@ public class PlayerProgressionData
 
 
     /// <summary>
-    ///     Data version for migration purposes.
-    ///     v3: Initial v3 format
-    ///     v4: Branch commitments
-    ///     v5: DateTime-based cooldowns (prayer and patrol)
+    ///     Data version (internal bookkeeping only — Pantheon 2.0 no longer carries cross-version save migrations).
     /// </summary>
     [ProtoMember(104)]
-    public int DataVersion { get; set; } = 5;
+    public int DataVersion { get; set; } = 6;
 
     /// <summary>
-    ///     Accumulated fractional favor (not yet awarded) for passive generation
+    ///     Accumulated fractional favor per deity domain (not yet awarded) for passive generation.
     /// </summary>
     [ProtoMember(105)]
-    public float AccumulatedFractionalFavor { get; set; }
+    public Dictionary<DeityDomain, float> AccumulatedFractionalFavorByDeity { get; set; } = new();
 
     /// <summary>
     ///     Set of discovered ruin locations (format: "x_y_z")
@@ -126,57 +123,115 @@ public class PlayerProgressionData
     public long NextPrayerAllowedTime { get; set; }
 
     /// <summary>
-    ///     Adds favor and updates statistics.
-    ///     Thread-safe.
+    ///     Gets current favor for a domain (thread-safe).
     /// </summary>
-    public void AddFavor(int amount)
-    {
-        if (amount > 0)
-        {
-            lock (Lock)
-            {
-                Favor += amount;
-                TotalFavorEarned += amount;
-            }
-        }
-    }
-
-    /// <summary>
-    ///     Adds fractional favor and updates statistics when accumulated amount >= 1.
-    ///     Thread-safe.
-    /// </summary>
-    public void AddFractionalFavor(float amount)
-    {
-        if (amount > 0)
-        {
-            lock (Lock)
-            {
-                AccumulatedFractionalFavor += amount;
-
-                // Award integer favor when we have accumulated >= 1.0
-                if (AccumulatedFractionalFavor >= 1.0f)
-                {
-                    var favorToAward = (int)AccumulatedFractionalFavor;
-                    AccumulatedFractionalFavor -= favorToAward; // Keep the fractional remainder
-
-                    Favor += favorToAward;
-                    TotalFavorEarned += favorToAward;
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    ///     Removes favor (for costs or penalties).
-    ///     Thread-safe.
-    /// </summary>
-    public bool RemoveFavor(int amount)
+    public int GetFavor(DeityDomain domain)
     {
         lock (Lock)
         {
-            if (Favor >= amount)
+            return FavorByDeity.GetValueOrDefault(domain);
+        }
+    }
+
+    /// <summary>
+    ///     Gets lifetime total favor earned for a domain (thread-safe).
+    /// </summary>
+    public int GetTotalFavorEarned(DeityDomain domain)
+    {
+        lock (Lock)
+        {
+            return TotalFavorEarnedByDeity.GetValueOrDefault(domain);
+        }
+    }
+
+    /// <summary>
+    ///     Gets accumulated fractional favor for a domain (thread-safe).
+    /// </summary>
+    public float GetAccumulatedFractionalFavor(DeityDomain domain)
+    {
+        lock (Lock)
+        {
+            return AccumulatedFractionalFavorByDeity.GetValueOrDefault(domain);
+        }
+    }
+
+    /// <summary>
+    ///     Adds favor for a deity and updates lifetime statistics.
+    ///     Thread-safe.
+    /// </summary>
+    public void AddFavor(DeityDomain domain, int amount)
+    {
+        if (amount <= 0)
+            return;
+
+        lock (Lock)
+        {
+            FavorByDeity[domain] = FavorByDeity.GetValueOrDefault(domain) + amount;
+            TotalFavorEarnedByDeity[domain] = TotalFavorEarnedByDeity.GetValueOrDefault(domain) + amount;
+        }
+    }
+
+    /// <summary>
+    ///     Adds fractional favor for a deity and awards integer favor when accumulated >= 1.
+    ///     Thread-safe.
+    /// </summary>
+    public void AddFractionalFavor(DeityDomain domain, float amount)
+    {
+        if (amount <= 0)
+            return;
+
+        lock (Lock)
+        {
+            var accumulated = AccumulatedFractionalFavorByDeity.GetValueOrDefault(domain) + amount;
+
+            if (accumulated >= 1.0f)
             {
-                Favor -= amount;
+                var favorToAward = (int)accumulated;
+                accumulated -= favorToAward;
+
+                FavorByDeity[domain] = FavorByDeity.GetValueOrDefault(domain) + favorToAward;
+                TotalFavorEarnedByDeity[domain] = TotalFavorEarnedByDeity.GetValueOrDefault(domain) + favorToAward;
+            }
+
+            AccumulatedFractionalFavorByDeity[domain] = accumulated;
+        }
+    }
+
+    /// <summary>
+    ///     Sets current favor for a deity (admin/testing path). Thread-safe.
+    /// </summary>
+    public void SetFavor(DeityDomain domain, int amount)
+    {
+        lock (Lock)
+        {
+            FavorByDeity[domain] = amount;
+        }
+    }
+
+    /// <summary>
+    ///     Sets total favor earned for a deity (admin/testing path). Thread-safe.
+    /// </summary>
+    public void SetTotalFavorEarned(DeityDomain domain, int amount)
+    {
+        lock (Lock)
+        {
+            TotalFavorEarnedByDeity[domain] = amount;
+        }
+    }
+
+    /// <summary>
+    ///     Removes favor for a deity (for costs or penalties).
+    ///     Returns false if insufficient favor.
+    ///     Thread-safe.
+    /// </summary>
+    public bool RemoveFavor(DeityDomain domain, int amount)
+    {
+        lock (Lock)
+        {
+            var current = FavorByDeity.GetValueOrDefault(domain);
+            if (current >= amount)
+            {
+                FavorByDeity[domain] = current - amount;
                 return true;
             }
 
@@ -233,15 +288,16 @@ public class PlayerProgressionData
     }
 
     /// <summary>
-    ///     Resets favor and blessings (penalty for switching religions).
-    ///     Also clears branch commitments since branches are domain-specific.
+    ///     Resets favor for the abandoned deity and clears blessings + branch commitments
+    ///     (penalty for switching religions). Favor with other deities is preserved.
     ///     Thread-safe.
     /// </summary>
-    public void ApplySwitchPenalty()
+    public void ApplySwitchPenalty(DeityDomain abandonedDomain)
     {
         lock (Lock)
         {
-            Favor = 0;
+            FavorByDeity.Remove(abandonedDomain);
+            AccumulatedFractionalFavorByDeity.Remove(abandonedDomain);
             _unlockedBlessings.Clear();
             _committedBranchesSerializable.Clear();
             _lockedBranchesSerializable.Clear();

--- a/DivineAscension/Systems/PlayerProgressionDataManager.cs
+++ b/DivineAscension/Systems/PlayerProgressionDataManager.cs
@@ -122,47 +122,42 @@ public class PlayerProgressionDataManager : IPlayerProgressionDataManager
     }
 
     /// <summary>
-    ///     Adds favor to a player
+    ///     Adds favor to a player for a specific deity.
     /// </summary>
-    public void AddFavor(string playerUID, int amount, string reason = "")
+    public void AddFavor(string playerUID, DeityDomain domain, int amount, string reason = "")
     {
         var data = GetOrCreatePlayerData(playerUID);
-        var oldRank = CalculateFavorRank(data.TotalFavorEarned);
+        var oldRank = CalculateFavorRank(data.GetTotalFavorEarned(domain));
 
-        data.AddFavor(amount);
+        data.AddFavor(domain, amount);
 
         if (!string.IsNullOrEmpty(reason))
-            _logger.Debug($"[DivineAscension] Player {playerUID} gained {amount} favor: {reason}");
+            _logger.Debug($"[DivineAscension] Player {playerUID} gained {amount} favor ({domain}): {reason}");
 
-        // Check for rank up
-        var newRank = CalculateFavorRank(data.TotalFavorEarned);
+        var newRank = CalculateFavorRank(data.GetTotalFavorEarned(domain));
         if (newRank > oldRank) SendRankUpNotification(playerUID, newRank);
 
-        // Notify listeners that player data changed (for UI updates)
         OnPlayerDataChanged?.Invoke(playerUID);
     }
 
     /// <summary>
-    ///     Adds fractional favor to a player (for passive favor generation)
+    ///     Adds fractional favor to a player for a specific deity (passive generation).
     /// </summary>
-    public void AddFractionalFavor(string playerUID, float amount, string reason = "")
+    public void AddFractionalFavor(string playerUID, DeityDomain domain, float amount, string reason = "")
     {
         var data = GetOrCreatePlayerData(playerUID);
-        var oldRank = CalculateFavorRank(data.TotalFavorEarned);
-        var oldFavor = data.Favor;
+        var oldRank = CalculateFavorRank(data.GetTotalFavorEarned(domain));
+        var oldFavor = data.GetFavor(domain);
 
-        data.AddFractionalFavor(amount);
+        data.AddFractionalFavor(domain, amount);
 
-        // Only log when favor is actually awarded (when accumulated >= 1)
-        if (data.AccumulatedFractionalFavor < amount && !string.IsNullOrEmpty(reason))
-            _logger.Debug($"[DivineAscension] Player {playerUID} gained favor: {reason}");
+        if (data.GetAccumulatedFractionalFavor(domain) < amount && !string.IsNullOrEmpty(reason))
+            _logger.Debug($"[DivineAscension] Player {playerUID} gained favor ({domain}): {reason}");
 
-        // Check for rank up
-        var newRank = CalculateFavorRank(data.TotalFavorEarned);
+        var newRank = CalculateFavorRank(data.GetTotalFavorEarned(domain));
         if (newRank > oldRank) SendRankUpNotification(playerUID, newRank);
 
-        // Notify listeners if favor actually changed (UI updates)
-        if (data.Favor != oldFavor) OnPlayerDataChanged?.Invoke(playerUID);
+        if (data.GetFavor(domain) != oldFavor) OnPlayerDataChanged?.Invoke(playerUID);
     }
 
     /// <summary>
@@ -175,17 +170,16 @@ public class PlayerProgressionDataManager : IPlayerProgressionDataManager
     }
 
     /// <summary>
-    ///     Removes favor from a player
+    ///     Removes favor from a player for a specific deity.
     /// </summary>
-    public bool RemoveFavor(string playerUID, int amount, string reason = "")
+    public bool RemoveFavor(string playerUID, DeityDomain domain, int amount, string reason = "")
     {
         var data = GetOrCreatePlayerData(playerUID);
-        var success = data.RemoveFavor(amount);
+        var success = data.RemoveFavor(domain, amount);
 
         if (success && !string.IsNullOrEmpty(reason))
-            _logger.Debug($"[DivineAscension] Player {playerUID} spent {amount} favor: {reason}");
+            _logger.Debug($"[DivineAscension] Player {playerUID} spent {amount} favor ({domain}): {reason}");
 
-        // Notify listeners that player data changed (for UI updates)
         if (success) OnPlayerDataChanged?.Invoke(playerUID);
 
         return success;
@@ -269,10 +263,10 @@ public class PlayerProgressionDataManager : IPlayerProgressionDataManager
     {
         if (!HasReligion(playerUID)) return;
 
-        HandleReligionSwitch(playerUID);
         var playerReligion = _religionManager.GetPlayerReligion(playerUID);
         if (playerReligion == null) return;
-        // Remove from religion
+
+        HandleReligionSwitch(playerUID, playerReligion.PatronDomain);
         _religionManager.RemoveMember(playerReligion.ReligionUID, playerUID);
 
         OnPlayerLeavesReligion.Invoke(_worldService.GetPlayerByUID(playerUID)!,
@@ -290,12 +284,12 @@ public class PlayerProgressionDataManager : IPlayerProgressionDataManager
     }
 
     /// <summary>
-    ///     Calculates favor rank based on total favor earned using configured thresholds
+    ///     Calculates favor rank for a deity based on total favor earned with that deity.
     /// </summary>
-    public FavorRank GetPlayerFavorRank(string playerUID)
+    public FavorRank GetPlayerFavorRank(string playerUID, DeityDomain domain)
     {
         var data = GetOrCreatePlayerData(playerUID);
-        return CalculateFavorRank(data.TotalFavorEarned);
+        return CalculateFavorRank(data.GetTotalFavorEarned(domain));
     }
 
     /// <summary>
@@ -383,91 +377,17 @@ public class PlayerProgressionDataManager : IPlayerProgressionDataManager
     }
 
     /// <summary>
-    ///     Migrates player branch commitments from existing unlocked blessings.
-    ///     For players with DataVersion &lt; 4, infers branch commitments from unlocked blessings.
+    ///     Applies switching penalty when leaving a religion (clears favor + blessings
+    ///     for the abandoned deity only; favor with other deities is preserved).
     /// </summary>
-    public void MigrateBranchCommitments(string playerUID, IBlessingRegistry blessingRegistry)
-    {
-        if (!TryGetPlayerData(playerUID, out var playerData) || playerData == null)
-            return;
-
-        // Only migrate if data version is less than 4
-        if (playerData.DataVersion >= 4)
-            return;
-
-        _logger.Debug(
-            $"[DivineAscension] Migrating branch commitments for player {playerUID} (v{playerData.DataVersion} -> v4)");
-
-        var migratedCount = 0;
-        foreach (var blessingId in playerData.UnlockedBlessings)
-        {
-            var blessing = blessingRegistry.GetBlessing(blessingId);
-            if (blessing == null || string.IsNullOrEmpty(blessing.Branch))
-                continue;
-
-            // Commit to this branch if not already committed in this domain
-            if (playerData.GetCommittedBranch(blessing.Domain) == null)
-            {
-                playerData.CommitToBranch(blessing.Domain, blessing.Branch, blessing.ExclusiveBranches);
-                migratedCount++;
-                _logger.Debug($"[DivineAscension] Migrated branch commitment: {blessing.Domain} -> {blessing.Branch}");
-            }
-        }
-
-        // Bump data version to 4
-        playerData.DataVersion = 4;
-
-        if (migratedCount > 0)
-        {
-            _logger.Notification(
-                $"[DivineAscension] Migrated {migratedCount} branch commitment(s) for player {playerUID}");
-        }
-    }
-
-    /// <summary>
-    ///     Applies switching penalty when changing religions
-    /// </summary>
-    public void HandleReligionSwitch(string playerUID)
+    public void HandleReligionSwitch(string playerUID, DeityDomain abandonedDomain)
     {
         var data = GetOrCreatePlayerData(playerUID);
 
-        _logger.Notification($"[DivineAscension] Applying religion switch penalty to player {playerUID}");
-
-        // Apply penalty (reset favor and blessings)
-        data.ApplySwitchPenalty();
-    }
-
-    /// <summary>
-    ///     Migrates player cooldowns from elapsed milliseconds to UTC DateTime.
-    ///     For players with DataVersion &lt; 5, clears old cooldowns (one-time reset).
-    ///     Cannot accurately convert elapsed-ms to DateTime without knowing server start time.
-    /// </summary>
-    internal void MigrateCooldownsToUtc(string playerUID)
-    {
-        if (!TryGetPlayerData(playerUID, out var playerData) || playerData == null)
-            return;
-
-        // Only migrate if data version is less than 5
-        if (playerData.DataVersion >= 5)
-            return;
-
-        _logger.Debug(
-            $"[DivineAscension] Migrating cooldowns for player {playerUID} (v{playerData.DataVersion} -> v5)");
-
-        // Clear old elapsed-ms cooldowns - cannot convert accurately
-        // Players get a one-time reset of their cooldowns after update
-        playerData.NextPrayerAllowedTime = 0;
-        playerData.LastPatrolCompletionTime = 0;
-
-        // New DateTime fields start as null (no cooldown active)
-        playerData.NextPrayerAllowedTimeUtc = null;
-        playerData.LastPatrolCompletionTimeUtc = null;
-
-        // Bump data version to 5
-        playerData.DataVersion = 5;
-
         _logger.Notification(
-            $"[DivineAscension] Migrated cooldowns to UTC DateTime for player {playerUID} (cooldowns reset)");
+            $"[DivineAscension] Applying religion switch penalty to player {playerUID} (deity {abandonedDomain})");
+
+        data.ApplySwitchPenalty(abandonedDomain);
     }
 
     private FavorRank CalculateFavorRank(int totalFavor)
@@ -547,12 +467,6 @@ public class PlayerProgressionDataManager : IPlayerProgressionDataManager
                     _playerData[playerUID] = playerData;
                     _logger.Debug(
                         $"[DivineAscension] Loaded data for player {playerUID} (v{playerData.DataVersion})");
-
-                    // Run migrations for older data versions
-                    if (playerData.DataVersion < 5)
-                    {
-                        MigrateCooldownsToUtc(playerUID);
-                    }
                 }
                 else
                 {

--- a/DivineAscension/Systems/PvPManager.cs
+++ b/DivineAscension/Systems/PvPManager.cs
@@ -79,11 +79,12 @@ public class PvPManager : IPvPManager
     public void AwardRewardsForAction(IServerPlayer player, string actionType, int favorAmount, int prestigeAmount)
     {
         var playerReligion = _religionManager.GetPlayerReligion(player.PlayerUID);
-        if (_playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID) == DeityDomain.None ||
+        var deity = _playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID);
+        if (deity == DeityDomain.None ||
             !_playerProgressionDataManager.HasReligion(player.PlayerUID)) return;
 
         // Award favor
-        if (favorAmount > 0) _playerProgressionDataManager.AddFavor(player.PlayerUID, favorAmount, actionType);
+        if (favorAmount > 0) _playerProgressionDataManager.AddFavor(player.PlayerUID, deity, favorAmount, actionType);
 
         // Award prestige
         if (prestigeAmount > 0)
@@ -207,7 +208,7 @@ public class PvPManager : IPvPManager
         }
 
         // Award favor to player
-        _playerProgressionDataManager.AddFavor(attacker.PlayerUID, (int)favorReward,
+        _playerProgressionDataManager.AddFavor(attacker.PlayerUID, attackerReligion.PatronDomain, (int)favorReward,
             $"PvP kill against {victim.PlayerName}");
 
         // Award prestige to religion
@@ -215,7 +216,7 @@ public class PvPManager : IPvPManager
             $"PvP kill by {attacker.PlayerName} against {victim.PlayerName}");
 
         // Get deity for display
-        var deityName = attackerReligion.DeityName;
+        var deityName = attackerReligion.PatronName;
 
         // Notify attacker with combined rewards
         var bonusText = "";
@@ -232,9 +233,9 @@ public class PvPManager : IPvPManager
 
         // Notify victim
         if (victimDeityDomain != DeityDomain.None && victimReligion != null &&
-            !string.IsNullOrEmpty(victimReligion.DeityName))
+            !string.IsNullOrEmpty(victimReligion.PatronName))
         {
-            var victimDeityName = victimReligion.DeityName;
+            var victimDeityName = victimReligion.PatronName;
             victim.SendMessage(
                 GlobalConstants.GeneralChatGroup,
                 $"[Divine Defeat] {victimDeityName} is displeased by your defeat.",
@@ -258,10 +259,10 @@ public class PvPManager : IPvPManager
         if (activeDeityType == DeityDomain.None || religionId == null) return;
 
         // Remove favor as penalty (minimum 0)
-        var penalty = Math.Min(_config.DeathPenalty, playerData.Favor);
+        var penalty = Math.Min(_config.DeathPenalty, playerData.GetFavor(activeDeityType));
         if (penalty > 0)
         {
-            playerData.Favor -= penalty;
+            playerData.RemoveFavor(activeDeityType, penalty);
 
             player.SendMessage(
                 GlobalConstants.GeneralChatGroup,

--- a/DivineAscension/Systems/ReligionManager.cs
+++ b/DivineAscension/Systems/ReligionManager.cs
@@ -174,7 +174,7 @@ public class ReligionManager : IReligionManager
             return false;
         }
 
-        religion.DeityName = trimmedName;
+        religion.PatronName = trimmedName;
         SaveAllReligions();
 
         _logger.Notification(
@@ -298,7 +298,7 @@ public class ReligionManager : IReligionManager
     public DeityDomain GetPlayerActiveDeityDomain(string playerId)
     {
         var religion = GetPlayerReligion(playerId);
-        return religion?.Domain ?? DeityDomain.None;
+        return religion?.PatronDomain ?? DeityDomain.None;
     }
 
     /// <summary>
@@ -488,7 +488,7 @@ public class ReligionManager : IReligionManager
     /// </summary>
     public List<ReligionData> GetReligionsByDomain(DeityDomain domain)
     {
-        return _religions.Values.Where(r => r.Domain == domain).ToList();
+        return _religions.Values.Where(r => r.PatronDomain == domain).ToList();
     }
 
     /// <summary>
@@ -931,10 +931,10 @@ public class ReligionManager : IReligionManager
         // Take snapshot for thread-safe iteration
         foreach (var religion in _religions.Values.ToList())
         {
-            if (string.IsNullOrEmpty(religion.DeityName))
+            if (string.IsNullOrEmpty(religion.PatronName))
             {
-                var domainName = religion.Domain.ToString();
-                religion.DeityName = domainName;
+                var domainName = religion.PatronDomain.ToString();
+                religion.PatronName = domainName;
                 migratedUIDs.Add(religion.ReligionUID);
                 _logger.Notification(
                     $"[DivineAscension] Migrated deity name for {religion.ReligionName}: '{domainName}'");
@@ -1001,10 +1001,10 @@ public class ReligionManager : IReligionManager
         // Take snapshot for thread-safe iteration
         foreach (var religion in _religions.Values.ToList())
         {
-            if (string.IsNullOrWhiteSpace(religion.DeityName))
+            if (string.IsNullOrWhiteSpace(religion.PatronName))
             {
                 // Set default deity name to domain name
-                religion.DeityName = religion.Domain.ToString();
+                religion.PatronName = religion.PatronDomain.ToString();
                 migratedCount++;
             }
         }

--- a/DivineAscension/Systems/ReligionPrestigeManager.cs
+++ b/DivineAscension/Systems/ReligionPrestigeManager.cs
@@ -272,7 +272,7 @@ public class ReligionPrestigeManager : IReligionPrestigeManager
         if (religion == null) return;
 
         // Get all religion blessings for this deity
-        var allReligionBlessings = _blessingRegistry.GetBlessingsForDeity(religion.Domain, BlessingKind.Religion);
+        var allReligionBlessings = _blessingRegistry.GetBlessingsForDeity(religion.PatronDomain, BlessingKind.Religion);
 
         // Find blessings that are now unlockable at the new rank
         var newlyUnlockableBlessings = new List<Blessing>();

--- a/DivineAscension/Systems/RitualProgressManager.cs
+++ b/DivineAscension/Systems/RitualProgressManager.cs
@@ -73,9 +73,9 @@ public class RitualProgressManager : IRitualProgressManager
         }
 
         // Validate domain match
-        if (ritual.Domain != religion.Domain)
+        if (ritual.Domain != religion.PatronDomain)
         {
-            return new RitualStartResult(false, $"This ritual is for {ritual.Domain} domain, but your religion follows {religion.Domain}");
+            return new RitualStartResult(false, $"This ritual is for {ritual.Domain} domain, but your religion follows {religion.PatronDomain}");
         }
 
         // Validate tier progression

--- a/DivineAscension/assets/divineascension/config/blessings/conquest.json
+++ b/DivineAscension/assets/divineascension/config/blessings/conquest.json
@@ -115,7 +115,8 @@
       "specialEffects": ["bloodlust"],
       "cost": 800,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     },
     {
       "blessingId": "conquest_warband",
@@ -193,7 +194,8 @@
       "specialEffects": [],
       "cost": 8000,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     }
   ]
 }

--- a/DivineAscension/assets/divineascension/config/blessings/craft.json
+++ b/DivineAscension/assets/divineascension/config/blessings/craft.json
@@ -113,7 +113,8 @@
       "specialEffects": ["passive_tool_repair_1per5min"],
       "cost": 800,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     },
     {
       "blessingId": "khoras_shared_workshop",
@@ -189,7 +190,8 @@
       "specialEffects": [],
       "cost": 8000,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     }
   ]
 }

--- a/DivineAscension/assets/divineascension/config/blessings/harvest.json
+++ b/DivineAscension/assets/divineascension/config/blessings/harvest.json
@@ -122,7 +122,8 @@
       "specialEffects": ["never_malnourished", "blessed_meals"],
       "cost": 800,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     },
     {
       "blessingId": "aethra_community_farm",
@@ -203,7 +204,8 @@
       "specialEffects": ["sacred_granary"],
       "cost": 8000,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     }
   ]
 }

--- a/DivineAscension/assets/divineascension/config/blessings/stone.json
+++ b/DivineAscension/assets/divineascension/config/blessings/stone.json
@@ -121,7 +121,8 @@
       "specialEffects": [],
       "cost": 800,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     },
     {
       "blessingId": "gaia_potters_circle",
@@ -199,7 +200,8 @@
       "specialEffects": [],
       "cost": 8000,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     }
   ]
 }

--- a/DivineAscension/assets/divineascension/config/blessings/wild.json
+++ b/DivineAscension/assets/divineascension/config/blessings/wild.json
@@ -117,7 +117,8 @@
       "specialEffects": [],
       "cost": 800,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     },
     {
       "blessingId": "lysa_hunting_party",
@@ -194,7 +195,8 @@
       "specialEffects": [],
       "cost": 8000,
       "branch": null,
-      "exclusiveBranches": null
+      "exclusiveBranches": null,
+      "requiresPatron": true
     }
   ]
 }


### PR DESCRIPTION
Closes #237.

## Summary
- `PlayerProgressionData` reshaped: Favor/TotalFavorEarned/AccumulatedFractionalFavor are now `Dictionary<DeityDomain, …>`; helpers (`Get/Set/Add/Remove/AddFractional/ApplySwitchPenalty`) all take a `DeityDomain`. `DataVersion` 5→6; legacy v3→v5 save-migration code dropped (1.x and 2.x do not share saves).
- `ReligionData`: `Domain → PatronDomain`, `DeityName → PatronName` (`ProtoMember` tags preserved).
- `Blessing` + `BlessingJsonDto` + `BlessingLoader`: new `RequiresPatron` field. 10 capstone JSONs (5 `avatar_of_*` + 5 `pantheon_of_*`) marked `"requiresPatron": true`.
- `IPlayerProgressionDataManager` methods (AddFavor / RemoveFavor / AddFractionalFavor / GetPlayerFavorRank / HandleReligionSwitch) gained a `DeityDomain` parameter; every call site sweeps to the player's current `PatronDomain` so mono-deity runtime behavior is preserved.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` — clean
- [x] `dotnet test` — 2093/2093 pass (new per-deity isolation + ProtoBuf round-trip + RequiresPatron loader tests included)
- [ ] In-game smoke: load fresh save, join religion, earn favor (mining/hunting), unlock a tier-1 blessing, save+reload — favor persists