### PR TITLE
feat(commands): multi-domain support for /favor and /blessing list (#251)

### DIFF
--- a/DivineAscension.Tests/Commands/CommandHelpersTests.cs
+++ b/DivineAscension.Tests/Commands/CommandHelpersTests.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Commands;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.Tests.Commands;
+
+[ExcludeFromCodeCoverage]
+public class CommandHelpersTests
+{
+    [Fact]
+    public void ParseDomainAndPlayer_BothNull_ReturnsBothNull()
+    {
+        var (d, p) = CommandHelpers.ParseDomainAndPlayer(null, null);
+        Assert.Null(d);
+        Assert.Null(p);
+    }
+
+    [Fact]
+    public void ParseDomainAndPlayer_FirstIsDomain_ReturnsDomainOnly()
+    {
+        var (d, p) = CommandHelpers.ParseDomainAndPlayer("Wild", null);
+        Assert.Equal(DeityDomain.Wild, d);
+        Assert.Null(p);
+    }
+
+    [Fact]
+    public void ParseDomainAndPlayer_FirstIsPlayer_ReturnsPlayerOnly()
+    {
+        var (d, p) = CommandHelpers.ParseDomainAndPlayer("Bob", null);
+        Assert.Null(d);
+        Assert.Equal("Bob", p);
+    }
+
+    [Fact]
+    public void ParseDomainAndPlayer_DomainThenPlayer_ParsesBoth()
+    {
+        var (d, p) = CommandHelpers.ParseDomainAndPlayer("Conquest", "Alice");
+        Assert.Equal(DeityDomain.Conquest, d);
+        Assert.Equal("Alice", p);
+    }
+
+    [Fact]
+    public void ParseDomainAndPlayer_PlayerThenDomain_ParsesBoth()
+    {
+        var (d, p) = CommandHelpers.ParseDomainAndPlayer("Alice", "Stone");
+        Assert.Equal(DeityDomain.Stone, d);
+        Assert.Equal("Alice", p);
+    }
+
+    [Fact]
+    public void ParseDomainAndPlayer_CaseInsensitiveDomain()
+    {
+        var (d, _) = CommandHelpers.ParseDomainAndPlayer("harvest", null);
+        Assert.Equal(DeityDomain.Harvest, d);
+    }
+
+    [Fact]
+    public void ParseDomainAndPlayer_NoneIsRejected()
+    {
+        var (d, p) = CommandHelpers.ParseDomainAndPlayer("None", null);
+        Assert.Null(d);
+        Assert.Equal("None", p); // treated as playername
+    }
+}

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandDomainTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandDomainTests.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Models.Enum;
+using DivineAscension.Tests.Commands.Helpers;
+using DivineAscension.Tests.Helpers;
+using Moq;
+
+namespace DivineAscension.Tests.Commands.Favor;
+
+/// <summary>
+///     Coverage for Issue #251: per-deity domain arg on /favor subcommands.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class FavorCommandDomainTests : FavorCommandsTestHelpers
+{
+    public FavorCommandDomainTests()
+    {
+        _sut = InitializeMocksAndSut();
+    }
+
+    [Fact]
+    public void OnAddFavor_NoDomainArg_DefaultsToPatron()
+    {
+        var mockPlayer = CreateMockPlayer("p1", "P1");
+        var playerData = CreatePlayerData("p1", DeityDomain.Craft);
+        var args = CreateAdminCommandArgs(mockPlayer.Object);
+        SetupParsers(args, 500, null, null);
+
+        _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("p1")).Returns(playerData);
+        _religionManager.Setup(r => r.GetPlayerReligion("p1"))
+            .Returns(TestFixtures.CreateTestReligion());
+        _religionManager.Setup(r => r.GetPlayerActiveDeityDomain("p1")).Returns(DeityDomain.Craft);
+
+        var result = _sut!.OnAddFavor(args);
+
+        Assert.Equal(Vintagestory.API.Common.EnumCommandStatus.Success, result.Status);
+        _playerReligionDataManager.Verify(m =>
+            m.AddFavor("p1", DeityDomain.Craft, 500), Times.Once);
+        _playerReligionDataManager.Verify(m =>
+            m.AddFavor(It.IsAny<string>(), DeityDomain.Wild, It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public void OnAddFavor_DomainArgOverridesPatron()
+    {
+        var mockPlayer = CreateMockPlayer("p1", "P1");
+        var playerData = CreatePlayerData("p1", DeityDomain.Craft);
+        var args = CreateAdminCommandArgs(mockPlayer.Object);
+        SetupParsers(args, 500, "Wild", null);
+
+        _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("p1")).Returns(playerData);
+        _religionManager.Setup(r => r.GetPlayerReligion("p1"))
+            .Returns(TestFixtures.CreateTestReligion());
+        _religionManager.Setup(r => r.GetPlayerActiveDeityDomain("p1")).Returns(DeityDomain.Craft);
+
+        var result = _sut!.OnAddFavor(args);
+
+        Assert.Equal(Vintagestory.API.Common.EnumCommandStatus.Success, result.Status);
+        _playerReligionDataManager.Verify(m =>
+            m.AddFavor("p1", DeityDomain.Wild, 500), Times.Once);
+    }
+
+    [Fact]
+    public void OnAddFavor_InvalidDomainAfterPlayerName_ReturnsError()
+    {
+        var mockPlayer = CreateMockPlayer("p1", "P1");
+        var playerData = CreatePlayerData("p1", DeityDomain.Craft);
+        var args = CreateAdminCommandArgs(mockPlayer.Object);
+        SetupParsers(args, 500, "P1", "Notadomain");
+
+        _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("p1")).Returns(playerData);
+        _religionManager.Setup(r => r.GetPlayerActiveDeityDomain("p1")).Returns(DeityDomain.Craft);
+
+        var result = _sut!.OnAddFavor(args);
+
+        Assert.Equal(Vintagestory.API.Common.EnumCommandStatus.Error, result.Status);
+        Assert.Contains("Notadomain", result.StatusMessage);
+    }
+
+    [Fact]
+    public void OnCheckFavor_DomainArg_ShowsThatDeity()
+    {
+        var mockPlayer = CreateMockPlayer("p1", "P1");
+        var playerData = CreatePlayerData("p1", DeityDomain.Wild, favor: 750);
+        var args = CreateCommandArgs(mockPlayer.Object);
+        SetupParsers(args, "Wild");
+
+        _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("p1")).Returns(playerData);
+        _religionManager.Setup(r => r.GetPlayerReligion("p1"))
+            .Returns(TestFixtures.CreateTestReligion());
+        _religionManager.Setup(r => r.GetPlayerActiveDeityDomain("p1")).Returns(DeityDomain.Craft);
+        _playerReligionDataManager.Setup(m => m.GetPlayerFavorRank("p1", DeityDomain.Wild))
+            .Returns(FavorRank.Disciple);
+
+        var result = _sut!.OnCheckFavor(args);
+
+        Assert.Equal(Vintagestory.API.Common.EnumCommandStatus.Success, result.Status);
+        Assert.Contains("Wild", result.StatusMessage);
+        Assert.Contains("750", result.StatusMessage);
+    }
+
+    [Fact]
+    public void OnFavorStats_NoDomain_ShowsPerDeitySummary()
+    {
+        var mockPlayer = CreateMockPlayer("p1", "P1");
+        var playerData = CreatePlayerData("p1", DeityDomain.Craft, favor: 100, totalFavor: 500);
+        playerData.SetFavor(DeityDomain.Wild, 250);
+        playerData.SetTotalFavorEarned(DeityDomain.Wild, 800);
+        var args = CreateCommandArgs(mockPlayer.Object);
+
+        _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("p1")).Returns(playerData);
+        _religionManager.Setup(r => r.GetPlayerReligion("p1"))
+            .Returns(TestFixtures.CreateTestReligion());
+        _religionManager.Setup(r => r.GetPlayerActiveDeityDomain("p1")).Returns(DeityDomain.Craft);
+
+        var result = _sut!.OnFavorStats(args);
+
+        Assert.Equal(Vintagestory.API.Common.EnumCommandStatus.Success, result.Status);
+        Assert.Contains("Per-deity favor:", result.StatusMessage);
+        Assert.Contains("100", result.StatusMessage);
+        Assert.Contains("250", result.StatusMessage);
+    }
+}

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandStatsTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandStatsTests.cs
@@ -130,6 +130,8 @@ public class FavorCommandStatsTests : FavorCommandsTestHelpers
         var playerData = CreatePlayerData("player-1", DeityDomain.Craft, 600, 600,
             FavorRank.Disciple);
         var args = CreateCommandArgs(mockPlayer.Object);
