### PR TITLE
feat(pantheon): phase 3 blessing gating (per-deity rank + patron capstones + 1.5x cost)

### DIFF
--- a/DivineAscension.Tests/GUI/Managers/BlessingStateManagerTests.cs
+++ b/DivineAscension.Tests/GUI/Managers/BlessingStateManagerTests.cs
@@ -56,6 +56,26 @@ public class BlessingStateManagerTests
         };
     }
 
+    /// <summary>
+    ///     Backward-compatible refresh helper for tests written before Phase 3's per-deity rank dict.
+    ///     Treats <paramref name="favorRank"/> as the rank for every deity, patron = Craft (default Blessing.Domain).
+    /// </summary>
+    private void Refresh(int favorRank, int prestigeRank)
+    {
+        // Seed every DeityDomain (incl. None, which is the default for blessings created without an explicit Domain)
+        // with the same rank so legacy tests keep their single-rank semantics.
+        var dict = new Dictionary<DeityDomain, int>
+        {
+            [DeityDomain.None] = favorRank,
+            [DeityDomain.Craft] = favorRank,
+            [DeityDomain.Wild] = favorRank,
+            [DeityDomain.Harvest] = favorRank,
+            [DeityDomain.Stone] = favorRank,
+            [DeityDomain.Conquest] = favorRank
+        };
+        _sut.RefreshAllBlessingStates(dict, prestigeRank, DeityDomain.None);
+    }
+
     #endregion
 
     #region Constructor Tests
@@ -469,7 +489,7 @@ public class BlessingStateManagerTests
         _sut.LoadBlessingStates(new List<Blessing> { blessing }, new List<Blessing>());
 
         // Act - with sufficient favor rank
-        _sut.RefreshAllBlessingStates(3, 0);
+        Refresh(3, 0);
 
         // Assert
         Assert.True(_sut.State.PlayerBlessingStates["test"].CanUnlock);
@@ -483,7 +503,7 @@ public class BlessingStateManagerTests
         _sut.LoadBlessingStates(new List<Blessing> { blessing }, new List<Blessing>());
 
         // Act - with insufficient favor rank
-        _sut.RefreshAllBlessingStates(2, 0);
+        Refresh(2, 0);
 
         // Assert
         Assert.False(_sut.State.PlayerBlessingStates["test"].CanUnlock);
@@ -497,7 +517,7 @@ public class BlessingStateManagerTests
         _sut.LoadBlessingStates(new List<Blessing>(), new List<Blessing> { blessing });
 
         // Act - with sufficient prestige rank
-        _sut.RefreshAllBlessingStates(0, 3);
+        Refresh(0, 3);
 
         // Assert
         Assert.True(_sut.State.ReligionBlessingStates["test"].CanUnlock);
@@ -511,7 +531,7 @@ public class BlessingStateManagerTests
         _sut.LoadBlessingStates(new List<Blessing>(), new List<Blessing> { blessing });
 
         // Act - with insufficient prestige rank
-        _sut.RefreshAllBlessingStates(0, 2);
+        Refresh(0, 2);
 
         // Assert
         Assert.False(_sut.State.ReligionBlessingStates["test"].CanUnlock);
@@ -526,7 +546,7 @@ public class BlessingStateManagerTests
         _sut.SetBlessingUnlocked("test", true);
 
         // Act
-        _sut.RefreshAllBlessingStates(5, 5);
+        Refresh(5, 5);
 
         // Assert - already unlocked, so CanUnlock should be false
         Assert.False(_sut.State.PlayerBlessingStates["test"].CanUnlock);
@@ -545,7 +565,7 @@ public class BlessingStateManagerTests
             new List<Blessing>());
 
         // Act - prereq not unlocked
-        _sut.RefreshAllBlessingStates(10, 10);
+        Refresh(10, 10);
 
         // Assert
         Assert.False(_sut.State.PlayerBlessingStates["dependent"].CanUnlock);
@@ -565,7 +585,7 @@ public class BlessingStateManagerTests
         _sut.SetBlessingUnlocked("prereq", true);
 
         // Act
-        _sut.RefreshAllBlessingStates(10, 10);
+        Refresh(10, 10);
 
         // Assert
         Assert.True(_sut.State.PlayerBlessingStates["dependent"].CanUnlock);
