### PR TITLE
feat(pantheon): phase 5a HUD — multi-deity rank bars (#241)

### DIFF
--- a/DivineAscension.Tests/GUI/Managers/ReligionStateManagerHudTests.cs
+++ b/DivineAscension.Tests/GUI/Managers/ReligionStateManagerHudTests.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.GUI.Interfaces;
+using DivineAscension.GUI.Managers;
+using DivineAscension.GUI.State;
+using DivineAscension.Models.Enum;
+using DivineAscension.Systems.Interfaces;
+using Moq;
+using Vintagestory.API.Client;
+using Xunit;
+
+namespace DivineAscension.Tests.GUI.Managers;
+
+[ExcludeFromCodeCoverage]
+public class ReligionStateManagerHudTests
+{
+    private readonly ReligionStateManager _sut;
+
+    public ReligionStateManagerHudTests()
+    {
+        var api = new Mock<ICoreClientAPI>();
+        var ui = new Mock<IUiService>();
+        var sound = new Mock<ISoundManager>();
+        _sut = new ReligionStateManager(api.Object, ui.Object, sound.Object);
+    }
+
+    [Fact]
+    public void BuildHudViewModel_NoReligion_RendersFiveZeroBarsNoPatron()
+    {
+        var vm = _sut.BuildHudViewModel(1920, 1080, new RankProgressHudState());
+
+        Assert.True(vm.IsVisible);
+        Assert.False(vm.HasReligion);
+        Assert.Equal(DeityDomain.None, vm.PatronDomain);
+        Assert.Equal(5, vm.Deities.Count);
+        Assert.All(vm.Deities, s => Assert.False(s.IsPatron));
+        Assert.All(vm.Deities, s => Assert.Equal(0, s.TotalFavorEarned));
+        Assert.All(vm.Deities, s => Assert.Equal("Initiate", s.RankName));
+    }
+
+    [Fact]
+    public void BuildHudViewModel_WithReligion_PatronFlagOnlyOnPatronSlice()
+    {
+        _sut.Initialize("rel-1", DeityDomain.Wild, "Wolves");
+
+        var vm = _sut.BuildHudViewModel(1920, 1080, new RankProgressHudState());
+
+        Assert.True(vm.HasReligion);
+        Assert.Equal(DeityDomain.Wild, vm.PatronDomain);
+        var patron = vm.Deities.Single(s => s.IsPatron);
+        Assert.Equal(DeityDomain.Wild, patron.Domain);
+        Assert.Equal(4, vm.Deities.Count(s => !s.IsPatron));
+    }
+
+    [Fact]
+    public void BuildHudViewModel_FavorByDeity_DrivesCorrectSlice()
+    {
+        _sut.Initialize("rel-1", DeityDomain.Wild, "Wolves");
+        _sut.TotalFavorEarnedByDeity[DeityDomain.Wild] = 600;
+        _sut.FavorRanksByDeity[DeityDomain.Wild] = 1; // Disciple
+
+        var vm = _sut.BuildHudViewModel(1920, 1080, new RankProgressHudState());
+
+        var wild = vm.Deities.Single(s => s.Domain == DeityDomain.Wild);
+        Assert.Equal("Disciple", wild.RankName);
+        Assert.Equal("Zealot", wild.NextRankName);
+        Assert.Equal(600, wild.TotalFavorEarned);
+        Assert.Equal(2000, wild.FavorRequiredForNext);
+        Assert.Equal(0.30f, wild.Progress, 3);
+        Assert.False(wild.IsMaxRank);
+    }
+
+    [Fact]
+    public void BuildHudViewModel_MaxRank_ProgressOneAndMaxFlagTrue()
+    {
+        _sut.Initialize("rel-1", DeityDomain.Stone, "Granite");
+        _sut.TotalFavorEarnedByDeity[DeityDomain.Stone] = 15000;
+        _sut.FavorRanksByDeity[DeityDomain.Stone] = 4;
+
+        var vm = _sut.BuildHudViewModel(1920, 1080, new RankProgressHudState());
+
+        var stone = vm.Deities.Single(s => s.Domain == DeityDomain.Stone);
+        Assert.True(stone.IsMaxRank);
+        Assert.Equal(1.0f, stone.Progress);
+        Assert.Equal("Avatar", stone.RankName);
+    }
+
+    [Fact]
+    public void BuildHudViewModel_FavorRankMissing_DerivedFromTotalFavor()
+    {
+        _sut.TotalFavorEarnedByDeity[DeityDomain.Craft] = 2500; // Zealot (>= 2000)
+
+        var vm = _sut.BuildHudViewModel(1920, 1080, new RankProgressHudState());
+
+        var craft = vm.Deities.Single(s => s.Domain == DeityDomain.Craft);
+        Assert.Equal("Zealot", craft.RankName);
+    }
+
+    [Fact]
+    public void BuildHudViewModel_CollapsedToPatron_StateFlagPropagates()
+    {
+        _sut.Initialize("rel-1", DeityDomain.Wild, "Wolves");
+        var state = new RankProgressHudState { CollapsedToPatron = true };
+
+        var vm = _sut.BuildHudViewModel(1920, 1080, state);
+
+        Assert.True(vm.CollapsedToPatron);
+        Assert.Equal(5, vm.Deities.Count); // viewmodel still carries all 5; renderer filters
+    }
+
+    [Fact]
+    public void BuildHudViewModel_DeityOrderIsStable()
+    {
+        var vm = _sut.BuildHudViewModel(1920, 1080, new RankProgressHudState());
+
+        var order = vm.Deities.Select(s => s.Domain).ToArray();
+        Assert.Equal(new[]
+        {
+            DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
+            DeityDomain.Harvest, DeityDomain.Stone
+        }, order);
+    }
+}

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -95,6 +95,11 @@ public partial class GuiDialog : ModSystem
             HotkeyType.GUIOrOtherControls, shiftPressed: true);
         _inputService.SetHotKeyHandler("divineascensionblessings", OnToggleDialog);
 