+        // Explicit-domain path produces single-deity output with Next Rank info.
+        SetupParsers(args, "Craft");
 
 
         _playerReligionDataManager.Setup(m => m.GetOrCreatePlayerData("player-1")).Returns(playerData);

--- a/DivineAscension/Commands/BlessingCommands.cs
+++ b/DivineAscension/Commands/BlessingCommands.cs
@@ -58,6 +58,7 @@ public class BlessingCommands(
             .RequiresPrivilege(Privilege.chat)
             .BeginSubCommand(BlessingCommandConstants.SubCommandList)
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSINGS_LIST_DESC))
+            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("domain"))
             .HandleWith(OnList)
             .EndSubCommand()
             .BeginSubCommand(BlessingCommandConstants.SubCommandPlayer)
@@ -128,10 +129,24 @@ public class BlessingCommands(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_PLAYER_NOT_FOUND));
 
         var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
-        var playerDeity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
-        if (playerDeity == DeityDomain.None)
-            return TextCommandResult.Error(
-                LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_NOT_IN_RELIGION));
+
+        var domainArg = args.ArgCount > 0 ? args[0] as string : null;
+        DeityDomain playerDeity;
+        if (!string.IsNullOrEmpty(domainArg))
+        {
+            if (!Enum.TryParse<DeityDomain>(domainArg, ignoreCase: true, out var parsed) ||
+                parsed == DeityDomain.None)
+                return TextCommandResult.Error(LocalizationService.Instance.Get(
+                    LocalizationKeys.CMD_FAVOR_ERROR_INVALID_DOMAIN, domainArg));
+            playerDeity = parsed;
+        }
+        else
+        {
+            playerDeity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+            if (playerDeity == DeityDomain.None)
+                return TextCommandResult.Error(
+                    LocalizationService.Instance.Get(LocalizationKeys.CMD_BLESSING_ERROR_NOT_IN_RELIGION));
+        }
 
         var playerBlessings = _blessingRegistry.GetBlessingsForDeity(playerDeity, BlessingKind.Player);
         var religionBlessings = _blessingRegistry.GetBlessingsForDeity(playerDeity, BlessingKind.Religion);

