### PR TITLE
feat(pantheon): per-deity favor routing + patron multiplier (#238)

### DIFF
--- a/DivineAscension.Tests/Systems/Favor/AnvilFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/AnvilFavorTrackerTests.cs
@@ -105,7 +105,7 @@ public class AnvilFavorTrackerTests
 
         // Assert
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<int>()),
+            f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<float>(), It.IsAny<DeityDomain>()),
             Times.Never
         );
 
@@ -126,7 +126,7 @@ public class AnvilFavorTrackerTests
 
         // Assert
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<int>()),
+            f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<float>(), It.IsAny<DeityDomain>()),
             Times.Never
         );
 
@@ -150,7 +150,7 @@ public class AnvilFavorTrackerTests
 
         // Assert
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<int>()),
+            f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<float>(), It.IsAny<DeityDomain>()),
             Times.Never
         );
 
@@ -159,9 +159,10 @@ public class AnvilFavorTrackerTests
     }
 
     [Fact]
-    public void HandleAnvilRecipeCompleted_WithNonCraftDeity_DoesNotAwardFavor()
+    public void HandleAnvilRecipeCompleted_WithNonCraftPatron_StillAwardsCraftFavor()
     {
-        // Arrange
+        // Under pantheon model, every player accrues per-deity favor via the source domain;
+        // the tracker no longer gates on the player's "active" deity.
         var tracker = CreateTracker();
         tracker.Initialize();
 
@@ -171,7 +172,7 @@ public class AnvilFavorTrackerTests
 
         _fakeWorldService.AddPlayer(mockPlayer.Object);
 
-        // Player follows Wild deity, not Craft
+        // Player has Wild patron — irrelevant; tracker routes Craft regardless.
         _mockPlayerProgressionDataManager
             .Setup(m => m.GetPlayerDeityType("player-uid"))
             .Returns(DeityDomain.Wild);
@@ -181,10 +182,10 @@ public class AnvilFavorTrackerTests
         // Act
         tracker.HandleAnvilRecipeCompleted("player-uid", pos, null);
 
-        // Assert
+        // Assert — tracker still emits Craft-domain favor
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<int>()),
-            Times.Never
+            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", It.IsAny<float>(), DeityDomain.Craft),
+            Times.Once
         );
 
         // Cleanup
@@ -219,7 +220,7 @@ public class AnvilFavorTrackerTests
 
         // Assert - Should award 5 favor (low tier)
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 5),
+            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 5, DeityDomain.Craft),
             Times.Once
         );
 
@@ -255,7 +256,7 @@ public class AnvilFavorTrackerTests
 
         // Assert - Should award 10 favor (mid tier)
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 10),
+            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 10, DeityDomain.Craft),
             Times.Once
         );
 
@@ -291,7 +292,7 @@ public class AnvilFavorTrackerTests
 
         // Assert - Should award 15 favor (high tier)
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 15),
+            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 15, DeityDomain.Craft),
             Times.Once
         );
 
@@ -327,7 +328,7 @@ public class AnvilFavorTrackerTests
 
         // Assert - Should award 20 favor (elite tier)
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 20),
+            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 20, DeityDomain.Craft),
             Times.Once
         );
 
@@ -360,7 +361,7 @@ public class AnvilFavorTrackerTests
 
         // Assert - Should award 10 favor (mid tier default)
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 10),
+            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 10, DeityDomain.Craft),
             Times.Once
         );
 
@@ -400,7 +401,7 @@ public class AnvilFavorTrackerTests
 
         // Assert - Should award 13 favor (20 * 0.65 = 13)
         _mockFavorSystem.Verify(
-            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 13),
+            f => f.AwardFavorForAction(mockPlayer.Object, "smithing", 13, DeityDomain.Craft),
             Times.Once
         );
 

--- a/DivineAscension.Tests/Systems/Favor/ChiselingFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/ChiselingFavorTrackerTests.cs
@@ -66,7 +66,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 0.02f), Times.Once);
+            mockPlayer.Object, "Stone Carving", 0.02f, DeityDomain.Stone), Times.Once);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 2f), Times.Once);
+            mockPlayer.Object, "Stone Carving", 2f, DeityDomain.Stone), Times.Once);
     }
 
     [Fact]
@@ -138,20 +138,20 @@ public class ChiselingFavorTrackerTests
 
         // Assert
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 40f), Times.Once);
+            mockPlayer.Object, "Stone Carving", 40f, DeityDomain.Stone), Times.Once);
     }
 
     [Fact]
-    public void HandleVoxelsChanged_NonStoneFollower_NoFavor()
+    public void HandleVoxelsChanged_NonStonePatron_StillAwardsStoneFavor()
     {
-        // Arrange
+        // Pantheon model: tracker no longer gates on the player's active deity.
         var mockPlayer = new Mock<IServerPlayer>();
         mockPlayer.Setup(p => p.PlayerUID).Returns("player1");
         mockPlayer.Setup(p => p.PlayerName).Returns("TestPlayer");
 
         var mockProgression = new Mock<IPlayerProgressionDataManager>();
         mockProgression.Setup(m => m.GetPlayerDeityType("player1"))
-            .Returns(DeityDomain.Wild); // Not Stone domain
+            .Returns(DeityDomain.Wild);
 
         var mockFavor = new Mock<IFavorSystem>();
         var fakeWorld = new FakeWorldService();
@@ -167,14 +167,12 @@ public class ChiselingFavorTrackerTests
 
         tracker.Initialize();
 
-        // Act - Invoke via reflection
         var method = typeof(StoneFavorTracker).GetMethod("HandleVoxelsChanged",
             BindingFlags.Instance | BindingFlags.NonPublic);
         method!.Invoke(tracker, new object[] { mockPlayer.Object, new BlockPos(0, 0, 0), 100 });
 
-        // Assert - No favor awarded
         mockFavor.Verify(f => f.AwardFavorForAction(
-            It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<float>()), Times.Never);
+            mockPlayer.Object, "Stone Carving", It.IsAny<float>(), DeityDomain.Stone), Times.Once);
     }
 
     [Fact]
@@ -216,7 +214,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert - Both should have 1.0x multiplier
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 2f), Times.Exactly(2)); // 100 × 0.02 × 1.0 = 2f
+            mockPlayer.Object, "Stone Carving", 2f, DeityDomain.Stone), Times.Exactly(2)); // 100 × 0.02 × 1.0 = 2f
     }
 
     [Fact]
@@ -260,7 +258,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert - Third action should have 1.25x multiplier
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 2.5f), Times.Once); // 100 × 0.02 × 1.25 = 2.5f
+            mockPlayer.Object, "Stone Carving", 2.5f, DeityDomain.Stone), Times.Once); // 100 × 0.02 × 1.25 = 2.5f
     }
 
     [Fact]
@@ -301,7 +299,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert - Sixth action should have 1.5x multiplier
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 3f), Times.Once); // 100 × 0.02 × 1.5 = 3f
+            mockPlayer.Object, "Stone Carving", 3f, DeityDomain.Stone), Times.Once); // 100 × 0.02 × 1.5 = 3f
     }
 
     [Fact]
@@ -349,7 +347,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert - After timeout, should be back to 1.0x multiplier
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 2f), Times.Exactly(3)); // Last action: 100 × 0.02 × 1.0 = 2f
+            mockPlayer.Object, "Stone Carving", 2f, DeityDomain.Stone), Times.Exactly(3)); // Last action: 100 × 0.02 × 1.0 = 2f
     }
 
     [Fact]
@@ -390,7 +388,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert - 21st action should have 2.5x multiplier
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 5f), Times.Once); // 100 × 0.02 × 2.5 = 5f
+            mockPlayer.Object, "Stone Carving", 5f, DeityDomain.Stone), Times.Once); // 100 × 0.02 × 2.5 = 5f
     }
 
     [Fact]
@@ -434,7 +432,7 @@ public class ChiselingFavorTrackerTests
 
         // Assert - Only 2 actions should be awarded (spam blocked by cooldown)
         mockFavor.Verify(f => f.AwardFavorForAction(
-            It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<float>()), Times.Exactly(2));
+            It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -484,6 +482,6 @@ public class ChiselingFavorTrackerTests
 
         // Assert - Should have two awards with 1.0x multiplier (session was cleaned up and restarted)
         mockFavor.Verify(f => f.AwardFavorForAction(
-            mockPlayer.Object, "Stone Carving", 2f), Times.Exactly(2)); // 100 × 0.02 × 1.0 = 2f
+            mockPlayer.Object, "Stone Carving", 2f, DeityDomain.Stone), Times.Exactly(2)); // 100 × 0.02 × 1.0 = 2f
     }
 }

--- a/DivineAscension.Tests/Systems/Favor/MiningFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/MiningFavorTrackerTests.cs
@@ -38,34 +38,31 @@ public class MiningFavorTrackerTests : IDisposable
     }
 
     [Fact]