+        // Collapse rank HUD to patron-only (Shift+H)
+        _inputService.RegisterHotKey("divineascensionhudcollapse", "Collapse Rank HUD to Patron", GlKeys.H,
+            HotkeyType.GUIOrOtherControls, shiftPressed: true);
+        _inputService.SetHotKeyHandler("divineascensionhudcollapse", OnToggleHudCollapse);
+
         // Initialize icon loaders
         DeityIconLoader.Initialize(_capi);
         GuiIconLoader.Initialize(_capi);
@@ -331,7 +336,8 @@ public partial class GuiDialog : ModSystem
         // Build view model from current state
         var vm = _manager.ReligionStateManager.BuildHudViewModel(
             _viewport.Size.X,
-            _viewport.Size.Y);
+            _viewport.Size.Y,
+            _state.HudState);
 
         // If player doesn't have a religion, don't show HUD
         if (!vm.IsVisible)
@@ -342,7 +348,7 @@ public partial class GuiDialog : ModSystem
         // Debug: Log first time HUD is drawn
         if (!_hudDrawnOnce)
         {
-            _logger?.Debug($"[DivineAscension] HUD drawing - Screen: {_viewport.Size.X}x{_viewport.Size.Y}, Favor: {vm.SpendableFavor}, Rank: {vm.FavorRankName}");
+            _logger?.Debug($"[DivineAscension] HUD drawing - Screen: {_viewport.Size.X}x{_viewport.Size.Y}, Favor: {vm.SpendableFavor}, Patron: {vm.PatronDomain}");
             _hudDrawnOnce = true;
         }
 

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -226,6 +226,15 @@ public partial class GuiDialog
     }
 
     /// <summary>
+    ///     Keybind handler - toggle HUD collapse-to-patron view
+    /// </summary>
+    private bool OnToggleHudCollapse(KeyCombination keyCombination)
+    {
+        _state.HudState.CollapsedToPatron = !_state.HudState.CollapsedToPatron;
+        return true;
+    }
+
+    /// <summary>
     ///     Handle religion list received from server
     /// </summary>
     private void OnReligionListReceived(ReligionListResponsePacket packet)

--- a/DivineAscension/GUI/Managers/ReligionStateManager.cs
+++ b/DivineAscension/GUI/Managers/ReligionStateManager.cs
@@ -157,32 +157,37 @@ public class ReligionStateManager : IReligionStateManager
     }
 
     /// <summary>