--- a/DivineAscension/Commands/CommandHelpers.cs
+++ b/DivineAscension/Commands/CommandHelpers.cs
@@ -89,4 +89,46 @@ public static class CommandHelpers
 
         return (caller, callerData, null);
     }
+
+    /// <summary>
+    ///     Parse two optional positional args (`[arg1] [arg2]`) into a domain + playername pair.
+    ///     Tries each arg as <see cref="DeityDomain"/> first (case-insensitive); the leftover is the
+    ///     playername. Either or both may be null. When both args fail to parse as a domain, the first
+    ///     is treated as the playername.
+    /// </summary>
+    public static (DeityDomain? domain, string? playerName) ParseDomainAndPlayer(string? arg1, string? arg2)
+    {
+        DeityDomain? domain = null;
+        string? playerName = null;
+
+        if (TryParseDomain(arg1, out var d1))
+            domain = d1;
+        else if (!string.IsNullOrEmpty(arg1))
+            playerName = arg1;
+
+        if (TryParseDomain(arg2, out var d2))
+        {
+            // If both parse as a domain, last one wins; the other becomes a name.
+            if (domain.HasValue) playerName = arg1;
+            domain = d2;
+        }
+        else if (!string.IsNullOrEmpty(arg2))
+        {
+            // arg2 is a name. If arg1 was also a name (no domain parsed), arg2 takes the slot.
+            if (playerName == null) playerName = arg2;
+            else playerName = arg2; // explicit second positional wins
+        }
+
+        return (domain, playerName);
+    }
+
+    private static bool TryParseDomain(string? value, out DeityDomain domain)
+    {
+        domain = DeityDomain.None;
+        if (string.IsNullOrEmpty(value)) return false;
+        if (!Enum.TryParse(value, ignoreCase: true, out DeityDomain parsed)) return false;
+        if (parsed == DeityDomain.None) return false;
+        domain = parsed;
+        return true;
+    }
 }