-    public void OnOreBlockBroken_WhenPlayerNotFollowingCraft_AwardsNoFavor()
+    public void OnOreBlockBroken_WhenPlayerHasNonCraftPatron_StillAwardsCraftFavor()
     {
+        // Under pantheon model, all players accrue per-deity favor; patron multiplier
+        // is applied centrally in FavorSystem rather than gating per-tracker.
         var fakeWorldService = new FakeWorldService();
         var mockPlayerReligion = TestFixtures.CreateMockPlayerProgressionDataManager();
         var mockFavor = TestFixtures.CreateMockFavorSystem();
-        var mockPlayer = TestFixtures.CreateMockServerPlayer("player-4", "NotKhoras");
+        var mockPlayer = TestFixtures.CreateMockServerPlayer("player-4", "WildPlayer");
 
         fakeWorldService.AddPlayer(mockPlayer.Object);
 
-        // Player follows Wild (not Craft)
         mockPlayerReligion.Setup(m => m.GetOrCreatePlayerData("player-4"))
             .Returns(TestFixtures.CreateTestPlayerReligionData("player-4", DeityDomain.Wild));
-        mockPlayerReligion.Setup(m => m.GetPlayerDeityType("player-4"))
-            .Returns(DeityDomain.Wild);
 
-        // Ore block would normally grant favor, but since player doesn't follow Craft, expect none
         var block = new Block { Code = new AssetLocation("game", "ore-medium-tin") };
         fakeWorldService.SetBlock(new BlockPos(0, 0, 0), block);
 
         var tracker = CreateTracker(fakeWorldService, mockPlayerReligion, mockFavor);
         tracker.Initialize();
 
-        // Trigger the ore block broken event
         var mockWorld = new Mock<IWorldAccessor>();
         BlockBehaviorOre.TriggerOreBlockBroken(mockWorld.Object, new BlockPos(0, 0, 0), mockPlayer.Object, block, EnumHandling.PassThrough);
 
-        mockFavor.Verify(m => m.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<int>()),
-            Times.Never);
+        mockFavor.Verify(m => m.AwardFavorForAction(It.IsAny<IServerPlayer>(), "mining ore", It.IsAny<float>(), DeityDomain.Craft),
+            Times.Once);
 
         tracker.Dispose();
     }
@@ -101,7 +98,7 @@ public class MiningFavorTrackerTests : IDisposable
         mockFavor.Verify(m => m.AwardFavorForAction(
             It.Is<IServerPlayer>(p => p.PlayerUID == "player-1"),
             "mining ore",
-            1), Times.Once);
+            1, It.IsAny<DeityDomain>()), Times.Once);
 
         tracker.Dispose();
     }
@@ -137,7 +134,7 @@ public class MiningFavorTrackerTests : IDisposable
         mockFavor.Verify(m => m.AwardFavorForAction(
             It.Is<IServerPlayer>(p => p.PlayerUID == "player-3"),
             "mining ore",
-            5), Times.Once);
+            5, It.IsAny<DeityDomain>()), Times.Once);
 
         tracker.Dispose();
     }

--- a/DivineAscension.Tests/Systems/Favor/PatrolFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/PatrolFavorTrackerTests.cs
@@ -247,36 +247,6 @@ public class PatrolFavorTrackerTests
 
     #endregion
 
-    #region IsConquestDomainPlayer Tests
-
-    [Fact]
-    public void IsConquestDomainPlayer_ConquestPlayer_ReturnsTrue()
-    {
-        // Arrange
-        SetupConquestPlayer("player1");
-
-        // Act - directly call internal method
-        var result = _tracker.IsConquestDomainPlayer("player1");
-
-        // Assert
-        Assert.True(result);
-    }
-
-    [Fact]
-    public void IsConquestDomainPlayer_NonConquestPlayer_ReturnsFalse()
-    {
-        // Arrange
-        SetupNonConquestPlayer("player1");
-
-        // Act - directly call internal method
-        var result = _tracker.IsConquestDomainPlayer("player1");
-
-        // Assert
-        Assert.False(result);
-    }
-
-    #endregion
-
     #region GetCivilizationHolySites Tests
 
     [Fact]

--- a/DivineAscension.Tests/Systems/Favor/RuinDiscoveryFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/RuinDiscoveryFavorTrackerTests.cs
@@ -164,55 +164,6 @@ public class RuinDiscoveryFavorTrackerTests
     }
 
     [Fact]
-    public void UpdateFollower_ConquestFollower_AddsToCache()
-    {
-        var fakeWorldService = new FakeWorldService();
-        var mockEventService = new Mock<IEventService>();
-        var mockPlayerProgression = TestFixtures.CreateMockPlayerProgressionDataManager();
-        var mockFavor = TestFixtures.CreateMockFavorSystem();
-        var mockPlayer = TestFixtures.CreateMockServerPlayer("player-1", "TestPlayer");
-
-        fakeWorldService.AddPlayer(mockPlayer.Object);
-
-        // Player follows Conquest
-        mockPlayerProgression.Setup(m => m.GetPlayerDeityType("player-1"))
-            .Returns(DeityDomain.Conquest);
-
-        var tracker = CreateTracker(mockEventService, fakeWorldService, mockPlayerProgression, mockFavor);
-        tracker.Initialize();
-
-        // Verify player is in follower cache by checking if they would be scanned
-        // (We can't directly access the cache, but initialization should add them)
-        mockPlayerProgression.Verify(m => m.GetPlayerDeityType("player-1"), Times.AtLeastOnce);
-
-        tracker.Dispose();
-    }
-
-    [Fact]
-    public void UpdateFollower_NonConquestFollower_RemovesFromCache()
-    {
-        var fakeWorldService = new FakeWorldService();
-        var mockEventService = new Mock<IEventService>();
-        var mockPlayerProgression = TestFixtures.CreateMockPlayerProgressionDataManager();
-        var mockFavor = TestFixtures.CreateMockFavorSystem();
-        var mockPlayer = TestFixtures.CreateMockServerPlayer("player-1", "TestPlayer");
-
-        fakeWorldService.AddPlayer(mockPlayer.Object);
-
-        // Player follows Harvest (not Conquest)
-        mockPlayerProgression.Setup(m => m.GetPlayerDeityType("player-1"))
-            .Returns(DeityDomain.Harvest);
-
-        var tracker = CreateTracker(mockEventService, fakeWorldService, mockPlayerProgression, mockFavor);
-        tracker.Initialize();
-
-        // Player should not be in cache (verified by deity type check)
-        mockPlayerProgression.Verify(m => m.GetPlayerDeityType("player-1"), Times.AtLeastOnce);
-
-        tracker.Dispose();
-    }
-
-    [Fact]
     public void Dispose_UnregistersCallbackAndClearsCache()
     {
         var mockEventService = new Mock<IEventService>();

--- a/DivineAscension.Tests/Systems/Favor/SmeltingFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/SmeltingFavorTrackerTests.cs
@@ -60,7 +60,7 @@ public class SmeltingFavorTrackerTests
         mockFavor.Verify(m => m.AwardFavorForAction(
             It.Is<IServerPlayer>(p => p.PlayerUID == "player-smelt-1"),
             "smelting",
-            It.Is<float>(f => Math.Abs(f - 1.0f) < 0.001f)
+            It.Is<float>(f => Math.Abs(f - 1.0f) < 0.001f), It.IsAny<DeityDomain>()
         ), Times.Once);
 
         tracker.Dispose();
@@ -93,23 +93,24 @@ public class SmeltingFavorTrackerTests
         mockFavor.Verify(m => m.AwardFavorForAction(
             It.Is<IServerPlayer>(p => p.PlayerUID == "player-smelt-2"),
             "smelting",
-            It.Is<float>(f => Math.Abs(f - 0.4f) < 0.001f)
+            It.Is<float>(f => Math.Abs(f - 0.4f) < 0.001f),
+            It.IsAny<DeityDomain>()
         ), Times.Once);
 
         tracker.Dispose();
     }
 
     [Fact]
-    public void HandleMoldPoured_NonKhorasFollower_NoFavor()
+    public void HandleMoldPoured_NonCraftPatron_StillAwardsCraftFavor()
     {
+        // Pantheon model: smelting favor routes to Craft regardless of player's active deity.
         var fakeWorldService = new FakeWorldService();
         var mockPlayerReligion = TestFixtures.CreateMockPlayerProgressionDataManager();
         var mockFavor = TestFixtures.CreateMockFavorSystem();
-        var mockPlayer = TestFixtures.CreateMockServerPlayer("player-smelt-3", "OtherDeity");
+        var mockPlayer = TestFixtures.CreateMockServerPlayer("player-smelt-3", "WildPlayer");
 
         fakeWorldService.AddPlayer(mockPlayer.Object);
 
-        // Player follows Lysa
         mockPlayerReligion.Setup(m => m.GetOrCreatePlayerData("player-smelt-3"))
             .Returns(TestFixtures.CreateTestPlayerReligionData("player-smelt-3", DeityDomain.Wild));
 
@@ -119,8 +120,8 @@ public class SmeltingFavorTrackerTests
         var method = GetHandleMethod();
         method.Invoke(tracker, new object?[] { "player-smelt-3", new BlockPos(5, 5, 5), 100, true });
 
-        mockFavor.Verify(m => m.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(), It.IsAny<float>()),
-            Times.Never);
+        mockFavor.Verify(m => m.AwardFavorForAction(It.IsAny<IServerPlayer>(), "smelting", It.IsAny<float>(), DeityDomain.Craft),
+            Times.Once);
 
         tracker.Dispose();
     }