+    ///     Stable render order for deity rows in the HUD.
+    /// </summary>
+    public static readonly DeityDomain[] HudDeityOrder =
+    {
+        DeityDomain.Craft,
+        DeityDomain.Wild,
+        DeityDomain.Conquest,
+        DeityDomain.Harvest,
+        DeityDomain.Stone
+    };
+
+    /// <summary>
     ///     Build the HUD view model from current state
     /// </summary>
-    /// <param name="screenWidth">Screen width for positioning</param>
-    /// <param name="screenHeight">Screen height for positioning</param>
-    /// <returns>View model for the rank progress HUD overlay</returns>
-    public Models.Hud.RankProgressHudViewModel BuildHudViewModel(float screenWidth, float screenHeight)
+    public Models.Hud.RankProgressHudViewModel BuildHudViewModel(
+        float screenWidth,
+        float screenHeight,
+        RankProgressHudState hudState)
     {
-        var favorProgress = GetPlayerFavorProgress();
         var prestigeProgress = GetReligionPrestigeProgress();
-
-        // Calculate progress percentages
-        var favorPct = favorProgress.IsMaxRank || favorProgress.RequiredFavor <= 0
-            ? 1.0f
-            : Math.Clamp((float)favorProgress.CurrentFavor / favorProgress.RequiredFavor, 0f, 1f);
-
         var prestigePct = prestigeProgress.IsMaxRank || prestigeProgress.RequiredPrestige <= 0
             ? 1.0f
             : Math.Clamp((float)prestigeProgress.CurrentPrestige / prestigeProgress.RequiredPrestige, 0f, 1f);
 
+        var hasReligion = HasReligion();
+        var slices = new List<Models.Hud.DeityRankSlice>(HudDeityOrder.Length);
+        foreach (var domain in HudDeityOrder)
+            slices.Add(BuildDeitySlice(domain, hasReligion));
+
         return new Models.Hud.RankProgressHudViewModel(
-            FavorRankName: RankRequirements.GetFavorRankName(CurrentFavorRank),
-            NextFavorRankName: RankRequirements.GetFavorRankName(CurrentFavorRank + 1),
-            TotalFavorEarned: TotalFavorEarned,
-            FavorRequiredForNext: favorProgress.RequiredFavor,
-            FavorProgress: favorPct,
-            IsFavorMaxRank: favorProgress.IsMaxRank,
+            Deities: slices,
             PrestigeRankName: RankRequirements.GetPrestigeRankName(CurrentPrestigeRank),
             NextPrestigeRankName: RankRequirements.GetPrestigeRankName(CurrentPrestigeRank + 1),
             CurrentPrestige: CurrentPrestige,
@@ -190,10 +195,44 @@ public class ReligionStateManager : IReligionStateManager
             PrestigeProgress: prestigePct,
             IsPrestigeMaxRank: prestigeProgress.IsMaxRank,
             SpendableFavor: CurrentFavor,
+            PatronDomain: hasReligion ? CurrentReligionDomain : DeityDomain.None,
+            HasReligion: hasReligion,
+            CollapsedToPatron: hudState.CollapsedToPatron,
             ScreenWidth: screenWidth,
             ScreenHeight: screenHeight,
-            IsVisible: HasReligion()
+            IsVisible: true
         );
+    }
+
+    private Models.Hud.DeityRankSlice BuildDeitySlice(DeityDomain domain, bool hasReligion)
+    {
+        var totalFavor = TotalFavorEarnedByDeity.GetValueOrDefault(domain);
+        var rank = FavorRanksByDeity.TryGetValue(domain, out var r) ? r : ComputeRank(totalFavor);
+        var required = RankRequirements.GetRequiredFavorForNextRank(
+            rank, DiscipleThreshold, ZealotThreshold, ChampionThreshold, AvatarThreshold);
+        var isMax = rank >= 4;
+        var progress = isMax || required <= 0
+            ? 1.0f
+            : Math.Clamp((float)totalFavor / required, 0f, 1f);
+
+        return new Models.Hud.DeityRankSlice(
+            Domain: domain,
+            RankName: RankRequirements.GetFavorRankName(rank),
+            NextRankName: RankRequirements.GetFavorRankName(rank + 1),
+            TotalFavorEarned: totalFavor,
+            FavorRequiredForNext: required,
+            Progress: progress,
+            IsMaxRank: isMax,
+            IsPatron: hasReligion && domain == CurrentReligionDomain);
+    }
+
+    private int ComputeRank(int totalFavor)
+    {
+        if (totalFavor >= AvatarThreshold) return 4;
+        if (totalFavor >= ChampionThreshold) return 3;
+        if (totalFavor >= ZealotThreshold) return 2;
+        if (totalFavor >= DiscipleThreshold) return 1;
+        return 0;
     }
 
     public void RequestReligionList(string? deityFilter = "")