@@ -589,10 +609,88 @@ public class BlessingStateManagerTests
         _sut.SetBlessingUnlocked("prereq1", true);
 
         // Act
-        _sut.RefreshAllBlessingStates(10, 10);
+        Refresh(10, 10);
 
         // Assert - should be false because prereq2 is not unlocked (AND logic)
         Assert.False(_sut.State.PlayerBlessingStates["dependent"].CanUnlock);
+    }
+
+    [Fact]
+    public void RefreshAllBlessingStates_CapstoneRequiresPatron_NonPatronBlocked()
+    {
+        // Phase 3: a RequiresPatron blessing in a non-patron domain stays locked.
+        var capstone = CreateBlessing("avatar_of_wild", BlessingKind.Player);
+        capstone.Domain = DeityDomain.Wild;
+        capstone.RequiresPatron = true;
+
+        _sut.LoadBlessingStates(new List<Blessing> { capstone }, new List<Blessing>());
+
+        var dict = new Dictionary<DeityDomain, int> { [DeityDomain.Wild] = 4 };
+        _sut.RefreshAllBlessingStates(dict, 4, DeityDomain.Craft);
+
+        Assert.False(_sut.State.PlayerBlessingStates["avatar_of_wild"].CanUnlock);
+    }
+
+    [Fact]
+    public void RefreshAllBlessingStates_CapstoneRequiresPatron_PatronCanUnlock()
+    {
+        var capstone = CreateBlessing("avatar_of_wild", BlessingKind.Player);
+        capstone.Domain = DeityDomain.Wild;
+        capstone.RequiresPatron = true;
+
+        _sut.LoadBlessingStates(new List<Blessing> { capstone }, new List<Blessing>());
+
+        var dict = new Dictionary<DeityDomain, int> { [DeityDomain.Wild] = 4 };
+        _sut.RefreshAllBlessingStates(dict, 4, DeityDomain.Wild);
+
+        Assert.True(_sut.State.PlayerBlessingStates["avatar_of_wild"].CanUnlock);
+    }
+
+    [Fact]
+    public void RefreshAllBlessingStates_NonPatron_SetsCostMultiplier1_5()
+    {
+        var blessing = CreateBlessing("test", BlessingKind.Player);
+        blessing.Domain = DeityDomain.Wild;
+
+        _sut.LoadBlessingStates(new List<Blessing> { blessing }, new List<Blessing>());
+
+        var dict = new Dictionary<DeityDomain, int> { [DeityDomain.Wild] = 4 };
+        _sut.RefreshAllBlessingStates(dict, 0, DeityDomain.Craft);
+
+        Assert.Equal(1.5f, _sut.State.PlayerBlessingStates["test"].NonPatronCostMultiplier);
+    }
+
+    [Fact]
+    public void RefreshAllBlessingStates_Patron_SetsCostMultiplier1_0()
+    {
+        var blessing = CreateBlessing("test", BlessingKind.Player);
+        blessing.Domain = DeityDomain.Wild;
+
+        _sut.LoadBlessingStates(new List<Blessing> { blessing }, new List<Blessing>());
+
+        var dict = new Dictionary<DeityDomain, int> { [DeityDomain.Wild] = 4 };
+        _sut.RefreshAllBlessingStates(dict, 0, DeityDomain.Wild);
+
+        Assert.Equal(1.0f, _sut.State.PlayerBlessingStates["test"].NonPatronCostMultiplier);
+    }
+
+    [Fact]
+    public void RefreshAllBlessingStates_PerDeityFavorRank_GatesByDomain()
+    {
+        // Stone-patron player with no Conquest favor is blocked from a Conquest tier-3 blessing.
+        var blessing = CreateBlessing("conquest_t3", BlessingKind.Player, requiredFavorRank: 3);
+        blessing.Domain = DeityDomain.Conquest;
+
+        _sut.LoadBlessingStates(new List<Blessing> { blessing }, new List<Blessing>());
+
+        var dict = new Dictionary<DeityDomain, int>
+        {
+            [DeityDomain.Stone] = 4,
+            [DeityDomain.Conquest] = 0
+        };
+        _sut.RefreshAllBlessingStates(dict, 0, DeityDomain.Stone);
+
+        Assert.False(_sut.State.PlayerBlessingStates["conquest_t3"].CanUnlock);
     }
 
     [Fact]