--- a/DivineAscension/Commands/FavorCommands.cs
+++ b/DivineAscension/Commands/FavorCommands.cs
@@ -50,14 +50,17 @@ public class FavorCommands
             .HandleWith(OnCheckFavor) // Default behavior: show current favor
             .BeginSubCommand("get")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_GET_DESC))
+            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("domain"))
             .HandleWith(OnCheckFavor)
             .EndSubCommand()
             .BeginSubCommand("info")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_INFO_DESC))
+            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("domain"))
             .HandleWith(OnFavorInfo)
             .EndSubCommand()
             .BeginSubCommand("stats")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_STATS_DESC))
+            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("domain"))
             .HandleWith(OnFavorStats)
             .EndSubCommand()
             .BeginSubCommand("ranks")
@@ -67,37 +70,47 @@ public class FavorCommands
             .EndSubCommand()
             .BeginSubCommand("set")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SET_DESC))
-            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"), _sapi.ChatCommands.Parsers.OptionalWord("playername"))
+            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"),
+                _sapi.ChatCommands.Parsers.OptionalWord("domain_or_player"),
+                _sapi.ChatCommands.Parsers.OptionalWord("playername_or_domain"))
             .RequiresPrivilege(Privilege.root)
             .HandleWith(OnSetFavor)
             .EndSubCommand()
             .BeginSubCommand("add")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ADD_DESC))
-            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"), _sapi.ChatCommands.Parsers.OptionalWord("playername"))
+            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"),
+                _sapi.ChatCommands.Parsers.OptionalWord("domain_or_player"),
+                _sapi.ChatCommands.Parsers.OptionalWord("playername_or_domain"))
             .RequiresPrivilege(Privilege.root)
             .HandleWith(OnAddFavor)
             .EndSubCommand()
             .BeginSubCommand("remove")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_REMOVE_DESC))
-            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"), _sapi.ChatCommands.Parsers.OptionalWord("playername"))
+            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"),
+                _sapi.ChatCommands.Parsers.OptionalWord("domain_or_player"),
+                _sapi.ChatCommands.Parsers.OptionalWord("playername_or_domain"))
             .RequiresPrivilege(Privilege.root)
             .HandleWith(OnRemoveFavor)
             .EndSubCommand()
             .BeginSubCommand("reset")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_RESET_DESC))
-            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("playername"))
+            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("domain_or_player"),
+                _sapi.ChatCommands.Parsers.OptionalWord("playername_or_domain"))
             .RequiresPrivilege(Privilege.root)
             .HandleWith(OnResetFavor)
             .EndSubCommand()
             .BeginSubCommand("max")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_MAX_DESC))
-            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("playername"))
+            .WithArgs(_sapi.ChatCommands.Parsers.OptionalWord("domain_or_player"),
+                _sapi.ChatCommands.Parsers.OptionalWord("playername_or_domain"))
             .RequiresPrivilege(Privilege.root)
             .HandleWith(OnMaxFavor)
             .EndSubCommand()
             .BeginSubCommand("settotal")
             .WithDescription(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SETTOTAL_DESC))
-            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"), _sapi.ChatCommands.Parsers.OptionalWord("playername"))
+            .WithArgs(_sapi.ChatCommands.Parsers.Int("amount"),
+                _sapi.ChatCommands.Parsers.OptionalWord("domain_or_player"),
+                _sapi.ChatCommands.Parsers.OptionalWord("playername_or_domain"))
             .RequiresPrivilege(Privilege.root)
             .HandleWith(OnSetTotalFavor)
             .EndSubCommand()