--- a/DivineAscension/GUI/Models/Hud/RankProgressHudViewModel.cs
+++ b/DivineAscension/GUI/Models/Hud/RankProgressHudViewModel.cs
@@ -1,31 +1,26 @@
+using System.Collections.Generic;
+using DivineAscension.Models.Enum;
+
 namespace DivineAscension.GUI.Models.Hud;
 
 /// <summary>
-///     Immutable view model containing all display data for the rank progress HUD overlay
+///     Per-deity slice rendered as a single bar in the rank HUD.
 /// </summary>
-/// <param name="FavorRankName">Current favor rank display name (e.g., "Disciple")</param>
-/// <param name="NextFavorRankName">Next favor rank display name (e.g., "Zealot")</param>
-/// <param name="TotalFavorEarned">Total lifetime favor earned</param>
-/// <param name="FavorRequiredForNext">Favor required to reach next rank</param>
-/// <param name="FavorProgress">Progress percentage towards next rank (0.0 to 1.0)</param>
-/// <param name="IsFavorMaxRank">Whether player is at max favor rank (Avatar)</param>
-/// <param name="PrestigeRankName">Current religion prestige rank display name (e.g., "Established")</param>
-/// <param name="NextPrestigeRankName">Next prestige rank display name (e.g., "Renowned")</param>
-/// <param name="CurrentPrestige">Current religion prestige points</param>
-/// <param name="PrestigeRequiredForNext">Prestige required for next rank</param>
-/// <param name="PrestigeProgress">Progress percentage towards next prestige rank (0.0 to 1.0)</param>
-/// <param name="IsPrestigeMaxRank">Whether religion is at max prestige rank (Mythic)</param>
-/// <param name="SpendableFavor">Current spendable favor balance</param>
-/// <param name="ScreenWidth">Screen width for positioning</param>
-/// <param name="ScreenHeight">Screen height for positioning</param>
-/// <param name="IsVisible">Whether the HUD should be displayed</param>
-public readonly record struct RankProgressHudViewModel(
-    string FavorRankName,
-    string NextFavorRankName,
+public readonly record struct DeityRankSlice(
+    DeityDomain Domain,
+    string RankName,
+    string NextRankName,
     int TotalFavorEarned,
     int FavorRequiredForNext,
-    float FavorProgress,
-    bool IsFavorMaxRank,
+    float Progress,
+    bool IsMaxRank,
+    bool IsPatron);
+
+/// <summary>
+///     Immutable view model for the rank progress HUD overlay (multi-deity).
+/// </summary>
+public readonly record struct RankProgressHudViewModel(
+    IReadOnlyList<DeityRankSlice> Deities,
     string PrestigeRankName,
     string NextPrestigeRankName,
     int CurrentPrestige,
@@ -33,6 +28,9 @@ public readonly record struct RankProgressHudViewModel(
     float PrestigeProgress,
     bool IsPrestigeMaxRank,
     int SpendableFavor,
+    DeityDomain PatronDomain,
+    bool HasReligion,
+    bool CollapsedToPatron,
     float ScreenWidth,
     float ScreenHeight,
     bool IsVisible);

--- a/DivineAscension/GUI/State/RankProgressHudState.cs
+++ b/DivineAscension/GUI/State/RankProgressHudState.cs
@@ -11,10 +11,16 @@ public class RankProgressHudState
     public bool IsVisible { get; set; }
 
     /// <summary>
+    ///     When true, render only the patron deity row instead of all five.
+    /// </summary>
+    public bool CollapsedToPatron { get; set; }
+
+    /// <summary>
     ///     Reset state to defaults
     /// </summary>
     public void Reset()
     {
         IsVisible = false;
+        CollapsedToPatron = false;
     }
 }

--- a/DivineAscension/GUI/UI/Components/Overlays/RankProgressHudOverlay.cs
+++ b/DivineAscension/GUI/UI/Components/Overlays/RankProgressHudOverlay.cs
@@ -3,147 +3,161 @@ using System.Numerics;
 using DivineAscension.GUI.Models.Hud;
 using DivineAscension.GUI.UI.Renderers.Components;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
 using ImGuiNET;
 
 namespace DivineAscension.GUI.UI.Components.Overlays;
 
 /// <summary>
-///     Renders the persistent rank progress HUD overlay in the bottom-right corner
+///     Renders the persistent rank progress HUD overlay in the bottom-right corner.
+///     Multi-deity: stacked mini-bars per deity, patron highlighted, plus prestige + balance.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal static class RankProgressHudOverlay
 {
-    private const float PanelWidth = 220f;
-    private const float PanelHeight = 85f;
+    private const float PanelWidth = 240f;
     private const float EdgeMargin = 20f;
     private const float Padding = 10f;
-    private const float ProgressBarHeight = 16f;
-    private const float RowSpacing = 6f;
-    private const float LabelFontSize = 12f;
+    private const float DeityBarHeight = 12f;
+    private const float PrestigeBarHeight = 16f;
+    private const float RowSpacing = 4f;
+    private const float SectionSpacing = 6f;
+    private const float BalanceRowHeight = 16f;
     private const float FavorFontSize = 14f;
+    private const float PatronBorderThickness = 2f;
 
-    /// <summary>
-    ///     Draw the rank progress HUD overlay
-    /// </summary>
-    /// <param name="vm">View model containing display data</param>
     internal static void Draw(RankProgressHudViewModel vm)
     {
         if (!vm.IsVisible) return;
 
-        // Use window draw list (requires ImGui window context)
         var drawList = ImGui.GetWindowDrawList();
         var winPos = ImGui.GetWindowPos();
 
-        // Calculate panel position (bottom-right corner, offset by window position)
-        var panelX = winPos.X + vm.ScreenWidth - PanelWidth - EdgeMargin;
-        var panelY = winPos.Y + vm.ScreenHeight - PanelHeight - EdgeMargin;
+        var collapsed = vm.CollapsedToPatron && vm.PatronDomain != DeityDomain.None;
+        var deityRowCount = collapsed ? 1 : vm.Deities.Count;
 
-        // Draw panel background with rounded corners
+        var panelHeight = (Padding * 2)
+                         + (deityRowCount * DeityBarHeight) + ((deityRowCount - 1) * RowSpacing)
+                         + (vm.HasReligion ? SectionSpacing + PrestigeBarHeight : 0)
+                         + SectionSpacing + BalanceRowHeight;
+
+        var panelX = winPos.X + vm.ScreenWidth - PanelWidth - EdgeMargin;
+        var panelY = winPos.Y + vm.ScreenHeight - panelHeight - EdgeMargin;
+
         var panelMin = new Vector2(panelX, panelY);
-        var panelMax = new Vector2(panelX + PanelWidth, panelY + PanelHeight);
+        var panelMax = new Vector2(panelX + PanelWidth, panelY + panelHeight);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Background, 0.9f));
         drawList.AddRectFilled(panelMin, panelMax, bgColor, 6f);
-
-        // Draw panel border
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
         drawList.AddRect(panelMin, panelMax, borderColor, 6f, ImDrawFlags.None, 1.5f);
 
-        // Track current Y position for layout
-        var currentY = panelY + Padding;
         var contentX = panelX + Padding;
         var contentWidth = PanelWidth - (Padding * 2);
+        var currentY = panelY + Padding;
 
-        // --- Favor Rank Progress ---
-        DrawRankProgressRow(
-            drawList,
-            contentX,
-            currentY,
-            contentWidth,
-            vm.FavorRankName,
-            vm.TotalFavorEarned,
-            vm.FavorRequiredForNext,
-            vm.FavorProgress,
-            vm.IsFavorMaxRank,
-            ColorPalette.Gold);
-
-        currentY += ProgressBarHeight + RowSpacing;
-
-        // --- Prestige Progress ---
-        DrawRankProgressRow(
-            drawList,
-            contentX,
-            currentY,
-            contentWidth,
-            vm.PrestigeRankName,
-            vm.CurrentPrestige,
-            vm.PrestigeRequiredForNext,
-            vm.PrestigeProgress,
-            vm.IsPrestigeMaxRank,
-            new Vector4(0.6f, 0.4f, 0.8f, 1.0f)); // Purple for prestige
-
-        currentY += ProgressBarHeight + RowSpacing;
-
-        // --- Spendable Favor Balance ---
-        DrawFavorBalance(drawList, contentX, currentY, vm.SpendableFavor);
-    }
-
-    /// <summary>
-    ///     Draw a single rank progress row with label and progress bar
-    /// </summary>
-    private static void DrawRankProgressRow(
-        ImDrawListPtr drawList,
-        float x,
-        float y,
-        float width,
-        string rankName,
-        int current,
-        int required,
-        float progress,
-        bool isMaxRank,
-        Vector4 fillColor)
-    {
-        // Build progress label text
-        string labelText;
-        if (isMaxRank)
+        if (collapsed)
         {
-            labelText = $"{rankName} (MAX)";
+            foreach (var slice in vm.Deities)
+            {
+                if (slice.Domain != vm.PatronDomain) continue;
+                DrawDeityRow(drawList, contentX, currentY, contentWidth, slice);
+                currentY += DeityBarHeight;
+                break;
+            }
         }
         else
         {
-            labelText = $"{rankName} ({current:N0}/{required:N0})";
+            for (var i = 0; i < vm.Deities.Count; i++)
+            {
+                if (i > 0) currentY += RowSpacing;
+                DrawDeityRow(drawList, contentX, currentY, contentWidth, vm.Deities[i]);
+                currentY += DeityBarHeight;
+            }
         }
 
-        // Draw progress bar with label
+        if (vm.HasReligion)
+        {
+            currentY += SectionSpacing;
+            DrawPrestigeRow(drawList, contentX, currentY, contentWidth, vm);
+            currentY += PrestigeBarHeight;
+        }
+
+        currentY += SectionSpacing;
+        DrawFavorBalance(drawList, contentX, currentY, vm.SpendableFavor);
+    }
+
+    private static void DrawDeityRow(
+        ImDrawListPtr drawList, float x, float y, float width, DeityRankSlice slice)
+    {
+        var prefix = DomainPrefix(slice.Domain);
+        var label = slice.IsMaxRank
+            ? $"{prefix} {slice.RankName} (MAX)"
+            : $"{prefix} {slice.RankName} ({slice.TotalFavorEarned:N0}/{slice.FavorRequiredForNext:N0})";
+
         ProgressBarRenderer.DrawProgressBar(
             drawList,
-            x, y, width, ProgressBarHeight,
-            progress,
-            fillColor,
+            x, y, width, DeityBarHeight,
+            slice.Progress,
+            DomainColor(slice.Domain),
             ColorPalette.DarkBrown,
-            labelText,
-            showGlow: progress > 0.8f);
+            label,
+            showGlow: slice.Progress > 0.8f);
+
+        if (slice.IsPatron)
+        {
+            var min = new Vector2(x - 1, y - 1);
+            var max = new Vector2(x + width + 1, y + DeityBarHeight + 1);
+            var border = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
+            drawList.AddRect(min, max, border, 4f, ImDrawFlags.None, PatronBorderThickness);
+        }
     }
 