@@ -613,7 +711,7 @@ public class BlessingStateManagerTests
         _sut.SetBlessingUnlocked("prereq1", true);
 
         // Act
-        _sut.RefreshAllBlessingStates(10, 10);
+        Refresh(10, 10);
 
         // Assert - should be true because one prerequisite is unlocked (OR logic)
         Assert.True(_sut.State.PlayerBlessingStates["capstone"].CanUnlock);

--- a/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
@@ -397,20 +397,85 @@ public class BlessingRegistryTests
     }
 
     [Fact]
-    public void CanUnlockBlessing_PlayerBlessing_WrongDeity_ReturnsFalse()
+    public void CanUnlockBlessing_PlayerBlessing_NonCapstoneWrongDeity_ReturnsTrue()
     {
-        // Arrange
+        // Phase 3: non-capstone player blessings unlock from any of the five deity trees,
+        // regardless of religion's patron domain. (Cost is 1.5x; see separate cost test.)
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
         var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Wild, BlessingKind.Player);
-        blessing.RequiredFavorRank = 0; // Set to Initiate so favor rank check passes
+        blessing.RequiredFavorRank = 0;
+        blessing.RequiresPatron = false;
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
-        // Act
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+
+        Assert.True(canUnlock);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_CapstoneNonPatron_ReturnsFalse()
+    {
+        // Capstones (RequiresPatron=true) are restricted to followers of the matching patron.
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        var blessing = TestFixtures.CreateTestBlessing("avatar_of_wild", "Avatar of Wild", DeityDomain.Wild, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.RequiresPatron = true;
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
+
         var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
 
-        // Assert
         Assert.False(canUnlock);
-        Assert.Contains("Requires deity: Wild", reason);
+        Assert.Contains("Capstone blessing requires patron deity: Wild", reason);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_CapstonePatron_ReturnsTrue()
+    {
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Wild, "religion-uid");
+        var blessing = TestFixtures.CreateTestBlessing("avatar_of_wild", "Avatar of Wild", DeityDomain.Wild, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.RequiresPatron = true;
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Wild, "player-uid");
+
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+
+        Assert.True(canUnlock);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_NonPatronCostIs1_5x()
+    {
+        // Patron=Craft, blessing domain=Wild, cost=100 → adjusted=150. Player has 140 → insufficient.
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        playerData.AddFavor(DeityDomain.Wild, 140);
+
+        var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Wild, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.Cost = 100;
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
+
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+
+        Assert.False(canUnlock);
+        Assert.Contains("Insufficient favor", reason);
+        Assert.Contains("requires 150", reason);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_PatronCostIs1x()
+    {
+        // Patron=Wild, blessing domain=Wild, cost=100, player has 100 → exactly enough at 1.0x.
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Wild, "religion-uid", favor: 0);
+        playerData.AddFavor(DeityDomain.Wild, 100);
+
+        var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Wild, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.Cost = 100;
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Wild, "player-uid");
+
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+
+        Assert.True(canUnlock);
     }
 
     [Fact]
@@ -598,19 +663,63 @@ public class BlessingRegistryTests
     }
 
     [Fact]
-    public void CanUnlockBlessing_ReligionBlessing_WrongDeity_ReturnsFalse()
+    public void CanUnlockBlessing_ReligionBlessing_NonCapstoneWrongDeity_ReturnsTrue()
     {
-        // Arrange
+        // Phase 3: non-capstone religion blessings unlock from any deity tree regardless of patron.
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
         var religionData = TestFixtures.CreateTestReligion("religion-uid", "Test Religion", DeityDomain.Craft);
         var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Wild, BlessingKind.Religion);
+        blessing.RequiresPatron = false;
 