--- a/DivineAscension.Tests/Systems/FavorSystemIntegrationTests.cs
+++ b/DivineAscension.Tests/Systems/FavorSystemIntegrationTests.cs
@@ -233,18 +233,18 @@ public class FavorSystemIntegrationTests
         _mockReligionManager.Setup(d => d.GetPlayerActiveDeityDomain("player-uid")).Returns(DeityDomain.Craft);
         _mockReligionManager.Setup(d => d.GetPlayerReligion("player-uid")).Returns(religion);
 
-        // Act
-        _favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15);
+        // Act — patron domain matches source, expect 1.5x multiplier
+        _favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15f, DeityDomain.Craft);
 
         // Assert
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 15, "test action"),
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 22.5f, "test action"),
             Times.Once()
         );
     }
 
     [Fact]
-    public void AwardFavorForAction_WithoutDeity_DoesNotAwardFavor()
+    public void AwardFavorForAction_WithSourceDomainNone_DoesNotAwardFavor()
     {
         // Arrange
         var playerData = TestFixtures.CreateTestPlayerReligionData(
@@ -258,12 +258,12 @@ public class FavorSystemIntegrationTests
             .Setup(m => m.GetOrCreatePlayerData("player-uid"))
             .Returns(playerData);
 
-        // Act
-        _favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15);
+        // Act — DeityDomain.None short-circuits in AwardFavorCore
+        _favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15f, DeityDomain.None);
 
         // Assert
         _mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFractionalFavor(It.IsAny<string>(), It.IsAny<DeityDomain>(), It.IsAny<float>(), It.IsAny<string>()),
             Times.Never()
         );
     }

--- a/DivineAscension.Tests/Systems/FavorSystemTests.cs
+++ b/DivineAscension.Tests/Systems/FavorSystemTests.cs
@@ -501,18 +501,18 @@ public class FavorSystemTests
             mockPlayerReligionDataManager.Object,
             mockReligionManager.Object);
 
-        // Act
-        favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15);
+        // Act — patron domain matches source, expect 1.5x multiplier
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15f, DeityDomain.Craft);
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 15, "test action"),
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 22.5f, "test action"),
             Times.Once
         );
     }
 
     [Fact]
-    public void AwardFavorForAction_WithPlayerWithoutDeity_DoesNotAwardFavor()
+    public void AwardFavorForAction_WithSourceDomainNone_DoesNotAwardFavor()
     {
         // Arrange
         var mockLogger = new Mock<ILoggerWrapper>();
@@ -537,14 +537,70 @@ public class FavorSystemTests
             mockPlayerReligionDataManager.Object,
             mockReligionManager.Object);
 
-        // Act
-        favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15);
+        // Act — DeityDomain.None short-circuits in AwardFavorCore
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "test action", 15f, DeityDomain.None);
 
         // Assert
         mockPlayerReligionDataManager.Verify(
-            m => m.AddFavor(It.IsAny<string>(), DeityDomain.Craft, It.IsAny<int>(), It.IsAny<string>()),
+            m => m.AddFavor(It.IsAny<string>(), It.IsAny<DeityDomain>(), It.IsAny<int>(), It.IsAny<string>()),
             Times.Never
         );
+        mockPlayerReligionDataManager.Verify(
+            m => m.AddFractionalFavor(It.IsAny<string>(), It.IsAny<DeityDomain>(), It.IsAny<float>(), It.IsAny<string>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public void AwardFavorForAction_NonPatronDomain_Applies1xMultiplier()
+    {
+        var mockLogger = new Mock<ILoggerWrapper>();
+        var fakeEventService = new FakeEventService();
+        var fakeWorldService = new FakeWorldService();
+        var mockProgression = new Mock<IPlayerProgressionDataManager>();
+        var mockReligionManager = new Mock<IReligionManager>();
+
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
+
+        // Religion's patron is Craft; source is Wild → non-patron, 1.0x.
+        mockProgression.Setup(m => m.GetOrCreatePlayerData("player-uid")).Returns(new PlayerProgressionData());
+        mockReligionManager.Setup(d => d.GetPlayerReligion("player-uid"))
+            .Returns(TestFixtures.CreateTestReligion(domain: DeityDomain.Craft));
+
+        var favorSystem = CreateFavorSystem(mockLogger.Object, fakeEventService, fakeWorldService,
+            mockProgression.Object, mockReligionManager.Object);
+
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "hunting", 10f, DeityDomain.Wild);
+
+        mockProgression.Verify(
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Wild, 10f, "hunting"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void AwardFavorForAction_NullReligion_Applies1xMultiplier()
+    {
+        var mockLogger = new Mock<ILoggerWrapper>();
+        var fakeEventService = new FakeEventService();
+        var fakeWorldService = new FakeWorldService();
+        var mockProgression = new Mock<IPlayerProgressionDataManager>();
+        var mockReligionManager = new Mock<IReligionManager>();
+
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
+
+        mockProgression.Setup(m => m.GetOrCreatePlayerData("player-uid")).Returns(new PlayerProgressionData());
+        mockReligionManager.Setup(d => d.GetPlayerReligion("player-uid")).Returns((ReligionData?)null);
+
+        var favorSystem = CreateFavorSystem(mockLogger.Object, fakeEventService, fakeWorldService,
+            mockProgression.Object, mockReligionManager.Object);
+
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "mining ore", 10f, DeityDomain.Craft);
+
+        mockProgression.Verify(
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 10f, "mining ore"),
+            Times.Once);
     }
 
     #endregion
@@ -578,6 +634,7 @@ public class FavorSystemTests
             .Returns(playerData);
 
         mockReligionManager.Setup(d => d.GetPlayerActiveDeityDomain("player-uid")).Returns(DeityDomain.Craft);
+        mockReligionManager.Setup(d => d.GetPlayerReligion("player-uid")).Returns(TestFixtures.CreateTestReligion());
         var favorSystem = CreateFavorSystem(
             mockLogger.Object,
             fakeEventService,
@@ -588,7 +645,7 @@ public class FavorSystemTests
         // Act
         favorSystem.AwardPassiveFavor(mockPlayer.Object, 1.0f);
 
-        // Assert
+        // Assert — passive favor now routes via AwardFavorCore (per-deity + patron multiplier applied).
         mockPlayerReligionDataManager.Verify(
             m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, It.IsAny<float>(), "Passive devotion"),
             Times.Once
@@ -981,7 +1038,7 @@ public class FavorSystemTests
         mockPlayerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player1-uid")).Returns(playerData1);
         mockPlayerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player2-uid")).Returns(playerData2);
 
-        mockReligionManager.Setup(m => m.GetPlayerReligion(It.IsAny<string>())).Returns((ReligionData?)null);
+        mockReligionManager.Setup(m => m.GetPlayerReligion(It.IsAny<string>())).Returns(TestFixtures.CreateTestReligion());
         mockReligionManager.Setup(m => m.GetPlayerActiveDeityDomain(It.IsAny<string>())).Returns(DeityDomain.Craft);
 
         var favorSystem = CreateFavorSystem(
@@ -1094,13 +1151,14 @@ public class FavorSystemTests
             mockTimeService.Object);
 
         // Act - Award favor for a combat kill (typical action from ConquestFavorTracker)
-        favorSystem.AwardFavorForAction(mockPlayer.Object, "combat kill drifter-normal", 5);
+        // Patron domain matches → 1.5x → favor 5 becomes 7.5, prestige tracks favor amount.
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "combat kill drifter-normal", 5f, DeityDomain.Conquest);
 
-        // Assert - Prestige SHOULD be awarded (but currently is NOT due to bug)
+        // Assert - Prestige SHOULD be awarded
         mockPrestigeManager.Verify(
             m => m.AddFractionalPrestige(
                 "conquest-religion-uid",
-                5f,
+                7.5f,
                 It.Is<string>(s => s.Contains("combat kill"))),
             Times.Once,
             "Combat kills should award prestige to Conquest religions, but the overly broad 'kill' filter prevents this");
@@ -1153,13 +1211,126 @@ public class FavorSystemTests
             mockTimeService.Object);
 
         // Act - Award favor for a PvP kill (this should NOT go through FavorSystem for prestige)
-        favorSystem.AwardFavorForAction(mockPlayer.Object, "PvP kill against OtherPlayer", 10);
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "PvP kill against OtherPlayer", 10f, DeityDomain.Conquest);
 
         // Assert - Prestige should NOT be awarded (PvPManager handles this separately)
         mockPrestigeManager.Verify(
             m => m.AddFractionalPrestige(It.IsAny<string>(), It.IsAny<float>(), It.IsAny<string>()),
             Times.Never,
             "PvP kills should NOT award prestige through FavorSystem (PvPManager handles it)");