@@ -164,13 +177,34 @@ public class FavorCommands
             CommandHelpers.ValidatePlayerHasDeity(player, _playerProgressionDataManager, _religionManager);
         if (errorResult is { Status: EnumCommandStatus.Error }) return errorResult;
 
-        var deity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+        var deityResult = ResolveDeity(player.PlayerUID, args.ArgCount > 0 ? args[0] as string : null);
+        if (deityResult.Error != null) return deityResult.Error;
+        var deity = deityResult.Domain;
         var deityName = deity.ToString();
 
         return TextCommandResult.Success(
             LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_SUCCESS_CHECK, playerProgressionData!.GetFavor(deity),
                 deityName, _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, deity).ToLocalizedString())
         );
+    }
+
+    /// <summary>
+    ///     Resolves a single optional domain arg, defaulting to the player's patron when absent.
+    /// </summary>
+    private (DeityDomain Domain, TextCommandResult? Error) ResolveDeity(string playerUID, string? domainArg)
+    {
+        if (!string.IsNullOrEmpty(domainArg))
+        {
+            if (!Enum.TryParse<DeityDomain>(domainArg, ignoreCase: true, out var parsed) ||
+                parsed == DeityDomain.None)
+            {
+                return (DeityDomain.None,
+                    TextCommandResult.Error(LocalizationService.Instance.Get(
+                        LocalizationKeys.CMD_FAVOR_ERROR_INVALID_DOMAIN, domainArg)));
+            }
+            return (parsed, null);
+        }
+        return (_religionManager.GetPlayerActiveDeityDomain(playerUID), null);
     }
 
     /// <summary>
@@ -187,7 +221,9 @@ public class FavorCommands
             CommandHelpers.ValidatePlayerHasDeity(player, _playerProgressionDataManager, _religionManager);
         if (errorResult is { Status: EnumCommandStatus.Error }) return errorResult;
 
-        var deityDomain = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+        var infoResult = ResolveDeity(player.PlayerUID, args.ArgCount > 0 ? args[0] as string : null);
+        if (infoResult.Error != null) return infoResult.Error;
+        var deityDomain = infoResult.Domain;
         var domainLocalized = deityDomain.ToLocalizedString();
 
         // Get current rank based on total favor
@@ -243,7 +279,26 @@ public class FavorCommands
             CommandHelpers.ValidatePlayerHasDeity(player, _playerProgressionDataManager, _religionManager);
         if (errorResult is { Status: EnumCommandStatus.Error }) return errorResult;
 
-        var deity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+        var domainArg = args.ArgCount > 0 ? args[0] as string : null;
+        var sb = new StringBuilder();
+
+        if (string.IsNullOrEmpty(domainArg))
+        {
+            // No domain arg: show per-deity summary for all five.
+            sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_HEADER_STATS));
+            sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_PER_DEITY));
+            foreach (var d in AllDeities)
+            {
+                var total = playerProgressionData!.GetTotalFavorEarned(d);
+                var rankName = RankRequirements.GetFavorRankName(GetCurrentFavorRank(total));
+                sb.AppendLine($"  {d.ToLocalizedString()}: {playerProgressionData.GetFavor(d):N0} ({rankName}, total {total:N0})");
+            }
+            return TextCommandResult.Success(sb.ToString());
+        }
+
+        var statsResult = ResolveDeity(player.PlayerUID, domainArg);
+        if (statsResult.Error != null) return statsResult.Error;
+        var deity = statsResult.Domain;
         var deityName = deity.ToLocalizedString();
 
         // Get current rank based on total favor
@@ -251,7 +306,6 @@ public class FavorCommands
         var currentRank = GetCurrentFavorRank(totalForDeity);
         var currentRankName = RankRequirements.GetFavorRankName(currentRank);
 
-        var sb = new StringBuilder();
         sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_HEADER_STATS));
         sb.AppendLine($"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_DOMAIN)} {deityName}");
         sb.AppendLine(
@@ -277,6 +331,38 @@ public class FavorCommands
         }
 
         return TextCommandResult.Success(sb.ToString());