-        // Act
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+
+        Assert.True(canUnlock);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_ReligionBlessing_CapstoneNonPatron_ReturnsFalse()
+    {
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        var religionData = TestFixtures.CreateTestReligion("religion-uid", "Test Religion", DeityDomain.Craft);
+        var blessing = TestFixtures.CreateTestBlessing("pantheon_of_wild", "Pantheon of Wild", DeityDomain.Wild, BlessingKind.Religion);
+        blessing.RequiresPatron = true;
+
         var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
 
-        // Assert
         Assert.False(canUnlock);
-        Assert.Contains("Religion deity mismatch", reason);
+        Assert.Contains("Capstone blessing requires patron deity: Wild", reason);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_ReligionBlessing_CapstonePatron_ReturnsTrue()
+    {
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Wild, "religion-uid");
+        var religionData = TestFixtures.CreateTestReligion("religion-uid", "Test Religion", DeityDomain.Wild);
+        var blessing = TestFixtures.CreateTestBlessing("pantheon_of_wild", "Pantheon of Wild", DeityDomain.Wild, BlessingKind.Religion);
+        blessing.RequiresPatron = true;
+
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+
+        Assert.True(canUnlock);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_ReligionBlessing_NonPatronCostIs1_5x()
+    {
+        // Patron=Craft, blessing domain=Wild, cost=400 → adjusted=600. Religion has 500 → insufficient.
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        var religionData = TestFixtures.CreateTestReligion("religion-uid", "Test Religion", DeityDomain.Craft);
+        religionData.AddPrestige(500);
+
+        var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Wild, BlessingKind.Religion);
+        blessing.RequiredPrestigeRank = 0;
+        blessing.Cost = 400;
+
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+
+        Assert.False(canUnlock);
+        Assert.Contains("Insufficient prestige", reason);
+        Assert.Contains("requires 600", reason);
     }
 
     [Fact]

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.State.Religion;
@@ -18,6 +19,21 @@ namespace DivineAscension.GUI;
 /// </summary>
 public partial class GuiDialog
 {
+    /// <summary>
+    ///     Builds the per-deity favor-rank dict consumed by BlessingStateManager.
+    ///     Phase 3: only the patron-deity rank is available client-side. Phase 4 will wire all five
+    ///     through BlessingDataResponsePacket.
+    /// </summary>
+    private Dictionary<DeityDomain, int> BuildFavorRanksByDeity()
+    {
+        var dict = new Dictionary<DeityDomain, int>();
+        if (_manager == null) return dict;
+        var patron = _manager.ReligionStateManager.CurrentReligionDomain;
+        if (patron != DeityDomain.None)
+            dict[patron] = _manager.ReligionStateManager.CurrentFavorRank;
+        return dict;
+    }
+
     /// <summary>
     ///     Periodically check if player religion data is available
     /// </summary>
@@ -124,9 +140,13 @@ public partial class GuiDialog
         // Set branch state from server (committed and locked branches)
         _manager.BlessingStateManager.SetBranchState(packet.CommittedBranches, packet.LockedBranches);
 
-        // Refresh states to update can-unlock status
-        _manager.BlessingStateManager.RefreshAllBlessingStates(_manager.ReligionStateManager.CurrentFavorRank,
-            _manager.ReligionStateManager.CurrentPrestigeRank);
+        // Refresh states to update can-unlock status.
+        // TODO(Phase 4): wire per-deity favor ranks through BlessingDataResponsePacket; for now only the
+        // patron-deity rank is known client-side, so other domains will read as Initiate (rank 0).
+        _manager.BlessingStateManager.RefreshAllBlessingStates(
+            BuildFavorRanksByDeity(),
+            _manager.ReligionStateManager.CurrentPrestigeRank,
+            _manager.ReligionStateManager.CurrentReligionDomain);
 
         // Initialize previous ranks to prevent false positives on first update
         var favorRankName = ((FavorRank)packet.FavorRank).ToString();
@@ -526,8 +546,10 @@ public partial class GuiDialog
         // Refresh blessing states in case new blessings became available
         // Only do this if dialog is open to avoid unnecessary processing
         if (_state.IsOpen && _manager.HasReligion())
-            _manager.BlessingStateManager.RefreshAllBlessingStates(_manager.ReligionStateManager.CurrentFavorRank,
-                _manager.ReligionStateManager.CurrentPrestigeRank);
+            _manager.BlessingStateManager.RefreshAllBlessingStates(
+                BuildFavorRanksByDeity(),
+                _manager.ReligionStateManager.CurrentPrestigeRank,
+                _manager.ReligionStateManager.CurrentReligionDomain);
 
         // Ensure HUD is visible when player has religion data
         EnsureHudVisible();
@@ -580,8 +602,10 @@ public partial class GuiDialog
             _manager?.BlessingStateManager.SetBlessingUnlocked(blessingId, true);
 
             // Refresh all blessing states to update prerequisites and glow effects
-            _manager?.BlessingStateManager.RefreshAllBlessingStates(_manager.ReligionStateManager.CurrentFavorRank,
-                _manager.ReligionStateManager.CurrentPrestigeRank);
+            _manager?.BlessingStateManager.RefreshAllBlessingStates(
+                BuildFavorRanksByDeity(),
+                _manager.ReligionStateManager.CurrentPrestigeRank,
+                _manager.ReligionStateManager.CurrentReligionDomain);
         }
     }
 