-    /// <summary>
-    ///     Draw the spendable favor balance row
-    /// </summary>
-    private static void DrawFavorBalance(
-        ImDrawListPtr drawList,
-        float x,
-        float y,
-        int spendableFavor)
+    private static void DrawPrestigeRow(
+        ImDrawListPtr drawList, float x, float y, float width, RankProgressHudViewModel vm)
     {
-        // Draw coin icon (simple circle as placeholder)
-        var iconRadius = 6f;
-        var iconCenterX = x + iconRadius;
-        var iconCenterY = y + iconRadius;
-        var coinColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        drawList.AddCircleFilled(new Vector2(iconCenterX, iconCenterY), iconRadius, coinColor);
+        var label = vm.IsPrestigeMaxRank
+            ? $"+ {vm.PrestigeRankName} (MAX)"
+            : $"+ {vm.PrestigeRankName} ({vm.CurrentPrestige:N0}/{vm.PrestigeRequiredForNext:N0})";
 
-        // Draw favor amount text
+        ProgressBarRenderer.DrawProgressBar(
+            drawList,
+            x, y, width, PrestigeBarHeight,
+            vm.PrestigeProgress,
+            new Vector4(0.6f, 0.4f, 0.8f, 1.0f),
+            ColorPalette.DarkBrown,
+            label,
+            showGlow: vm.PrestigeProgress > 0.8f);
+    }
+
+    private static void DrawFavorBalance(ImDrawListPtr drawList, float x, float y, int spendableFavor)
+    {
+        const float iconRadius = 6f;
+        var iconCenter = new Vector2(x + iconRadius, y + iconRadius);
+        var coinColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
+        drawList.AddCircleFilled(iconCenter, iconRadius, coinColor);
+
         var textX = x + (iconRadius * 2) + 6f;
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
-        var favorText = $"{spendableFavor:N0}";
-        drawList.AddText(ImGui.GetFont(), FavorFontSize, new Vector2(textX, y), textColor, favorText);
+        drawList.AddText(ImGui.GetFont(), FavorFontSize, new Vector2(textX, y), textColor, $"{spendableFavor:N0}");
     }