+    }
+
+    private static readonly DeityDomain[] AllDeities =
+    {
+        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
+        DeityDomain.Harvest, DeityDomain.Stone
+    };
+
+    /// <summary>
+    ///     Reads `args[startIndex]` and `args[startIndex+1]` as two optional positional words and
+    ///     smart-parses them into (domain?, playerName?). Returns an error result when a raw value
+    ///     was supplied that resembles neither a known DeityDomain nor a valid playername context.
+    ///     The error case fires only when *both* args are present and *neither* parses as a domain
+    ///     and ParseDomainAndPlayer leaves the user with an ambiguous duplicate playername — we
+    ///     surface a clear "invalid domain" message instead of silently dropping an arg.
+    /// </summary>
+    private static (DeityDomain? Domain, string? PlayerName, TextCommandResult? Error)
+        ParseDomainAndPlayerArgs(TextCommandCallingArgs args, int startIndex)
+    {
+        var arg1 = args.ArgCount > startIndex ? args[startIndex] as string : null;
+        var arg2 = args.ArgCount > startIndex + 1 ? args[startIndex + 1] as string : null;
+        var (domain, playerName) = CommandHelpers.ParseDomainAndPlayer(arg1, arg2);
+
+        // If user supplied two args and neither resolved to a domain, assume the second was meant
+        // as the domain — flag it as invalid so the admin sees a precise error.
+        if (domain == null && !string.IsNullOrEmpty(arg1) && !string.IsNullOrEmpty(arg2))
+        {
+            return (null, null, TextCommandResult.Error(LocalizationService.Instance.Get(
+                LocalizationKeys.CMD_FAVOR_ERROR_INVALID_DOMAIN, arg2)));
+        }
+
+        return (domain, playerName, null);
     }
 
     /// <summary>
@@ -318,7 +404,8 @@ public class FavorCommands
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_BE_PLAYER));
 
         var amount = (int)args[0];
-        var targetPlayerName = (string)args[1];
+        var (parsedDomain, targetPlayerName, parseError) = ParseDomainAndPlayerArgs(args, 1);
+        if (parseError != null) return parseError;
 
         // Validate amount
         if (amount < 0)
@@ -339,7 +426,7 @@ public class FavorCommands
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
         var targetUID = targetPlayer?.PlayerUID ?? player.PlayerUID;
-        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetUID);
+        var targetDeity = parsedDomain ?? _religionManager.GetPlayerActiveDeityDomain(targetUID);
         playerData.SetFavor(targetDeity, amount);
 
         var targetName = targetPlayerName != null ? $" for {targetPlayer?.PlayerName}" : "";
@@ -358,7 +445,8 @@ public class FavorCommands
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_BE_PLAYER));
 
         var amount = (int)args[0];
-        var targetPlayerName = (string)args[1];
+        var (parsedDomain, targetPlayerName, parseError) = ParseDomainAndPlayerArgs(args, 1);
+        if (parseError != null) return parseError;
 
         // Validate amount
         if (amount <= 0)
@@ -378,7 +466,7 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetPlayer.PlayerUID);
+        var targetDeity = parsedDomain ?? _religionManager.GetPlayerActiveDeityDomain(targetPlayer.PlayerUID);
         var oldFavor = playerData.GetFavor(targetDeity);
         _playerProgressionDataManager.AddFavor(targetPlayer.PlayerUID, targetDeity, amount);
 
@@ -399,7 +487,8 @@ public class FavorCommands
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_BE_PLAYER));
 
         var amount = (int)args[0];
-        var targetPlayerName = (string)args[1];
+        var (parsedDomain, targetPlayerName, parseError) = ParseDomainAndPlayerArgs(args, 1);
+        if (parseError != null) return parseError;
 
         // Validate amount
         if (amount <= 0)