--- a/DivineAscension/GUI/Managers/BlessingStateManager.cs
+++ b/DivineAscension/GUI/Managers/BlessingStateManager.cs
@@ -184,7 +184,10 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         }
     }
 
-    public void RefreshAllBlessingStates(int currentFavorRank, int currentPrestigeRank)
+    public void RefreshAllBlessingStates(
+        Dictionary<DeityDomain, int> favorRanksByDeity,
+        int currentPrestigeRank,
+        DeityDomain patronDomain)
     {
         // Update CanUnlock status for all player blessings
         foreach (var state in State.PlayerBlessingStates.Values)
@@ -194,7 +197,8 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
             state.IsBranchLocked = branchLocked;
             state.LockedByBranch = branchLocked ? GetCommittedBranch(state.Blessing.Domain) : null;
 
-            state.CanUnlock = CanUnlockBlessing(state, currentFavorRank, currentPrestigeRank);
+            state.NonPatronCostMultiplier = state.Blessing.Domain == patronDomain ? 1.0f : 1.5f;
+            state.CanUnlock = CanUnlockBlessing(state, favorRanksByDeity, currentPrestigeRank, patronDomain);
             state.UpdateVisualState();
         }
 
@@ -203,22 +207,30 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         {
             state.IsBranchLocked = false;
             state.LockedByBranch = null;
-            state.CanUnlock = CanUnlockBlessing(state, currentFavorRank, currentPrestigeRank);
+            state.NonPatronCostMultiplier = state.Blessing.Domain == patronDomain ? 1.0f : 1.5f;
+            state.CanUnlock = CanUnlockBlessing(state, favorRanksByDeity, currentPrestigeRank, patronDomain);
             state.UpdateVisualState();
         }
     }
 
     /// <summary>
-    ///     Check if a blessing can be unlocked based on prerequisites and rank requirements
-    ///     This is a client-side validation - server will do final validation
+    ///     Check if a blessing can be unlocked based on prerequisites and rank requirements.
+    ///     Client-side validation only — server is authoritative.
     /// </summary>