+    }
+
+    [Fact]
+    public void AwardFavorForAction_NonPatronSource_DoesNotAwardPrestige()
+    {
+        // Pantheon model: a player can earn favor in every domain, but their religion
+        // only gains prestige from activity in its own patron domain.
+        var mockLogger = new Mock<ILoggerWrapper>();
+        var fakeEventService = new FakeEventService();
+        var fakeWorldService = new FakeWorldService();
+        var mockPlayerProgressionDataManager = new Mock<IPlayerProgressionDataManager>();
+        var mockReligionManager = new Mock<IReligionManager>();
+        var mockPrestigeManager = new Mock<IReligionPrestigeManager>();
+        var mockActivityLogManager = new Mock<IActivityLogManager>();
+        var mockMessenger = new Mock<IPlayerMessengerService>();
+
+        var religion = new ReligionData
+        {
+            ReligionUID = "craft-religion-uid",
+            ReligionName = "Smiths",
+            PatronDomain = DeityDomain.Craft,
+            PatronName = "Khoras",
+            FounderUID = "player-uid"
+        };
+
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
+        mockPlayer.Setup(p => p.PlayerName).Returns("TestPlayer");
+        fakeWorldService.AddPlayer(mockPlayer.Object);
+
+        mockReligionManager.Setup(m => m.GetPlayerReligion("player-uid")).Returns(religion);
+
+        var mockTimeService = new Mock<ITimeService>();
+        var favorSystem = new FavorSystem(
+            mockLogger.Object,
+            fakeEventService,
+            fakeWorldService,
+            mockPlayerProgressionDataManager.Object,
+            mockReligionManager.Object,
+            mockPrestigeManager.Object,
+            mockActivityLogManager.Object,
+            CreateTestConfig(),
+            mockMessenger.Object,
+            mockTimeService.Object);
+
+        // Act — Wild source, religion is Craft patron
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "hunting deer", 10f, DeityDomain.Wild);
+
+        // Favor still lands in the Wild bucket at 1.0× (non-patron multiplier).
+        mockPlayerProgressionDataManager.Verify(
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Wild, 10f, "hunting deer"),
+            Times.Once);
+
+        // Prestige and activity log must NOT fire for non-patron source.
+        mockPrestigeManager.Verify(
+            m => m.AddFractionalPrestige(It.IsAny<string>(), It.IsAny<float>(), It.IsAny<string>()),
+            Times.Never);
+        mockActivityLogManager.Verify(
+            m => m.LogActivity(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DeityDomain>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void AwardFavorForAction_PatronSource_AwardsPrestige()
+    {
+        var mockLogger = new Mock<ILoggerWrapper>();
+        var fakeEventService = new FakeEventService();
+        var fakeWorldService = new FakeWorldService();
+        var mockPlayerProgressionDataManager = new Mock<IPlayerProgressionDataManager>();
+        var mockReligionManager = new Mock<IReligionManager>();
+        var mockPrestigeManager = new Mock<IReligionPrestigeManager>();
+        var mockActivityLogManager = new Mock<IActivityLogManager>();
+        var mockMessenger = new Mock<IPlayerMessengerService>();
+
+        var religion = new ReligionData
+        {
+            ReligionUID = "craft-religion-uid",
+            ReligionName = "Smiths",
+            PatronDomain = DeityDomain.Craft,
+            PatronName = "Khoras",
+            FounderUID = "player-uid"
+        };
+
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.Setup(p => p.PlayerUID).Returns("player-uid");
+        mockPlayer.Setup(p => p.PlayerName).Returns("TestPlayer");
+        fakeWorldService.AddPlayer(mockPlayer.Object);
+
+        mockReligionManager.Setup(m => m.GetPlayerReligion("player-uid")).Returns(religion);
+
+        var mockTimeService = new Mock<ITimeService>();
+        var favorSystem = new FavorSystem(
+            mockLogger.Object,
+            fakeEventService,
+            fakeWorldService,
+            mockPlayerProgressionDataManager.Object,
+            mockReligionManager.Object,
+            mockPrestigeManager.Object,
+            mockActivityLogManager.Object,
+            CreateTestConfig(),
+            mockMessenger.Object,
+            mockTimeService.Object);
+
+        // Act — patron-domain source: favor × 1.5, prestige flows.
+        favorSystem.AwardFavorForAction(mockPlayer.Object, "mining ore", 10f, DeityDomain.Craft);
+
+        mockPlayerProgressionDataManager.Verify(
+            m => m.AddFractionalFavor("player-uid", DeityDomain.Craft, 15f, "mining ore"),
+            Times.Once);
+        mockPrestigeManager.Verify(
+            m => m.AddFractionalPrestige("craft-religion-uid", 15f, It.Is<string>(s => s.Contains("mining ore"))),
+            Times.Once);
     }
 
     #endregion

--- a/DivineAscension/Systems/Favor/AnvilFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/AnvilFavorTracker.cs
@@ -60,10 +60,6 @@ public class AnvilFavorTracker(
         var player = _worldService.GetPlayerByUID(playerUid) as IServerPlayer;
         if (player == null) return;
 
-        // Verify religion
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(playerUid);
-        if (deityType != DeityDomain.Craft) return;
-
         // Compute favor from output preview (fallback to mid tier)
         var baseFavor = outputPreview != null ? CalculateBaseFavor(outputPreview) : FavorMidTier;
 
@@ -71,7 +67,7 @@ public class AnvilFavorTracker(
         var usedHelve = CheckHelveHammerUsage(pos);
         var finalFavor = ApplyAutomationPenalty(baseFavor, usedHelve);
 
-        _favorSystem.AwardFavorForAction(player, "smithing", finalFavor);
+        _favorSystem.AwardFavorForAction(player, "smithing", finalFavor, DeityDomain.Craft);
         _logger.Debug(
             $"[AnvilFavorTracker:{_instanceId}] Awarded {finalFavor} favor to {player.PlayerName} for smithing (base {baseFavor}, helve:{usedHelve}) at {pos}");
     }

--- a/DivineAscension/Systems/Favor/ConquestFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/ConquestFavorTracker.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
@@ -13,7 +12,7 @@ using Vintagestory.GameContent;
 namespace DivineAscension.Systems.Favor;
 
 /// <summary>
-///     Tracks combat kills and awards favor to Conquest domain followers.
+///     Tracks combat kills and awards favor to the Conquest domain bucket.
 ///     Awards favor for killing hostile creatures and monsters.
 /// </summary>
 public class ConquestFavorTracker(
@@ -23,8 +22,6 @@ public class ConquestFavorTracker(
     IWorldService worldService,
     IFavorSystem favorSystem) : IFavorTracker, IDisposable
 {
-    private readonly HashSet<string> _conquestFollowers = new();
-
     private readonly IEventService
         _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
 
@@ -47,9 +44,6 @@ public class ConquestFavorTracker(
     public void Dispose()
     {
         _eventService.UnsubscribeEntityDeath(OnEntityDeath);
-        _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion -= OnPlayerLeavesProgression;
-        _conquestFollowers.Clear();
     }
 
     public DeityDomain DeityDomain { get; } = DeityDomain.Conquest;
@@ -57,39 +51,6 @@ public class ConquestFavorTracker(
     public void Initialize()
     {
         _eventService.OnEntityDeath(OnEntityDeath);
-
-        // Cache followers
-        RefreshFollowerCache();
-
-        _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesProgression;
-    }
-
-    private void RefreshFollowerCache()
-    {
-        var onlinePlayers = _worldService.GetAllOnlinePlayers();
-        if (onlinePlayers == null) return;
-
-        foreach (var player in onlinePlayers) UpdateFollower(player.PlayerUID);
-    }
-
-    private void OnPlayerDataChanged(string playerId)
-    {
-        UpdateFollower(playerId);
-    }
-
-    private void UpdateFollower(string playerId)
-    {
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(playerId);
-        if (deityType == DeityDomain)
-            _conquestFollowers.Add(playerId);
-        else
-            _conquestFollowers.Remove(playerId);
-    }
-
-    private void OnPlayerLeavesProgression(IServerPlayer player, string religionId)
-    {
-        _conquestFollowers.Remove(player.PlayerUID);
     }
 
     private void OnEntityDeath(Entity? entity, DamageSource? damageSource)
@@ -100,8 +61,6 @@ public class ConquestFavorTracker(
         var killer = damageSource.GetCauseEntity();
         if (killer is EntityPlayer { Player: IServerPlayer player })
         {
-            if (!_conquestFollowers.Contains(player.PlayerUID)) return;
-
             // Skip if target is a player (PvP is handled separately)
             if (entity is EntityPlayer) return;
 
@@ -109,7 +68,7 @@ public class ConquestFavorTracker(
             if (!IsCombatWorthy(entity)) return;
 
             var favor = GetFavorForEntity(entity);
-            if (favor > 0) _favorSystem.AwardFavorForAction(player, "combat kill " + entity.Code.Path, favor);
+            if (favor > 0) _favorSystem.AwardFavorForAction(player, "combat kill " + entity.Code.Path, favor, DeityDomain.Conquest);
         }
     }
 

--- a/DivineAscension/Systems/Favor/ForagingFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/ForagingFavorTracker.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
@@ -22,8 +21,6 @@ public class ForagingFavorTracker(
     private readonly IPlayerProgressionDataManager _playerProgressionDataManager =
         playerProgressionDataManager ?? throw new ArgumentNullException(nameof(playerProgressionDataManager));
 
-    private readonly HashSet<string> _wildFollowers = new();
-
     private readonly IWorldService
         _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
 
@@ -32,9 +29,6 @@ public class ForagingFavorTracker(
         ForagingPatches.Picked -= OnBlockUsed;
         MushroomPatches.OnMushroomHarvested -= OnMushroomHarvested;
         FlowerPatches.OnFlowerHarvested -= OnFlowerHarvested;
-        _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion -= OnPlayerLeavesProgression;
-        _wildFollowers.Clear();
     }
 
     public DeityDomain DeityDomain { get; } = DeityDomain.Wild;
@@ -44,38 +38,6 @@ public class ForagingFavorTracker(
         ForagingPatches.Picked += OnBlockUsed;
         MushroomPatches.OnMushroomHarvested += OnMushroomHarvested;
         FlowerPatches.OnFlowerHarvested += OnFlowerHarvested;
-
-        // Cache followers
-        RefreshFollowerCache();
-
-        _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesProgression;
-    }
-
-    private void RefreshFollowerCache()
-    {
-        var onlinePlayers = _worldService.GetAllOnlinePlayers();
-
-        foreach (var player in onlinePlayers) UpdateFollower(player.PlayerUID);
-    }
-
-    private void OnPlayerDataChanged(string playerUID)
-    {
-        UpdateFollower(playerUID);
-    }
-
-    private void UpdateFollower(string playerUID)
-    {
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(playerUID);
-        if (deityType == DeityDomain)
-            _wildFollowers.Add(playerUID);
-        else
-            _wildFollowers.Remove(playerUID);
-    }
-
-    private void OnPlayerLeavesProgression(IServerPlayer player, string religionUID)
-    {
-        _wildFollowers.Remove(player.PlayerUID);
     }
 
     /// <summary>
@@ -83,9 +45,7 @@ public class ForagingFavorTracker(
     /// </summary>
     private void OnMushroomHarvested(IServerPlayer player, Block block, string? mushroomType)
     {
-        if (!_wildFollowers.Contains(player.PlayerUID)) return;
-
-        _favorSystem.AwardFavorForAction(player, "foraging", 0.5f);
+        _favorSystem.AwardFavorForAction(player, "foraging", 0.5f, DeityDomain.Wild);
     }
 
     /// <summary>
@@ -94,8 +54,6 @@ public class ForagingFavorTracker(
     /// </summary>
     private void OnFlowerHarvested(IServerPlayer player, Block block, string? flowerType, bool isScytheHarvest)
     {
-        if (!_wildFollowers.Contains(player.PlayerUID)) return;
-
         if (isScytheHarvest)
         {
             // Use batched favor for scythe harvesting (avoid performance issues on large fields)
@@ -104,7 +62,7 @@ public class ForagingFavorTracker(
         else
         {
             // Use immediate favor for manual harvesting (better player feedback)
-            _favorSystem.AwardFavorForAction(player, "foraging", 0.5f);
+            _favorSystem.AwardFavorForAction(player, "foraging", 0.5f, DeityDomain.Wild);
         }
     }
 
@@ -115,10 +73,9 @@ public class ForagingFavorTracker(
     private void OnBlockUsed(IServerPlayer? player, BlockSelection? blockSel, Block? block)
     {
         if (player == null || blockSel == null || block == null) return;
-        if (!_wildFollowers.Contains(player.PlayerUID)) return;
 
         if (IsBerryBush(block) && HasRipeBerries(block))
-            _favorSystem.AwardFavorForAction(player, "foraging", 0.5f);
+            _favorSystem.AwardFavorForAction(player, "foraging", 0.5f, DeityDomain.Wild);
     }
 
     private bool IsBerryBush(Block block)

--- a/DivineAscension/Systems/Favor/HarvestFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/HarvestFavorTracker.cs
@@ -37,8 +37,6 @@ public class HarvestFavorTracker(
 
     private readonly IFavorSystem _favorSystem = favorSystem ?? throw new ArgumentNullException(nameof(favorSystem));
 
-    private readonly HashSet<string> _harvestFollowers = new();
-
     // Event-based: no polling or container tracking needed
 
     // Simple per-player cooking award rate limit (to prevent rapid repeats)
@@ -57,10 +55,7 @@ public class HarvestFavorTracker(
         BlockCropPatches.OnCropHarvested -= OnCropHarvested;
         CropPlantingPatches.OnCropPlanted -= HandleCropPlanted;
         CookingPatches.OnMealCooked -= HandleMealCooked;
-        _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion -= OnPlayerLeavesProgression;
         _eventService.UnsubscribePlayerDisconnect(OnPlayerDisconnect);
-        _harvestFollowers.Clear();
         _lastCookingAwardUtc.Clear();
     }
 
@@ -78,13 +73,6 @@ public class HarvestFavorTracker(
         // be the last interacting player; patches will ensure correct uid.
         CookingPatches.OnMealCooked += HandleMealCooked;
 
-        // Build initial cache of Aethra followers
-        RefreshFollowerCache();
-
-        // Listen for religion changes to update cache
-        _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesProgression;
-
         // Clean up cooking cooldown cache on player disconnect
         _eventService.OnPlayerDisconnect(OnPlayerDisconnect);
 
@@ -95,42 +83,13 @@ public class HarvestFavorTracker(
 
     private void HandleCropPlanted(IServerPlayer player, Block cropBlock)
     {
-        if (!_harvestFollowers.Contains(player.PlayerUID)) return;
-
         // Award favor for planting crops
-        _favorSystem.AwardFavorForAction(player, "planting " + GetCropName(cropBlock), FavorPerPlanting);
+        _favorSystem.AwardFavorForAction(player, "planting " + GetCropName(cropBlock), FavorPerPlanting, DeityDomain.Harvest);
     }
 
     #endregion
 
-    #region Follower Cache Management
-
-    private void RefreshFollowerCache()
-    {
-        _harvestFollowers.Clear();
-
-        var onlinePlayers = _worldService.GetAllOnlinePlayers();
-        if (onlinePlayers == null) return;
-
-        foreach (var player in onlinePlayers)
-        {
-            if (_playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID) == DeityDomain)
-                _harvestFollowers.Add(player.PlayerUID);
-        }
-    }
-
-    private void OnPlayerDataChanged(string playerUID)
-    {
-        if (_playerProgressionDataManager.GetPlayerDeityType(playerUID) == DeityDomain)
-            _harvestFollowers.Add(playerUID);
-        else
-            _harvestFollowers.Remove(playerUID);
-    }
-
-    private void OnPlayerLeavesProgression(IServerPlayer player, string religionUID)
-    {
-        _harvestFollowers.Remove(player.PlayerUID);
-    }
+    #region Player Disconnect Cleanup
 
     private void OnPlayerDisconnect(IServerPlayer player)
     {
@@ -147,7 +106,6 @@ public class HarvestFavorTracker(
     /// </summary>
     private void OnCropHarvested(IServerPlayer player, BlockCrop crop, BlockPos pos, bool isScytheHarvest)
     {
-        if (!_harvestFollowers.Contains(player.PlayerUID)) return;
         if (!IsMatureCrop(crop)) return;
 
         var actionName = "harvesting " + GetCropName(crop);
@@ -160,7 +118,7 @@ public class HarvestFavorTracker(
         else
         {
             // Use immediate favor for manual harvesting (better player feedback)
-            _favorSystem.AwardFavorForAction(player, actionName, FavorPerCropHarvest);
+            _favorSystem.AwardFavorForAction(player, actionName, FavorPerCropHarvest, DeityDomain.Harvest);
         }
     }
 
@@ -204,8 +162,6 @@ public class HarvestFavorTracker(
 
     private void HandleMealCooked(IServerPlayer player, ItemStack cookedStack, BlockPos pos)
     {
-        if (!_harvestFollowers.Contains(player.PlayerUID)) return;
-
         // Rate limit per player
         var now = DateTime.UtcNow;
         if (_lastCookingAwardUtc.TryGetValue(player.PlayerUID, out var last) &&
@@ -214,7 +170,7 @@ public class HarvestFavorTracker(
         var favor = CalculateMealFavor(cookedStack);
         if (favor <= 0) return;
 
-        _favorSystem.AwardFavorForAction(player, "cooking " + GetMealName(cookedStack), favor);
+        _favorSystem.AwardFavorForAction(player, "cooking " + GetMealName(cookedStack), favor, DeityDomain.Harvest);
         _lastCookingAwardUtc[player.PlayerUID] = now;
 
         _logger.Debug(

--- a/DivineAscension/Systems/Favor/HuntingFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/HuntingFavorTracker.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
@@ -28,8 +27,6 @@ public class HuntingFavorTracker(
     private readonly IPlayerProgressionDataManager _playerProgressionDataManager =
         playerProgressionDataManager ?? throw new ArgumentNullException(nameof(playerProgressionDataManager));
 
-    private readonly HashSet<string> _wildFollowers = new();
-
     private readonly IWorldService
         _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
 
@@ -41,9 +38,6 @@ public class HuntingFavorTracker(
     public void Dispose()
     {
         _eventService.UnsubscribeEntityDeath(OnEntityDeath);
-        _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion -= OnPlayerLeavesProgression;
-        _wildFollowers.Clear();
     }
 
     public DeityDomain DeityDomain { get; } = DeityDomain.Wild;
@@ -52,39 +46,6 @@ public class HuntingFavorTracker(
     public void Initialize()
     {
         _eventService.OnEntityDeath(OnEntityDeath);
-
-        // Cache followers
-        RefreshFollowerCache();
-
-        _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesProgression;
-    }
-
-    private void RefreshFollowerCache()
-    {
-        var onlinePlayers = _worldService.GetAllOnlinePlayers();
-        if (onlinePlayers == null) return;
-
-        foreach (var player in onlinePlayers) UpdateFollower(player.PlayerUID);
-    }
-
-    private void OnPlayerDataChanged(string playerId)
-    {
-        UpdateFollower(playerId);
-    }
-
-    private void UpdateFollower(string playerId)
-    {
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(playerId);
-        if (deityType == DeityDomain)
-            _wildFollowers.Add(playerId);
-        else
-            _wildFollowers.Remove(playerId);
-    }
-
-    private void OnPlayerLeavesProgression(IServerPlayer player, string religionId)
-    {
-        _wildFollowers.Remove(player.PlayerUID);
     }
 
     private void OnEntityDeath(Entity? entity, DamageSource? damageSource)
@@ -95,12 +56,11 @@ public class HuntingFavorTracker(
         var killer = damageSource.GetCauseEntity();
         if (killer is EntityPlayer { Player: IServerPlayer player })
         {
-            if (!_wildFollowers.Contains(player.PlayerUID)) return;
             if (entity is not EntityAgent || entity is EntityPlayer) return;
 
             if (!IsHuntable(entity)) return;
             var favor = GetFavorForEntity(entity);
-            if (favor > 0) _favorSystem.AwardFavorForAction(player, "hunting " + entity.Code.Path, favor);
+            if (favor > 0) _favorSystem.AwardFavorForAction(player, "hunting " + entity.Code.Path, favor, DeityDomain.Wild);
         }
     }
 

--- a/DivineAscension/Systems/Favor/MiningFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/MiningFavorTracker.cs
@@ -30,8 +30,6 @@ public class MiningFavorTracker(
     private const float QualityRich = 1.5f;
     private const float QualityBountiful = 2.0f;
 
-    // Cache of active Craft followers for fast lookup (avoids database hit on every block break)
-    private readonly HashSet<string> _craftFollowers = new();
     private readonly IFavorSystem _favorSystem = favorSystem ?? throw new ArgumentNullException(nameof(favorSystem));
 
     private readonly ILoggerWrapper _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -45,9 +43,6 @@ public class MiningFavorTracker(
     public void Dispose()
     {
         BlockBehaviorOre.OnOreBlockBroken -= OnOreBlockBroken;
-        _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion -= OnPlayerLeavesProgression;
-        _craftFollowers.Clear();
     }
 
     public DeityDomain DeityDomain { get; } = DeityDomain.Craft;
@@ -56,49 +51,6 @@ public class MiningFavorTracker(
     {
         // Subscribe to ore block break events (via BlockBehavior)
         BlockBehaviorOre.OnOreBlockBroken += OnOreBlockBroken;
-
-        // Build initial cache of Craft followers
-        RefreshFollowerCache();
-
-        // Listen for religion changes to update cache
-        _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesProgression;
-    }
-
-    /// <summary>
-    ///     Rebuild cache of active Craft followers
-    /// </summary>
-    private void RefreshFollowerCache()
-    {
-        _craftFollowers.Clear();
-
-        var onlinePlayers = _worldService.GetAllOnlinePlayers();
-
-        foreach (var player in onlinePlayers)
-        {
-            if (_playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID) == DeityDomain)
-                _craftFollowers.Add(player.PlayerUID);
-        }
-    }
-
-    /// <summary>
-    ///     Update cache when player data changes (e.g., joins a religion)
-    /// </summary>
-    private void OnPlayerDataChanged(string playerUID)
-    {
-        if (_playerProgressionDataManager.GetPlayerDeityType(playerUID) == DeityDomain)
-            _craftFollowers.Add(playerUID);
-        else
-            _craftFollowers.Remove(playerUID);
-    }
-
-    /// <summary>
-    ///     Update cache when a player leaves a religion
-    /// </summary>
-    private void OnPlayerLeavesProgression(IServerPlayer player, string religionUID)
-    {
-        // Player left religion, remove from cache
-        _craftFollowers.Remove(player.PlayerUID);
     }
 
     /// <summary>
@@ -109,7 +61,6 @@ public class MiningFavorTracker(
     {
         // Player can be null when blocks break automatically (gravity, neighbor updates, etc.)
         if (player == null) return;
-        if (!_craftFollowers.Contains(player.PlayerUID)) return;
 
         // Calculate favor based on mineral type and quality
         var baseFavor = GetMineralTierFavor(block);
@@ -119,7 +70,7 @@ public class MiningFavorTracker(
         var serverPlayer = _worldService.GetPlayerByUID(player.PlayerUID) as IServerPlayer;
         if (serverPlayer != null)
         {
-            _favorSystem.AwardFavorForAction(serverPlayer, "mining ore", finalFavor);
+            _favorSystem.AwardFavorForAction(serverPlayer, "mining ore", finalFavor, DeityDomain.Craft);
 
             _logger.Debug(
                 $"[MiningFavorTracker] Awarded {finalFavor} favor to {player.PlayerName} " +

--- a/DivineAscension/Systems/Favor/PatrolFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/PatrolFavorTracker.cs
@@ -179,12 +179,6 @@ public class PatrolFavorTracker : IFavorTracker, IDisposable
     {
         var playerUID = player.PlayerUID;
 
-        // Only track Conquest domain players
-        if (!IsConquestDomainPlayer(playerUID))
-        {
-            return;
-        }
-
         // Only track civilization sites (not just own religion)
         var civSites = GetCivilizationHolySites(playerUID);
         if (!civSites.Any(s => s.SiteUID == site.SiteUID))
@@ -556,14 +550,6 @@ public class PatrolFavorTracker : IFavorTracker, IDisposable
         }
 
         return sites;
-    }
-
-    /// <summary>
-    /// Checks if a player is a Conquest domain follower.
-    /// </summary>
-    internal bool IsConquestDomainPlayer(string playerUID)
-    {
-        return _playerProgressionDataManager.GetPlayerDeityType(playerUID) == DeityDomain.Conquest;
     }
 
     #endregion

--- a/DivineAscension/Systems/Favor/RuinDiscoveryFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/RuinDiscoveryFavorTracker.cs
@@ -28,8 +28,6 @@ public class RuinDiscoveryFavorTracker(
     private const int SCAN_RADIUS = 50; // 50 blocks
     private const int SCAN_STEP = 5; // Check every 5 blocks (sparse scanning)
 
-    private readonly HashSet<string> _conquestFollowers = new();
-
     private readonly IEventService
         _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
 
@@ -47,9 +45,6 @@ public class RuinDiscoveryFavorTracker(
     public void Dispose()
     {
         _eventService.UnregisterCallback(_callbackId);
-        _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion -= OnPlayerLeavesProgression;
-        _conquestFollowers.Clear();
     }
 
     public DeityDomain DeityDomain { get; } = DeityDomain.Conquest;
@@ -59,26 +54,17 @@ public class RuinDiscoveryFavorTracker(
         // Register periodic callback for ruin scanning
         _callbackId = _eventService.RegisterCallback(OnTick, SCAN_INTERVAL_MS);
 
-        // Build initial cache of Conquest followers
-        RefreshFollowerCache();
-
-        // Listen for religion changes to update cache
-        _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesProgression;
-
         _logger.Debug($"{SystemConstants.LogPrefix} Initialized RuinDiscoveryFavorTracker");
     }
 
     /// <summary>
-    ///     Periodic callback to scan for ruins near Conquest followers
+    ///     Periodic callback to scan for ruins near all online players
     /// </summary>
     private void OnTick(float deltaTime)
     {
-        foreach (var playerUID in _conquestFollowers.ToList())
+        foreach (var p in _worldService.GetAllOnlinePlayers())
         {
-            var player = _worldService.GetPlayerByUID(playerUID) as IServerPlayer;
-            if (player?.Entity == null) continue;
-
+            if (p is not IServerPlayer player || player.Entity == null) continue;
             ScanForRuins(player);
         }
     }
@@ -202,7 +188,7 @@ public class RuinDiscoveryFavorTracker(
         playerData!.DiscoveredRuins.Add(posKey);
 
         // Award favor
-        _favorSystem.AwardFavorForAction(player, $"discovered {type} ruin", favor);
+        _favorSystem.AwardFavorForAction(player, $"discovered {type} ruin", favor, DeityDomain.Conquest);
 
         // Send notification
         player.SendMessage(GlobalConstants.GeneralChatGroup,
@@ -211,42 +197,6 @@ public class RuinDiscoveryFavorTracker(
 
         _logger.Debug(
             $"{SystemConstants.LogPrefix} Player {player.PlayerName} discovered {type} ruin at {posKey} (+{favor} favor)");
-    }
-
-    /// <summary>
-    ///     Rebuild cache of active Conquest followers
-    /// </summary>
-    private void RefreshFollowerCache()
-    {
-        _conquestFollowers.Clear();
-
-        var onlinePlayers = _worldService.GetAllOnlinePlayers();
-        if (onlinePlayers == null) return;
-
-        foreach (var player in onlinePlayers)
-        {
-            if (_playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID) == DeityDomain)
-                _conquestFollowers.Add(player.PlayerUID);
-        }
-    }
-
-    /// <summary>
-    ///     Update cache when player data changes (e.g., joins a religion)
-    /// </summary>
-    private void OnPlayerDataChanged(string playerUID)
-    {
-        if (_playerProgressionDataManager.GetPlayerDeityType(playerUID) == DeityDomain)
-            _conquestFollowers.Add(playerUID);
-        else
-            _conquestFollowers.Remove(playerUID);
-    }
-
-    /// <summary>
-    ///     Update cache when a player leaves a religion
-    /// </summary>
-    private void OnPlayerLeavesProgression(IServerPlayer player, string religionUID)
-    {
-        _conquestFollowers.Remove(player.PlayerUID);
     }
 
     /// <summary>

--- a/DivineAscension/Systems/Favor/SkinningFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/SkinningFavorTracker.cs
@@ -33,18 +33,13 @@ public class SkinningFavorTracker(
     private readonly IPlayerProgressionDataManager _playerProgressionDataManager =
         playerProgressionDataManager ?? throw new ArgumentNullException(nameof(playerProgressionDataManager));
 
-    private readonly HashSet<string> _wildFollowers = new();
-
     private readonly IWorldService
         _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
 
     public void Dispose()
     {
         SkinningPatches.OnAnimalSkinned -= OnAnimalSkinned;
-        _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion -= OnPlayerLeavesProgression;
         _eventService.UnsubscribePlayerDisconnect(OnPlayerDisconnect);
-        _wildFollowers.Clear();
         _lastSkinningAwardUtc.Clear();
     }
 
@@ -55,40 +50,8 @@ public class SkinningFavorTracker(
     {
         SkinningPatches.OnAnimalSkinned += OnAnimalSkinned;
 
-        // Cache followers
-        RefreshFollowerCache();
-
-        _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
-        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesProgression;
-
         // Clean up throttle cache on player disconnect
         _eventService.OnPlayerDisconnect(OnPlayerDisconnect);
-    }
-
-    private void RefreshFollowerCache()
-    {
-        var onlinePlayers = _worldService.GetAllOnlinePlayers();
-
-        foreach (var player in onlinePlayers) UpdateFollower(player.PlayerUID);
-    }
-
-    private void OnPlayerDataChanged(string playerId)
-    {
-        UpdateFollower(playerId);
-    }
-
-    private void UpdateFollower(string playerId)
-    {
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(playerId);
-        if (deityType == DeityDomain)
-            _wildFollowers.Add(playerId);
-        else
-            _wildFollowers.Remove(playerId);
-    }
-
-    private void OnPlayerLeavesProgression(IServerPlayer player, string religionId)
-    {
-        _wildFollowers.Remove(player.PlayerUID);
     }
 
     private void OnPlayerDisconnect(IServerPlayer player)
@@ -109,9 +72,6 @@ public class SkinningFavorTracker(
     {
         if (player == null || entity == null) return;
 
-        // Only award favor to Wild domain followers
-        if (!_wildFollowers.Contains(player.PlayerUID)) return;
-
         // Rate limit per player per entity to prevent duplicate messages
         var key = $"{player.PlayerUID}:{entity.EntityId}";
         var now = DateTime.UtcNow;
@@ -124,7 +84,7 @@ public class SkinningFavorTracker(
         if (favor > 0)
         {
             // Award favor with action type for prestige integration
-            _favorSystem.AwardFavorForAction(player, "skinning " + entity.Code.Path, favor);
+            _favorSystem.AwardFavorForAction(player, "skinning " + entity.Code.Path, favor, DeityDomain.Wild);
             _lastSkinningAwardUtc[key] = now;
         }
     }

--- a/DivineAscension/Systems/Favor/SmeltingFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/SmeltingFavorTracker.cs
@@ -92,17 +92,13 @@ public class SmeltingFavorTracker(
         if (player == null)
             return;
 
-        // Check if player follows Craft domain
-        if (_playerProgressionDataManager.GetPlayerDeityType(playerId) != DeityDomain.Craft)
-            return;
-
         // Calculate favor
         var favor = CalculatePouringFavor(unitsPoured, isToolMold);
 
         if (favor >= 0.01f) // Only award if meaningful amount
         {
             // Use fractional favor accumulation
-            _favorSystem.AwardFavorForAction(player, "smelting", favor);
+            _favorSystem.AwardFavorForAction(player, "smelting", favor, DeityDomain.Craft);
 
             _logger.Debug(
                 $"[SmeltingFavorTracker] Awarded {favor:F2} favor to {player.PlayerName} for pouring {unitsPoured} units into {(isToolMold ? "tool" : "ingot")} mold");

--- a/DivineAscension/Systems/Favor/StoneFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/StoneFavorTracker.cs
@@ -113,16 +113,12 @@ public class StoneFavorTracker(
 
     private void HandleClayFormingFinished(IServerPlayer player, ItemStack stack, int clayConsumed)
     {
-        // Verify religion
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID);
-        if (deityType != DeityDomain.Stone) return;
-
         if (clayConsumed > 0)
         {
             // Clay consumed already accounts for the total batch (don't multiply by stack size)
             // Phase 1 improvement: Double pottery favor rewards
             var favorAmount = clayConsumed * 2;
-            _favorSystem.AwardFavorForAction(player, "Pottery Crafting", favorAmount);
+            _favorSystem.AwardFavorForAction(player, "Pottery Crafting", favorAmount, DeityDomain.Stone);
 
             _logger.Debug(
                 $"[StoneFavorTracker] Awarded {favorAmount} favor for clay forming " +
@@ -208,15 +204,11 @@ public class StoneFavorTracker(
     private void CalculateAndAwardFavor(IServerPlayer player, int voxelsDelta, float multiplier)
     {
         var favorAmount = voxelsDelta * FavorPerVoxel * multiplier;
-        _favorSystem.AwardFavorForAction(player, "Stone Carving", favorAmount);
+        _favorSystem.AwardFavorForAction(player, "Stone Carving", favorAmount, DeityDomain.Stone);
     }
 
     private void HandleVoxelsChanged(IPlayer player, BlockPos pos, int voxelsDelta)
     {
-        // Verify religion
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID);
-        if (deityType != DeityDomain.Stone) return;
-
         if (voxelsDelta <= 0) return;
 
         var serverPlayer = player as IServerPlayer;
@@ -246,10 +238,6 @@ public class StoneFavorTracker(
 
     private void OnBlockPlaced(IServerPlayer byPlayer, int oldblockId, BlockSelection blockSel, ItemStack withItemStack)
     {
-        // Verify religion
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(byPlayer.PlayerUID);
-        if (deityType != DeityDomain.Stone) return;
-
         var placedBlock = _worldService.GetBlock(blockSel.Position);
         if (!IsConstructionBlock(placedBlock, out var favor)) return;
 
@@ -261,7 +249,7 @@ public class StoneFavorTracker(
                 return; // Still in cooldown
         }
 
-        _favorSystem.AwardFavorForAction(byPlayer, "construction", favor);
+        _favorSystem.AwardFavorForAction(byPlayer, "construction", favor, DeityDomain.Stone);
         _lastConstructionTime[byPlayer.PlayerUID] = currentTime;
 
         _logger.Debug(
@@ -369,15 +357,11 @@ public class StoneFavorTracker(
         // Player can be null when blocks break automatically (gravity, neighbor updates, etc.)
         if (player == null) return;
 
-        // Verify religion
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(player.PlayerUID);
-        if (deityType != DeityDomain.Stone) return;
-
         var serverPlayer = player as IServerPlayer;
         if (serverPlayer == null)
             return;
 
-        _favorSystem.AwardFavorForAction(serverPlayer, "gathering stone", FavorPerStoneBlock);
+        _favorSystem.AwardFavorForAction(serverPlayer, "gathering stone", FavorPerStoneBlock, DeityDomain.Stone);
 
         _logger.Debug(
             $"[StoneFavorTracker] Awarded {FavorPerStoneBlock} favor to {player.PlayerName} for mining");
@@ -448,9 +432,6 @@ public class StoneFavorTracker(
 
         if (string.IsNullOrEmpty(playerUid)) return;
 
-        var deityType = _playerProgressionDataManager.GetPlayerDeityType(playerUid);
-        if (deityType != DeityDomain.Stone) return;
-
         float totalFavor = 0;
         foreach (var stack in firedItems)
         {
@@ -468,7 +449,7 @@ public class StoneFavorTracker(
 
         if (totalFavor > 0)
         {
-            _favorSystem.AwardFavorForAction(playerUid, "Pottery firing", totalFavor, deityType);
+            _favorSystem.AwardFavorForAction(playerUid, "Pottery firing", totalFavor, DeityDomain.Stone);
             _logger.Debug($"[StoneFavorTracker] Total pit kiln favor awarded: {totalFavor}");
         }
     }

--- a/DivineAscension/Systems/FavorSystem.cs
+++ b/DivineAscension/Systems/FavorSystem.cs
@@ -175,15 +175,6 @@ public class FavorSystem : IFavorSystem
         }
     }
 
-    /// <summary>
-    ///     Awards favor for deity-aligned actions (extensible for future features)
-    /// </summary>
-    public void AwardFavorForAction(IServerPlayer player, string actionType, int amount)
-    {
-        var domain = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
-        AwardFavorCore(player.PlayerUID, actionType, amount, domain);
-    }
-
     public void Dispose()
     {
         _eventService.UnsubscribePlayerDeath(OnPlayerDeath);
@@ -201,15 +192,14 @@ public class FavorSystem : IFavorSystem
         _patrolFavorTracker?.Dispose();
     }
 
-    public void AwardFavorForAction(IServerPlayer player, string actionType, float amount)
+    public void AwardFavorForAction(IServerPlayer player, string actionType, float amount, DeityDomain sourceDomain)
     {
-        var domain = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
-        AwardFavorCore(player.PlayerUID, actionType, amount, domain);
+        AwardFavorCore(player.PlayerUID, actionType, amount, sourceDomain);
     }
 
-    public void AwardFavorForAction(string playerUid, string actionType, float amount, DeityDomain deityDomain)
+    public void AwardFavorForAction(string playerUid, string actionType, float amount, DeityDomain sourceDomain)
     {
-        AwardFavorCore(playerUid, actionType, amount, deityDomain);
+        AwardFavorCore(playerUid, actionType, amount, sourceDomain);
     }
 
     /// <summary>
@@ -355,21 +345,20 @@ public class FavorSystem : IFavorSystem
     }
 
     /// <summary>
-    ///     Awards favor for deity-aligned actions (extensible for future features) by UID
-    /// </summary>
-    internal void AwardFavorForAction(string playerUid, string actionType, int amount)
-    {
-        var domain = _religionManager.GetPlayerActiveDeityDomain(playerUid);
-        AwardFavorCore(playerUid, actionType, amount, domain);
-    }
-
-    /// <summary>
     ///     Core favor award implementation with activity logging.
     ///     All public overloads delegate to this method.
     /// </summary>
     private void AwardFavorCore(string playerUid, string actionType, float amount, DeityDomain deityDomain)
     {
         if (deityDomain == DeityDomain.None) return;
+
+        // Apply patron multiplier: religion's patron domain accrues at 1.5x, all others (and null religion) at 1.0x.
+        var playerReligion = _religionManager.GetPlayerReligion(playerUid);
+        if (playerReligion != null && playerReligion.PatronDomain == deityDomain)
+        {
+            amount *= 1.5f;
+            _logger.Debug($"[FavorSystem] Applied patron multiplier 1.5x to {amount:F2} favor ({deityDomain})");
+        }
 
         // Apply holy site buff multiplier if active
         var player = _worldService.GetPlayerByUID(playerUid);
@@ -403,12 +392,16 @@ public class FavorSystem : IFavorSystem
         _playerProgressionDataManager.AddFractionalFavor(playerUid, deityDomain, amount, actionType);
 
         // 2. Check if player is in religion and should receive prestige
-        var playerReligion = _religionManager.GetPlayerReligion(playerUid);
         if (string.IsNullOrEmpty(playerReligion?.ReligionUID))
         {
             // Not in religion - no prestige to award
             return;
         }
+
+        // Prestige only flows when the source domain matches the religion's patron.
+        // Pantheon model: every player accrues all five domains, but a religion only
+        // gains stature from activity in its own patron domain.
+        if (playerReligion.PatronDomain != deityDomain) return;
 
         // 3. Check if activity is deity-themed (determines both prestige and logging)
         var isDeityThemed = ShouldAwardPrestigeForActivity(deityDomain, actionType);
@@ -483,7 +476,9 @@ public class FavorSystem : IFavorSystem
     {
         var religionData = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
 
-        var deity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+        // Passive favor is religion-driven; route into the religion's patron domain so a future removal is a clean delete.
+        var religion = _religionManager.GetPlayerReligion(player.PlayerUID);
+        var deity = religion?.PatronDomain ?? DeityDomain.None;
         if (deity == DeityDomain.None) return;
 
         // Calculate in-game hours elapsed this tick
@@ -496,9 +491,10 @@ public class FavorSystem : IFavorSystem
         // Apply multipliers
         var finalFavor = baseFavor * CalculatePassiveFavorMultiplier(player, religionData, deity);
 
-        // Award favor using fractional accumulation
-        if (finalFavor >= 0.01f) // Only award when we have at least 0.01 favor
-            _playerProgressionDataManager.AddFractionalFavor(player.PlayerUID, deity, finalFavor, "Passive devotion");
+        // Route through core so per-deity + (patron) multiplier path is consistent; "Passive devotion" actionType
+        // is excluded from prestige in ShouldAwardPrestigeForActivity.
+        if (finalFavor >= 0.01f)
+            AwardFavorCore(player.PlayerUID, "Passive devotion", finalFavor, deity);
     }
 
     /// <summary>

--- a/DivineAscension/Systems/Interfaces/IFavorSystem.cs
+++ b/DivineAscension/Systems/Interfaces/IFavorSystem.cs
@@ -15,19 +15,16 @@ public interface IFavorSystem : IDisposable
     void Initialize();
 
     /// <summary>
-    ///     Awards favor for deity-aligned actions (extensible for future features)
+    ///     Awards favor for a deity-aligned action against the specified source domain.
+    ///     Patron multiplier (1.5x) is applied inside the system when the player's religion
+    ///     has <paramref name="sourceDomain"/> as its PatronDomain; otherwise 1.0x.
     /// </summary>
-    void AwardFavorForAction(IServerPlayer player, string actionType, int amount);
+    void AwardFavorForAction(IServerPlayer player, string actionType, float amount, DeityDomain sourceDomain);
 
     /// <summary>
-    ///     Awards a fractional amount of favor (supports fine-grained activities)
+    ///     Awards favor by player UID (for async/delayed events) against the specified source domain.
     /// </summary>
-    void AwardFavorForAction(IServerPlayer player, string actionType, float amount);
-
-    /// <summary>
-    ///     Awards a fractional amount of favor by player UID (for async/delayed events)
-    /// </summary>
-    void AwardFavorForAction(string playerUid, string actionType, float amount, DeityDomain deityDomain);
+    void AwardFavorForAction(string playerUid, string actionType, float amount, DeityDomain sourceDomain);
 
     /// <summary>
     ///     Queues favor for batched processing. Use this for high-frequency events like scythe harvesting


### PR DESCRIPTION
## Summary
- Trackers pass source `DeityDomain` explicitly to `FavorSystem`; implicit `GetPlayerActiveDeityDomain` routing path removed.
- `AwardFavorCore` applies a 1.5× patron multiplier when `religion.PatronDomain == deityDomain` (1.0× otherwise, null-religion safe), composing before holy-site and civ multipliers.
- Per-tracker "must follow X deity" gates and follower-set bookkeeping deleted — every player now accrues all five domain buckets.
- Prestige and activity log gated on `playerReligion.PatronDomain == deityDomain`, fixing the leak where any religion accumulated prestige from members' off-domain activity (e.g. Wild-patron player mining ore awarded prestige to a Wild religion).
- Passive favor routed through the same core path against the religion's `PatronDomain`.

Closes #238.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` clean
- [x] `dotnet test --filter FullyQualifiedName~Favor` — 354/354 pass, including new patron / non-patron / null-religion / prestige-gate / patron-prestige cases
- [x] Full suite — 2093/2093 pass
- [ ] Manual smoke: Wild-patron player mines ore → Craft favor bucket increments at 1.0×, religion gains zero prestige
- [ ] Manual smoke: Craft-patron player mines ore → Craft favor at 1.5×, religion prestige increments