@@ -419,7 +508,7 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetPlayer.PlayerUID);
+        var targetDeity = parsedDomain ?? _religionManager.GetPlayerActiveDeityDomain(targetPlayer.PlayerUID);
         var oldFavor = playerData.GetFavor(targetDeity);
         _playerProgressionDataManager.RemoveFavor(targetPlayer.PlayerUID, targetDeity, amount);
         var actualRemoved = oldFavor - playerData.GetFavor(targetDeity);
@@ -440,7 +529,8 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_BE_PLAYER));
 
-        var targetPlayerName = (string)args[0];
+        var (parsedDomain, targetPlayerName, parseError) = ParseDomainAndPlayerArgs(args, 0);
+        if (parseError != null) return parseError;
 
         // Resolve target player
         var (targetPlayer, playerData, errorResult) = CommandHelpers.ResolveTargetPlayer(player, targetPlayerName,
@@ -453,7 +543,7 @@ public class FavorCommands
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
         var targetUID = targetPlayer?.PlayerUID ?? player.PlayerUID;
-        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetUID);
+        var targetDeity = parsedDomain ?? _religionManager.GetPlayerActiveDeityDomain(targetUID);
         var oldFavor = playerData.GetFavor(targetDeity);
         playerData.SetFavor(targetDeity, 0);
 
@@ -472,7 +562,8 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_BE_PLAYER));
 
-        var targetPlayerName = (string)args[0];
+        var (parsedDomain, targetPlayerName, parseError) = ParseDomainAndPlayerArgs(args, 0);
+        if (parseError != null) return parseError;
 
         // Resolve target player
         var (targetPlayer, playerData, errorResult) = CommandHelpers.ResolveTargetPlayer(player, targetPlayerName,
@@ -485,7 +576,7 @@ public class FavorCommands
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
         var targetUID = targetPlayer?.PlayerUID ?? player.PlayerUID;
-        var targetDeity = _religionManager.GetPlayerActiveDeityDomain(targetUID);
+        var targetDeity = parsedDomain ?? _religionManager.GetPlayerActiveDeityDomain(targetUID);
         var oldFavor = playerData.GetFavor(targetDeity);
         playerData.SetFavor(targetDeity, 99999);
 
@@ -543,7 +634,8 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_TOTAL_EXCEEDS_MAX));
 
-        var targetPlayerArg = (string)args[1];
+        var (parsedDomain, targetPlayerArg, parseError) = ParseDomainAndPlayerArgs(args, 1);
+        if (parseError != null) return parseError;
 
         // Handle targeting another player
         if (targetPlayerArg != null)
@@ -570,7 +662,7 @@ public class FavorCommands
                 return TextCommandResult.Error(
                     LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_TARGET_NO_RELIGION));
 
-            var targetDeity = _religionManager.GetPlayerActiveDeityDomain(serverPlayer.PlayerUID);
+            var targetDeity = parsedDomain ?? _religionManager.GetPlayerActiveDeityDomain(serverPlayer.PlayerUID);
             var oldTotal = targetProgressionData.GetTotalFavorEarned(targetDeity);
             var oldRank = _playerProgressionDataManager.GetPlayerFavorRank(serverPlayer.PlayerUID, targetDeity);
 
@@ -589,7 +681,7 @@ public class FavorCommands
             return TextCommandResult.Error(
                 LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_ERROR_MUST_HAVE_RELIGION));
 
-        var callerDeity = _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
+        var callerDeity = parsedDomain ?? _religionManager.GetPlayerActiveDeityDomain(player.PlayerUID);
         var callerOldTotal = religionData.GetTotalFavorEarned(callerDeity);
         var callerOldRank = _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, callerDeity);
 

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -832,6 +832,8 @@ public static class LocalizationKeys
     public const string CMD_FAVOR_ERROR_TARGET_NO_RELIGION = "divineascension:cmd.favor.error.target_no_religion";
     public const string CMD_FAVOR_ERROR_TOTAL_NEGATIVE = "divineascension:cmd.favor.error.total_negative";
     public const string CMD_FAVOR_ERROR_TOTAL_EXCEEDS_MAX = "divineascension:cmd.favor.error.total_exceeds_max";