-    private bool CanUnlockBlessing(BlessingNodeState state, int currentFavorRank, int currentPrestigeRank)
+    private bool CanUnlockBlessing(
+        BlessingNodeState state,
+        Dictionary<DeityDomain, int> favorRanksByDeity,
+        int currentPrestigeRank,
+        DeityDomain patronDomain)
     {
         // Already unlocked
         if (state.IsUnlocked) return false;
 
         // Branch is locked (for player blessings only)
         if (state.IsBranchLocked) return false;
+
+        // Patron capstone gate: capstones (RequiresPatron) require religion's patron to match blessing domain
+        if (state.Blessing.RequiresPatron && patronDomain != state.Blessing.Domain) return false;
 
         // Check prerequisites
         if (state.Blessing.PrerequisiteBlessings is { Count: > 0 })
@@ -256,8 +268,9 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         // Check rank requirements based on the blessing kind
         if (state.Blessing.Kind == BlessingKind.Player)
         {
-            // Player blessings require favor rank
-            if (state.Blessing.RequiredFavorRank > currentFavorRank) return false;
+            // Player blessings require per-deity favor rank for the blessing's domain
+            var domainRank = favorRanksByDeity.GetValueOrDefault(state.Blessing.Domain);
+            if (state.Blessing.RequiredFavorRank > domainRank) return false;
         }
         else if (state.Blessing.Kind == BlessingKind.Religion)
         {

--- a/DivineAscension/Models/BlessingNodeState.cs
+++ b/DivineAscension/Models/BlessingNodeState.cs
@@ -87,6 +87,13 @@ public class BlessingNodeState
     public int Tier { get; set; }
 
     /// <summary>
+    ///     Cost multiplier applied because the blessing's domain differs from the religion's patron.
+    ///     1.0 when the blessing's domain matches the patron (or no religion); 1.5 otherwise.
+    ///     UI uses this to show a "1.5x cost" hint on non-patron blessings.
+    /// </summary>
+    public float NonPatronCostMultiplier { get; set; } = 1.0f;
+
+    /// <summary>
     ///     Update visual state based on unlock status and unlock eligibility
     /// </summary>
     public void UpdateVisualState()

--- a/DivineAscension/Systems/BlessingRegistry.cs
+++ b/DivineAscension/Systems/BlessingRegistry.cs
@@ -154,9 +154,9 @@ public class BlessingRegistry : IBlessingRegistry
                 return (false, $"Requires {requiredRank} favor rank (Current: {playerFavorRank})");
             }
 
-            // Check deity matches
-            if (religionData!.PatronDomain != blessing.Domain)
-                return (false, $"Requires deity: {blessing.Domain} (Current: {religionData!.PatronDomain})");
+            // Patron capstone gate: capstones require religion's patron to match blessing's domain
+            if (blessing.RequiresPatron && religionData!.PatronDomain != blessing.Domain)
+                return (false, $"Capstone blessing requires patron deity: {blessing.Domain} (Current: {religionData!.PatronDomain})");
 
             // Check branch exclusivity (only for player blessings with a branch)
             if (!string.IsNullOrEmpty(blessing.Branch))
@@ -201,8 +201,9 @@ public class BlessingRegistry : IBlessingRegistry
             }
 
             // Check favor cost (skip if cost will be deducted atomically)
-            if (!skipCostCheck && blessing.Cost > 0 && playerData.GetFavor(blessing.Domain) < blessing.Cost)
-                return (false, $"Insufficient favor: requires {blessing.Cost}, have {playerData.GetFavor(blessing.Domain)}");
+            var playerAdjustedCost = AdjustedCost(blessing, religionData);
+            if (!skipCostCheck && playerAdjustedCost > 0 && playerData.GetFavor(blessing.Domain) < playerAdjustedCost)
+                return (false, $"Insufficient favor: requires {playerAdjustedCost}, have {playerData.GetFavor(blessing.Domain)}");
 
             return (true, "Can unlock");
         }
@@ -222,9 +223,9 @@ public class BlessingRegistry : IBlessingRegistry
             return (false, $"Religion requires {requiredRank} prestige rank (Current: {religionData.PrestigeRank})");
         }
 
-        // Check deity matches
-        if (religionData.PatronDomain != blessing.Domain)
-            return (false, $"Religion deity mismatch (Blessing: {blessing.Domain}, Religion: {religionData.PatronDomain})");
+        // Patron capstone gate: capstones require religion's patron to match blessing's domain
+        if (blessing.RequiresPatron && religionData.PatronDomain != blessing.Domain)
+            return (false, $"Capstone blessing requires patron deity: {blessing.Domain} (Current: {religionData.PatronDomain})");
 
         // Check prerequisites
         if (blessing.PrerequisiteBlessings != null)
@@ -237,9 +238,22 @@ public class BlessingRegistry : IBlessingRegistry
                 }
 
         // Check prestige cost (skip if cost will be deducted atomically)
-        if (!skipCostCheck && blessing.Cost > 0 && religionData.Prestige < blessing.Cost)
-            return (false, $"Insufficient prestige: requires {blessing.Cost}, have {religionData.Prestige}");
+        var religionAdjustedCost = AdjustedCost(blessing, religionData);
+        if (!skipCostCheck && religionAdjustedCost > 0 && religionData.Prestige < religionAdjustedCost)
+            return (false, $"Insufficient prestige: requires {religionAdjustedCost}, have {religionData.Prestige}");
 
         return (true, "Can unlock");