+
+    private static string DomainPrefix(DeityDomain domain) => domain switch
+    {
+        DeityDomain.Craft => "C",
+        DeityDomain.Wild => "W",
+        DeityDomain.Conquest => "Q",
+        DeityDomain.Harvest => "H",
+        DeityDomain.Stone => "S",
+        _ => "?"
+    };
+
+    private static Vector4 DomainColor(DeityDomain domain) => domain switch
+    {
+        DeityDomain.Craft => new Vector4(0.85f, 0.55f, 0.20f, 1.0f),
+        DeityDomain.Wild => new Vector4(0.30f, 0.70f, 0.35f, 1.0f),
+        DeityDomain.Conquest => new Vector4(0.80f, 0.25f, 0.25f, 1.0f),
+        DeityDomain.Harvest => new Vector4(0.95f, 0.80f, 0.30f, 1.0f),
+        DeityDomain.Stone => new Vector4(0.55f, 0.55f, 0.60f, 1.0f),
+        _ => ColorPalette.Grey
+    };
 }

--- a/DivineAscension/Systems/Favor/ConquestFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/ConquestFavorTracker.cs
@@ -37,9 +37,20 @@ public class ConquestFavorTracker(
 
     private TagSetFast? _hostileTags;
 
-    private TagSetFast HostileTags =>
-        _hostileTags ??= _worldService.World.Api.EntityTagRegistry.CreateTagSet(
-            ["hostile", "monster", "drifter", "locust"]);
+    private TagSetFast HostileTags
+    {
+        get
+        {
+            if (_hostileTags is { } cached) return cached;
+            // VS 1.22 tag names: drifters carry "rust-creature", locusts/bosses carry "mechanical".
+            // No generic "hostile"/"monster" tags exist. TryCreateTagSet populates partial sets on unknown
+            // names instead of throwing, so future asset renames don't stall the death event tick.
+            _worldService.World.Api.EntityTagRegistry.TryCreateTagSetAndLogIssues(
+                out TagSetFast set, "rust-creature", "mechanical");
+            _hostileTags = set;
+            return set;
+        }
+    }
 
     public void Dispose()
     {


### PR DESCRIPTION
## Summary
- Renders all five deity favor bars in the rank HUD (Craft, Wild, Conquest, Harvest, Stone) with patron-deity highlighted by a gold border; prestige + spendable favor stay below.
- Adds **Shift+H** to collapse the HUD to the patron row only; no-religion players see five zeroed bars (no patron border, prestige row hidden).
- Drive-by fix: `ConquestFavorTracker` was calling `EntityTagRegistry.CreateTagSet(["hostile","monster","drifter","locust"])`, none of which exist in VS 1.22. The throw fired on every entity death and stalled the server tick (~29s). Now uses `TryCreateTagSetAndLogIssues` with the real names `"rust-creature"` and `"mechanical"`.

Closes #241.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` — clean.
- [x] `dotnet test` — 2125/2125 (7 new `ReligionStateManagerHudTests`).
- [ ] Manual playtest (VS launch): five bars render with no religion; create a Wild religion → Wild bar gets gold border on next favor tick; hunt a deer + mine stone in one session → Wild and Stone bars both advance, Wild ~1.5× faster (patron multiplier); Shift+H collapses to patron only; leave religion → patron border clears next favor tick; kill a drifter → Conquest bar advances, no server-tick stall.