### PR TITLE
fix(commands): /blessing unlock honors patron cost multiplier (#250)

### DIFF
--- a/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
@@ -967,4 +967,35 @@ public class BlessingRegistryTests
     }
 
     #endregion
+
+    #region AdjustedCost Tests
+
+    [Fact]
+    public void AdjustedCost_PatronDomain_ReturnsBaseCost()
+    {
+        var blessing = new Blessing { Cost = 100, Domain = DeityDomain.Craft };
+        var religion = TestFixtures.CreateTestReligion("uid", "Test", DeityDomain.Craft, "founder");
+
+        Assert.Equal(100, BlessingRegistry.AdjustedCost(blessing, religion));
+    }
+
+    [Fact]
+    public void AdjustedCost_NonPatronDomain_AppliesOneAndAHalfMultiplier()
+    {
+        var blessing = new Blessing { Cost = 100, Domain = DeityDomain.Wild };
+        var religion = TestFixtures.CreateTestReligion("uid", "Test", DeityDomain.Craft, "founder");
+
+        Assert.Equal(150, BlessingRegistry.AdjustedCost(blessing, religion));
+    }
+
+    [Fact]
+    public void AdjustedCost_ZeroBaseCost_ReturnsZero()
+    {
+        var blessing = new Blessing { Cost = 0, Domain = DeityDomain.Wild };
+        var religion = TestFixtures.CreateTestReligion("uid", "Test", DeityDomain.Craft, "founder");
+
+        Assert.Equal(0, BlessingRegistry.AdjustedCost(blessing, religion));
+    }
+
+    #endregion
 }

--- a/DivineAscension/Commands/BlessingCommands.cs
+++ b/DivineAscension/Commands/BlessingCommands.cs
@@ -8,6 +8,7 @@ using DivineAscension.Extensions;
 using DivineAscension.Models.Enum;
 using DivineAscension.Network;
 using DivineAscension.Services;
+using DivineAscension.Systems;
 using DivineAscension.Systems.Interfaces;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -509,11 +510,13 @@ public class BlessingCommands(
                 return TextCommandResult.Error(
                     LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_NOT_IN_RELIGION));
 
-            // Atomically deduct favor cost (includes sufficiency check)
-            if (blessing.Cost > 0 && !playerData.RemoveFavor(blessing.Domain, blessing.Cost))
+            // Atomically deduct favor cost (includes sufficiency check).
+            // Non-patron blessings cost 1.5x; capstones are patron-only and always 1.0x.
+            var adjustedCost = BlessingRegistry.AdjustedCost(blessing, religion);
+            if (adjustedCost > 0 && !playerData.RemoveFavor(blessing.Domain, adjustedCost))
                 return TextCommandResult.Error(
                     LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_INSUFFICIENT_FAVOR,
-                        blessing.Cost, playerData.GetFavor(blessing.Domain)));
+                        adjustedCost, playerData.GetFavor(blessing.Domain)));
 
             var success = _playerProgressionDataManager.UnlockPlayerBlessing(playerUid, blessingId);
             if (!success)
@@ -554,11 +557,13 @@ public class BlessingCommands(
         if (!religion.IsFounder(playerUid))
             return TextCommandResult.Error(LocalizationService.Instance.Get(LocalizationKeys.CMD_ERROR_NOT_FOUNDER));
 
-        // Atomically deduct prestige cost (includes sufficiency check)
-        if (blessing.Cost > 0 && !religion.RemovePrestige(blessing.Cost))
+        // Atomically deduct prestige cost (includes sufficiency check).
+        // Non-patron religion blessings cost 1.5x; capstones are patron-only and always 1.0x.
+        var adjustedReligionCost = BlessingRegistry.AdjustedCost(blessing, religion);
+        if (adjustedReligionCost > 0 && !religion.RemovePrestige(adjustedReligionCost))
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_INSUFFICIENT_PRESTIGE,
-                    blessing.Cost, religion.Prestige));
+                    adjustedReligionCost, religion.Prestige));
 
         religion.UnlockBlessing(blessingId);
         _blessingEffectSystem.RefreshReligionBlessings(religion.ReligionUID);


### PR DESCRIPTION
## Summary
`BlessingCommands.OnUnlock` deducted raw `blessing.Cost` for both player and religion paths, bypassing the 1.5× non-patron multiplier that Phase 3 (#239) wired through `BlessingNetworkHandler`. Players/admins unlocking via the `/blessing unlock` chat command could buy non-patron blessings at the base cost.

Switches both call sites to `BlessingRegistry.AdjustedCost(blessing, religion)`, matching the working network path (`BlessingNetworkHandler.cs:104,154`).

`RequiresPatron` capstone gating is already enforced upstream via `BlessingRegistry.CanUnlockBlessing` (`BlessingRegistry.cs:158,227`) — only the cost was leaking.

Closes #250.

## Changes
- `DivineAscension/Commands/BlessingCommands.cs`: player path (L513-516) and religion path (L558-561) now compute adjusted cost; error messages report the adjusted value. `using DivineAscension.Systems;` added.
- `DivineAscension.Tests/Systems/BlessingRegistryTests.cs`: three new tests on the static `AdjustedCost` formula (patron 1.0×, non-patron 1.5×, zero-cost passthrough).

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug`
- [x] `dotnet test --filter "FullyQualifiedName~BlessingRegistry|FullyQualifiedName~BlessingCommand"` — 130/130 passing
- [ ] In-game: unlock a non-patron player blessing via `/blessing unlock <id>` and confirm 1.5× favor deduction