+    }
+
+    /// <summary>
+    ///     Compute adjusted blessing cost. Non-patron domain blessings cost 1.5x; patron domain blessings cost 1.0x.
+    ///     Capstones (RequiresPatron) are gated separately and always paid at 1.0x.
+    /// </summary>
+    public static int AdjustedCost(Blessing blessing, ReligionData religion)
+    {
+        if (blessing.Cost <= 0) return 0;
+        return religion.PatronDomain == blessing.Domain
+            ? blessing.Cost
+            : (int)(blessing.Cost * 1.5f);
     }
 }

--- a/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
@@ -99,12 +99,14 @@ public class BlessingNetworkHandler : IServerNetworkHandler
                         }
                         else
                         {
-                            // Atomically deduct favor cost (includes sufficiency check)
-                            if (blessing.Cost > 0 && !playerData.RemoveFavor(blessing.Domain, blessing.Cost))
+                            // Atomically deduct favor cost (includes sufficiency check).
+                            // Non-patron blessings cost 1.5x; capstones are patron-only and always 1.0x.
+                            var adjustedCost = BlessingRegistry.AdjustedCost(blessing, religion);
+                            if (adjustedCost > 0 && !playerData.RemoveFavor(blessing.Domain, adjustedCost))
                             {
                                 message = LocalizationService.Instance.Get(
                                     LocalizationKeys.CMD_BLESSING_ERROR_INSUFFICIENT_FAVOR,
-                                    blessing.Cost, playerData.GetFavor(blessing.Domain));
+                                    adjustedCost, playerData.GetFavor(blessing.Domain));
                             }
                             else
                             {
@@ -147,12 +149,14 @@ public class BlessingNetworkHandler : IServerNetworkHandler
                         }
                         else
                         {
-                            // Atomically deduct prestige cost (includes sufficiency check)
-                            if (blessing.Cost > 0 && !religion.RemovePrestige(blessing.Cost))
+                            // Atomically deduct prestige cost (includes sufficiency check).
+                            // Non-patron religion blessings cost 1.5x; capstones are patron-only and always 1.0x.
+                            var adjustedCost = BlessingRegistry.AdjustedCost(blessing, religion);
+                            if (adjustedCost > 0 && !religion.RemovePrestige(adjustedCost))
                             {
                                 message = LocalizationService.Instance.Get(
                                     LocalizationKeys.CMD_BLESSING_ERROR_INSUFFICIENT_PRESTIGE,
-                                    blessing.Cost, religion.Prestige);
+                                    adjustedCost, religion.Prestige);
                             }
                             else
                             {


### PR DESCRIPTION
## Summary
- Drops religion-deity-match check on both player and religion blessing paths — any of the 5 deity trees is now accessible regardless of patron.
- Gates the 10 capstones (`avatar_of_*`, `pantheon_of_*`) to patron followers via the existing `RequiresPatron` flag.
- Charges non-patron blessings 1.5× (favor on player path, prestige on religion path) via a new static `BlessingRegistry.AdjustedCost(blessing, religion)` shared by client checks and server deductions.
- Preserves founder-only religion-blessing spend.

Closes #239.

## Notes / known gaps
- `BlessingNodeState.NonPatronCostMultiplier` is set but no renderer consumes it yet — UI hint for "1.5× cost" lands in Phase 5b.
- `BlessingDataResponsePacket` still ships a single favor rank for the religion's patron deity; client treats the other four domains as rank 0 until Phase 4 wires per-deity favor through the packet. Server is authoritative, so clicking an apparently-locked non-patron blessing will still succeed if the server-side rank is sufficient.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug`
- [x] `dotnet test` — 2105 / 2105 pass
- [ ] In-game smoke: Stone-patron religion, accrue Conquest favor, unlock Conquest tier-1 player blessing at 1.5× cost.
- [ ] Verify `avatar_of_conquest` stays locked for the Stone patron.
- [ ] Switch patron to Conquest; founder unlocks `pantheon_of_conquest` at 1.0× cost; non-founder member denied.