+    public const string CMD_FAVOR_ERROR_INVALID_DOMAIN = "divineascension:cmd.favor.error.invalid_domain";
+    public const string CMD_FAVOR_LABEL_PER_DEITY = "divineascension:cmd.favor.label.per_deity";
 
     // Success messages
     public const string CMD_FAVOR_SUCCESS_CHECK = "divineascension:cmd.favor.success.check";

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -524,6 +524,8 @@
   "divineascension:cmd.favor.error.target_no_religion": "Target must have a religion",
   "divineascension:cmd.favor.error.total_negative": "Total favor earned cannot be negative.",
   "divineascension:cmd.favor.error.total_exceeds_max": "Total favor earned cannot exceed 999,999.",
+  "divineascension:cmd.favor.error.invalid_domain": "Invalid deity domain '{0}'. Expected one of: Craft, Wild, Conquest, Harvest, Stone.",
+  "divineascension:cmd.favor.label.per_deity": "Per-deity favor:",
   "divineascension:cmd.favor.success.check": "You have {0} favor with {1} (Rank: {2})",
   "divineascension:cmd.favor.success.set": "Favor set to {0}{1}",
   "divineascension:cmd.favor.success.add": "Added {0} favor{1} ({2} → {3})",


### PR DESCRIPTION
## Summary
Pantheon 2.0 made favor per-deity (#237, #238) but the chat commands still operated through `IReligionManager.GetPlayerActiveDeityDomain` (= patron only). Admins couldn't grant, inspect, or reset favor for the four non-patron deities, and `/blessing list` only showed the patron tree.

This PR adds optional `[domain]` args via a smart-parse helper. Existing arg ordering is preserved — when the user omits the domain, behavior is unchanged (defaults to patron). No muscle-memory break for admins who don't care about non-patron domains.

Closes #251.

## New surface area

| Command | Signature |
|---|---|
| `/favor get / info / stats` | `[domain]` |
| `/favor set / add / remove / settotal` | `<amount> [domain_or_player] [other]` |
| `/favor reset / max` | `[domain_or_player] [other]` |
| `/blessing list` | `[domain]` |

`/favor stats` (no domain) now shows a per-deity favor summary for all five deities (was patron-only). Pass a domain to get the legacy single-deity detail view.

Smart-parse: `CommandHelpers.ParseDomainAndPlayer(arg1, arg2)` tries each arg as `DeityDomain` (case-insensitive, `None` rejected); leftover is the playername. So `/favor add 500 Wild`, `/favor add 500 PlayerX`, and `/favor add 500 PlayerX Wild` all work as expected.

## Files changed
- `DivineAscension/Commands/CommandHelpers.cs` — new `ParseDomainAndPlayer` helper.
- `DivineAscension/Commands/FavorCommands.cs` — parser slots + handlers; new `ResolveDeity` and `ParseDomainAndPlayerArgs` helpers; `OnFavorStats` restructured.
- `DivineAscension/Commands/BlessingCommands.cs` — `/blessing list [domain]` parser + handler.
- `DivineAscension/Constants/LocalizationKeys.cs` + `assets/divineascension/lang/en.json` — `CMD_FAVOR_ERROR_INVALID_DOMAIN`, `CMD_FAVOR_LABEL_PER_DEITY`.
- Tests: `CommandHelpersTests.cs` (7 cases), `FavorCommandDomainTests.cs` (5 cases), `FavorCommandStatsTests.cs` (1 existing test updated to explicitly pass `Craft` for the single-deity output).

## Out of scope
- Roster favor displays in `RoleCommands` and `ReligionCommands` — both show member favor via `religion.PatronDomain`. Acceptable for a single-line summary; revisit alongside the Phase 5 multi-deity HUD work if needed.
- `/favor resetcooldown` — unchanged (not favor-domain related).

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug`
- [x] `dotnet test` — 2117/2117 passing
- [x] Smart-parse covers: domain-only, player-only, both orderings, case-insensitive domain, `None` rejected as a domain
- [ ] In-game: `/favor add 500 Wild`, `/favor stats` (no arg) shows all five, `/blessing list Wild`