### PR TITLE
feat(pantheon): phase 5b — blessing UI navigates all five deities (#244)

### DIFF
--- a/DivineAscension.Tests/GUI/Managers/BlessingStateManagerPantheonTests.cs
+++ b/DivineAscension.Tests/GUI/Managers/BlessingStateManagerPantheonTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.GUI.Interfaces;
+using DivineAscension.GUI.Managers;
+using DivineAscension.Models;
+using DivineAscension.Models.Enum;
+using DivineAscension.Systems.Interfaces;
+using Moq;
+using Vintagestory.API.Client;
+using Xunit;
+
+namespace DivineAscension.Tests.GUI.Managers;
+
+[ExcludeFromCodeCoverage]
+public class BlessingStateManagerPantheonTests
+{
+    private readonly BlessingStateManager _sut;
+
+    public BlessingStateManagerPantheonTests()
+    {
+        var api = new Mock<ICoreClientAPI>();
+        var ui = new Mock<IUiService>();
+        var sound = new Mock<ISoundManager>();
+        _sut = new BlessingStateManager(api.Object, ui.Object, sound.Object);
+    }
+
+    private static Blessing B(string id, DeityDomain domain, BlessingKind kind = BlessingKind.Player,
+        bool requiresPatron = false, int cost = 10)
+    {
+        return new Blessing
+        {
+            BlessingId = id,
+            Name = id,
+            Domain = domain,
+            Kind = kind,
+            RequiresPatron = requiresPatron,
+            Cost = cost,
+            PrerequisiteBlessings = new List<string>()
+        };
+    }
+
+    [Fact]
+    public void LoadBlessingStates_PopulatesAllFiveDeityBuckets()
+    {
+        var players = new List<Blessing>
+        {
+            B("c1", DeityDomain.Craft),
+            B("w1", DeityDomain.Wild),
+            B("q1", DeityDomain.Conquest),
+            B("h1", DeityDomain.Harvest),
+            B("s1", DeityDomain.Stone)
+        };
+        var religion = new List<Blessing>
+        {
+            B("rc1", DeityDomain.Craft, BlessingKind.Religion),
+            B("rw1", DeityDomain.Wild, BlessingKind.Religion)
+        };
+
+        _sut.LoadBlessingStates(players, religion);
+
+        Assert.Equal(5, _sut.State.PlayerBlessingStatesByDeity.Count);
+        foreach (var domain in new[] { DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone })
+            Assert.Single(_sut.State.PlayerBlessingStatesByDeity[domain]);
+        Assert.Single(_sut.State.ReligionBlessingStatesByDeity[DeityDomain.Craft]);
+        Assert.Single(_sut.State.ReligionBlessingStatesByDeity[DeityDomain.Wild]);
+        Assert.Empty(_sut.State.ReligionBlessingStatesByDeity[DeityDomain.Stone]);
+    }
+
+    [Fact]
+    public void RefreshAllBlessingStates_NonPatronCostMultiplier_AppliedPerDeity()
+    {
+        _sut.LoadBlessingStates(new List<Blessing>
+        {
+            B("craft", DeityDomain.Craft),
+            B("wild", DeityDomain.Wild)
+        }, new List<Blessing>());
+
+        var ranks = new Dictionary<DeityDomain, int>();
+        _sut.RefreshAllBlessingStates(ranks, 0, DeityDomain.Wild);
+
+        var craft = _sut.State.PlayerBlessingStatesByDeity[DeityDomain.Craft]["craft"];
+        var wild = _sut.State.PlayerBlessingStatesByDeity[DeityDomain.Wild]["wild"];
+        Assert.Equal(1.5f, craft.NonPatronCostMultiplier);
+        Assert.Equal(1.0f, wild.NonPatronCostMultiplier);
+    }
+
+    [Fact]
+    public void RefreshAllBlessingStates_RequiresPatronCapstone_LockedOnNonPatron()
+    {
+        _sut.LoadBlessingStates(new List<Blessing>
+        {
+            B("avatar_of_craft", DeityDomain.Craft, requiresPatron: true)
+        }, new List<Blessing>());
+
+        // Patron is Wild, so the Craft capstone must stay locked even with maxed Craft rank.
+        var ranks = new Dictionary<DeityDomain, int> { [DeityDomain.Craft] = 4 };
+        _sut.RefreshAllBlessingStates(ranks, 0, DeityDomain.Wild);
+
+        var capstone = _sut.State.PlayerBlessingStatesByDeity[DeityDomain.Craft]["avatar_of_craft"];
+        Assert.False(capstone.CanUnlock);
+    }
+
+    [Fact]
+    public void RequiresPatronCapstone_UnlockableWhenPatronMatches()
+    {
+        _sut.LoadBlessingStates(new List<Blessing>
+        {
+            B("avatar_of_wild", DeityDomain.Wild, requiresPatron: true)
+        }, new List<Blessing>());
+
+        var ranks = new Dictionary<DeityDomain, int> { [DeityDomain.Wild] = 4 };
+        _sut.RefreshAllBlessingStates(ranks, 0, DeityDomain.Wild);
+
+        var capstone = _sut.State.PlayerBlessingStatesByDeity[DeityDomain.Wild]["avatar_of_wild"];
+        Assert.True(capstone.CanUnlock);
+    }
+
+    [Fact]
+    public void SetActiveDeity_SwapsActiveAndResetsSelection()
+    {
+        _sut.LoadBlessingStates(new List<Blessing>
+        {
+            B("craft", DeityDomain.Craft),
+            B("wild", DeityDomain.Wild)
+        }, new List<Blessing>());
+        _sut.SetActiveDeity(DeityDomain.Craft);
+        _sut.SelectBlessing("craft");
+        Assert.Equal("craft", _sut.State.TreeState.SelectedBlessingId);
+
+        _sut.SetActiveDeity(DeityDomain.Wild);
+
+        Assert.Equal(DeityDomain.Wild, _sut.State.ActiveDeity);
+        Assert.Null(_sut.State.TreeState.SelectedBlessingId);
+        Assert.Single(_sut.ActivePlayerBlessings);
+        Assert.True(_sut.ActivePlayerBlessings.ContainsKey("wild"));
+    }
+
+    [Fact]
+    public void SetActiveDeity_DoesNotResetUnlockedFlags()
+    {
+        _sut.LoadBlessingStates(new List<Blessing> { B("craft", DeityDomain.Craft) }, new List<Blessing>());
+        _sut.SetBlessingUnlocked("craft", true);
+
+        _sut.SetActiveDeity(DeityDomain.Wild);
+        _sut.SetActiveDeity(DeityDomain.Craft);
+
+        Assert.True(_sut.ActivePlayerBlessings["craft"].IsUnlocked);
+    }
+
+    [Fact]
+    public void ActiveBlessings_EmptyWhenDeityHasNone()
+    {
+        _sut.LoadBlessingStates(new List<Blessing> { B("craft", DeityDomain.Craft) }, new List<Blessing>());
+
+        _sut.SetActiveDeity(DeityDomain.Stone);
+
+        Assert.Empty(_sut.ActivePlayerBlessings);
+        Assert.Empty(_sut.ActiveReligionBlessings);
+    }
+}

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -46,6 +46,8 @@ public static class LocalizationKeys
     public const string UI_RELIGION_NAME_ERROR_TOO_LONG = "divineascension:ui.religion.name.error.too_long";
     public const string UI_RELIGION_NAME_ERROR_PROFANITY = "divineascension:ui.religion.name.error.profanity";
     public const string UI_RELIGION_DOMAIN_LABEL = "divineascension:ui.religion.domain.label";
+    public const string UI_RELIGION_PATRON_HEADING = "divineascension:ui.religion.patron.heading";
+    public const string UI_RELIGION_PATRON_EXPLAINER = "divineascension:ui.religion.patron.explainer";
     public const string UI_RELIGION_DEITY_NAME_LABEL = "divineascension:ui.religion.deity_name.label";
     public const string UI_RELIGION_DEITY_NAME_PLACEHOLDER = "divineascension:ui.religion.deity_name.placeholder";
 

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -103,18 +103,19 @@ public partial class GuiDialog
 
         var playerBlessings = packet.PlayerBlessings.Select(p => ToModel(p, BlessingKind.Player)).ToList();
         var religionBlessings = packet.ReligionBlessings.Select(p => ToModel(p, BlessingKind.Religion)).ToList();
-        // Pre-Phase-5 single-tree UI still renders one deity; filter to patron.
-        var patronPlayerBlessings = playerBlessings.Where(b => b.Domain == patron).ToList();
-        var patronReligionBlessings = religionBlessings.Where(b => b.Domain == patron).ToList();
 
-        // Load blessing states into manager (single-tree UI consumes patron deity only for now)
-        _manager.BlessingStateManager.LoadBlessingStates(patronPlayerBlessings, patronReligionBlessings);
+        // Phase 5b: load all five deities; UI switches via deity selector.
+        _manager.BlessingStateManager.LoadBlessingStates(playerBlessings, religionBlessings);
+        _manager.BlessingStateManager.SetActiveDeity(
+            patron != DeityDomain.None ? patron : DeityDomain.Craft);
 
-        // Preload blessing textures for the patron deity domain to prevent stuttering on first render
-        var allBlessings = patronPlayerBlessings.Concat(patronReligionBlessings).ToList();
+        // Preload blessing textures for every deity to prevent stuttering when switching tabs.
+        var allBlessings = playerBlessings.Concat(religionBlessings).ToList();
+        foreach (var domain in new[] { DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone })
+            BlessingIconLoader.PreloadDeityTextures(
+                allBlessings.Where(b => b.Domain == domain).ToList(), domain);
         _logger?.Debug(
-            $"[DivineAscension] Preloading {allBlessings.Count} blessing textures for {patron}...");
-        BlessingIconLoader.PreloadDeityTextures(allBlessings, patron);
+            $"[DivineAscension] Preloaded blessing textures for all five deities ({allBlessings.Count} blessings total).");
 
         // Mark unlocked blessings
         foreach (var blessingId in packet.UnlockedPlayerBlessings)
@@ -141,7 +142,7 @@ public partial class GuiDialog
 
         _state.IsReady = true;
         _logger?.Notification(
-            $"[DivineAscension] Loaded {patronPlayerBlessings.Count} player blessings and {patronReligionBlessings.Count} religion blessings for {patron}");
+            $"[DivineAscension] Loaded {playerBlessings.Count} player + {religionBlessings.Count} religion blessings across all five deities; active={patron}");
 
         // Ensure HUD is visible now that we have religion data
         EnsureHudVisible();

--- a/DivineAscension/GUI/Managers/BlessingStateManager.cs
+++ b/DivineAscension/GUI/Managers/BlessingStateManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using DivineAscension.GUI.Events.Blessing;
 using DivineAscension.GUI.Interfaces;
 using DivineAscension.GUI.Models.Blessing.Tab;
+using DivineAscension.Systems;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.UI.Renderers.Blessing;
 using DivineAscension.Models;
@@ -17,6 +18,11 @@ namespace DivineAscension.GUI.Managers;
 /// </summary>
 public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISoundManager soundManager)
 {
+    private static readonly DeityDomain[] AllDeities =
+    {
+        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone
+    };
+
     private readonly ICoreClientAPI _coreClientApi = api ?? throw new ArgumentNullException(nameof(api));
 
     private readonly ISoundManager
@@ -26,22 +32,40 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
 
     public BlessingTabState State { get; } = new();
 
-    /// <summary>
-    ///     Branches the player has committed to, keyed by domain (as int)
-    /// </summary>
     private Dictionary<int, string> _committedBranches = new();
-
-    /// <summary>
-    ///     Branches that are locked out due to exclusive branch choices, keyed by domain (as int)
-    /// </summary>
     private Dictionary<int, List<string>> _lockedBranches = new();
 
     /// <summary>
-    ///     Draws the blessings tab and processes all events
+    ///     Player blessings for the currently active deity tab. Empty dict if none loaded.
     /// </summary>
+    public IReadOnlyDictionary<string, BlessingNodeState> ActivePlayerBlessings =>
+        State.PlayerBlessingStatesByDeity.TryGetValue(State.ActiveDeity, out var d)
+            ? d
+            : EmptyStates;
+
+    /// <summary>
+    ///     Religion blessings for the currently active deity tab. Empty dict if none loaded.
+    /// </summary>
+    public IReadOnlyDictionary<string, BlessingNodeState> ActiveReligionBlessings =>
+        State.ReligionBlessingStatesByDeity.TryGetValue(State.ActiveDeity, out var d)
+            ? d
+            : EmptyStates;
+
+    private static readonly Dictionary<string, BlessingNodeState> EmptyStates = new();
+
     public void DrawBlessingsTab(float windowPosX, float windowPosY, float width, float contentHeight, int windowWidth,
-        int windowHeight, float deltaTime, int playerFavor, int religionPrestige)
+        int windowHeight, float deltaTime, int playerFavor, int religionPrestige, DeityDomain patronDomain,
+        Dictionary<DeityDomain, int>? favorRanksByDeity = null,
+        Dictionary<DeityDomain, int>? totalFavorEarnedByDeity = null,
+        int discipleThreshold = 500, int zealotThreshold = 2000,
+        int championThreshold = 5000, int avatarThreshold = 10000)
     {
+        var summaries = BuildDeitySummaries(
+            patronDomain,
+            favorRanksByDeity ?? new Dictionary<DeityDomain, int>(),
+            totalFavorEarnedByDeity ?? new Dictionary<DeityDomain, int>(),
+            discipleThreshold, zealotThreshold, championThreshold, avatarThreshold);
+
         var vm = new BlessingTabViewModel(
             windowPosX,
             windowPosY,
@@ -52,12 +76,15 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
             deltaTime,
             State.TreeState.SelectedBlessingId,
             GetSelectedBlessingState(),
-            State.PlayerBlessingStates,
-            State.ReligionBlessingStates,
+            ActivePlayerBlessings,
+            ActiveReligionBlessings,
             State.TreeState.PlayerScrollState,
             State.TreeState.ReligionScrollState,
             playerFavor,
-            religionPrestige
+            religionPrestige,
+            State.ActiveDeity,
+            patronDomain,
+            summaries
         );
 
         var result = BlessingTabRenderer.DrawBlessingsTab(vm);
@@ -65,43 +92,41 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         ProcessBlessingTabEvents(result);
     }
 
-    /// <summary>
-    ///     Processes all blessing tab events (side effects: state updates, sounds, network requests)
-    /// </summary>
     internal void ProcessBlessingTabEvents(BlessingTabRenderResult result)
     {
-        // Update hovering state from result
         State.TreeState.HoveringBlessingId = result.HoveringBlessingId;
 
-        // Process tree events
+        if (result.RequestedActiveDeity is { } newActive && newActive != State.ActiveDeity)
+        {
+            State.ActiveDeity = newActive;
+            State.TreeState.SelectedBlessingId = null;
+            State.TreeState.PlayerScrollState.Reset();
+            State.TreeState.ReligionScrollState.Reset();
+            _soundManager.PlayClick();
+        }
+
         foreach (var ev in result.TreeEvents)
             switch (ev)
             {
                 case TreeEvent.Selected e:
-                    // Update state
                     State.TreeState.SelectedBlessingId = e.BlessingId;
-                    // Play sound
                     _soundManager.PlayClick();
                     break;
 
-                case TreeEvent.Hovered e:
-                    // State already updated from result.HoveringBlessingId
+                case TreeEvent.Hovered:
                     break;
 
                 case TreeEvent.PlayerTreeScrollChanged e:
-                    // Update state
                     State.TreeState.PlayerScrollState.X = e.ScrollX;
                     State.TreeState.PlayerScrollState.Y = e.ScrollY;
                     break;
 
                 case TreeEvent.ReligionTreeScrollChanged e:
-                    // Update state
                     State.TreeState.ReligionScrollState.X = e.ScrollX;
                     State.TreeState.ReligionScrollState.Y = e.ScrollY;
                     break;
             }
 
-        // Process action events
         foreach (var ev in result.ActionsEvents)
             switch (ev)
             {
@@ -116,9 +141,6 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
     }
 
 
-    /// <summary>
-    ///     Handles blessing unlock request
-    /// </summary>
     private void HandleUnlockClicked()
     {
         if (State.TreeState.SelectedBlessingId == null) return;
@@ -126,14 +148,12 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         if (selectedState == null || !selectedState.CanUnlock || selectedState.IsUnlocked)
             return;
 
-        // Client-side validation
         if (string.IsNullOrEmpty(selectedState.Blessing.BlessingId))
         {
             _coreClientApi.ShowChatMessage("Error: Invalid blessing ID");
             return;
         }
 
-        // Play click sound
         _soundManager.PlayClick();
 
         _uiService.RequestBlessingUnlock(selectedState.Blessing.BlessingId);
@@ -141,36 +161,53 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
 
     private BlessingNodeState? GetBlessingState(string blessingId)
     {
-        return State.PlayerBlessingStates.TryGetValue(blessingId, out var playerState)
-            ? playerState
-            : State.ReligionBlessingStates.GetValueOrDefault(blessingId);
+        foreach (var dict in State.PlayerBlessingStatesByDeity.Values)
+            if (dict.TryGetValue(blessingId, out var s)) return s;
+        foreach (var dict in State.ReligionBlessingStatesByDeity.Values)
+            if (dict.TryGetValue(blessingId, out var s)) return s;
+        return null;
     }
 
-    /// <summary>
-    ///     Get a selected blessing's state (if any)
-    /// </summary>
     public BlessingNodeState? GetSelectedBlessingState()
     {
         if (string.IsNullOrEmpty(State.TreeState.SelectedBlessingId)) return null;
-
         return GetBlessingState(State.TreeState.SelectedBlessingId);
     }
 
+    /// <summary>
+    ///     Load blessings for all five deities. `playerBlessings` and `religionBlessings`
+    ///     should already contain entries for every deity — server populates them in
+    ///     <see cref="DivineAscension.Network.BlessingDataResponsePacket"/> after #240.
+    /// </summary>
     public void LoadBlessingStates(List<Blessing> playerBlessings, List<Blessing> religionBlessings)
     {
-        State.PlayerBlessingStates.Clear();
-        State.ReligionBlessingStates.Clear();
+        State.PlayerBlessingStatesByDeity.Clear();
+        State.ReligionBlessingStatesByDeity.Clear();
+
+        foreach (var domain in AllDeities)
+        {
+            State.PlayerBlessingStatesByDeity[domain] = new Dictionary<string, BlessingNodeState>();
+            State.ReligionBlessingStatesByDeity[domain] = new Dictionary<string, BlessingNodeState>();
+        }
 
         foreach (var blessing in playerBlessings)
         {
-            var state = new BlessingNodeState(blessing);
-            State.PlayerBlessingStates[blessing.BlessingId] = state;
+            if (!State.PlayerBlessingStatesByDeity.TryGetValue(blessing.Domain, out var bucket))
+            {
+                bucket = new Dictionary<string, BlessingNodeState>();
+                State.PlayerBlessingStatesByDeity[blessing.Domain] = bucket;
+            }
+            bucket[blessing.BlessingId] = new BlessingNodeState(blessing);
         }
 
         foreach (var blessing in religionBlessings)
         {
-            var state = new BlessingNodeState(blessing);
-            State.ReligionBlessingStates[blessing.BlessingId] = state;
+            if (!State.ReligionBlessingStatesByDeity.TryGetValue(blessing.Domain, out var bucket))
+            {
+                bucket = new Dictionary<string, BlessingNodeState>();
+                State.ReligionBlessingStatesByDeity[blessing.Domain] = bucket;
+            }
+            bucket[blessing.BlessingId] = new BlessingNodeState(blessing);
         }
     }
 
@@ -189,59 +226,44 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         int currentPrestigeRank,
         DeityDomain patronDomain)
     {
-        // Update CanUnlock status for all player blessings
-        foreach (var state in State.PlayerBlessingStates.Values)
-        {
-            // Check branch lock status
-            var branchLocked = IsBranchLocked(state.Blessing.Domain, state.Blessing.Branch);
-            state.IsBranchLocked = branchLocked;
-            state.LockedByBranch = branchLocked ? GetCommittedBranch(state.Blessing.Domain) : null;
+        foreach (var bucket in State.PlayerBlessingStatesByDeity.Values)
+            foreach (var state in bucket.Values)
+            {
+                var branchLocked = IsBranchLocked(state.Blessing.Domain, state.Blessing.Branch);
+                state.IsBranchLocked = branchLocked;
+                state.LockedByBranch = branchLocked ? GetCommittedBranch(state.Blessing.Domain) : null;
+                state.NonPatronCostMultiplier = state.Blessing.Domain == patronDomain ? 1.0f : 1.5f;
+                state.CanUnlock = CanUnlockBlessing(state, favorRanksByDeity, currentPrestigeRank, patronDomain);
+                state.UpdateVisualState();
+            }
 
-            state.NonPatronCostMultiplier = state.Blessing.Domain == patronDomain ? 1.0f : 1.5f;
-            state.CanUnlock = CanUnlockBlessing(state, favorRanksByDeity, currentPrestigeRank, patronDomain);
-            state.UpdateVisualState();
-        }
-
-        // Update CanUnlock status for all religion blessings (no branch restrictions)
-        foreach (var state in State.ReligionBlessingStates.Values)
-        {
-            state.IsBranchLocked = false;
-            state.LockedByBranch = null;
-            state.NonPatronCostMultiplier = state.Blessing.Domain == patronDomain ? 1.0f : 1.5f;
-            state.CanUnlock = CanUnlockBlessing(state, favorRanksByDeity, currentPrestigeRank, patronDomain);
-            state.UpdateVisualState();
-        }
+        foreach (var bucket in State.ReligionBlessingStatesByDeity.Values)
+            foreach (var state in bucket.Values)
+            {
+                state.IsBranchLocked = false;
+                state.LockedByBranch = null;
+                state.NonPatronCostMultiplier = state.Blessing.Domain == patronDomain ? 1.0f : 1.5f;
+                state.CanUnlock = CanUnlockBlessing(state, favorRanksByDeity, currentPrestigeRank, patronDomain);
+                state.UpdateVisualState();
+            }
     }
 
-    /// <summary>
-    ///     Check if a blessing can be unlocked based on prerequisites and rank requirements.
-    ///     Client-side validation only — server is authoritative.
-    /// </summary>
     private bool CanUnlockBlessing(
         BlessingNodeState state,
         Dictionary<DeityDomain, int> favorRanksByDeity,
         int currentPrestigeRank,
         DeityDomain patronDomain)
     {
-        // Already unlocked
         if (state.IsUnlocked) return false;
-
-        // Branch is locked (for player blessings only)
         if (state.IsBranchLocked) return false;
-
-        // Patron capstone gate: capstones (RequiresPatron) require religion's patron to match blessing domain
         if (state.Blessing.RequiresPatron && patronDomain != state.Blessing.Domain) return false;
 
-        // Check prerequisites
         if (state.Blessing.PrerequisiteBlessings is { Count: > 0 })
         {
-            // Capstone blessings (branch == null) use OR logic - at least one prerequisite must be unlocked
-            // Regular blessings use AND logic - all prerequisites must be unlocked
             var isCapstone = string.IsNullOrEmpty(state.Blessing.Branch);
 
             if (isCapstone)
             {
-                // OR logic: at least one prerequisite must be unlocked
                 var anyUnlocked = false;
                 foreach (var prereqId in state.Blessing.PrerequisiteBlessings)
                 {
@@ -256,7 +278,6 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
             }
             else
             {
-                // AND logic: all prerequisites must be unlocked
                 foreach (var prereqId in state.Blessing.PrerequisiteBlessings)
                 {
                     var prereqState = GetBlessingState(prereqId);
@@ -265,51 +286,93 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
             }
         }
 
-        // Check rank requirements based on the blessing kind
         if (state.Blessing.Kind == BlessingKind.Player)
         {
-            // Player blessings require per-deity favor rank for the blessing's domain
             var domainRank = favorRanksByDeity.GetValueOrDefault(state.Blessing.Domain);
             if (state.Blessing.RequiredFavorRank > domainRank) return false;
         }
         else if (state.Blessing.Kind == BlessingKind.Religion)
         {
-            // Religion blessings require prestige rank
             if (state.Blessing.RequiredPrestigeRank > currentPrestigeRank) return false;
         }
 
-        return true; // All requirements met
+        return true;
     }
 
-    /// <summary>
-    ///     Clear blessing selection
-    /// </summary>
+    private List<DeityBlessingSummary> BuildDeitySummaries(
+        DeityDomain patronDomain,
+        Dictionary<DeityDomain, int> favorRanksByDeity,
+        Dictionary<DeityDomain, int> totalFavorEarnedByDeity,
+        int discipleThreshold, int zealotThreshold, int championThreshold, int avatarThreshold)
+    {
+        var list = new List<DeityBlessingSummary>(AllDeities.Length);
+        foreach (var domain in AllDeities)
+        {
+            var rank = favorRanksByDeity.GetValueOrDefault(domain);
+            var totalFavor = totalFavorEarnedByDeity.GetValueOrDefault(domain);
+            var requiredForNext = RankRequirements.GetRequiredFavorForNextRank(
+                rank, discipleThreshold, zealotThreshold, championThreshold, avatarThreshold);
+            var playerBucket = State.PlayerBlessingStatesByDeity.GetValueOrDefault(domain);
+            var religionBucket = State.ReligionBlessingStatesByDeity.GetValueOrDefault(domain);
+            var unlockedPlayer = 0;
+            var totalPlayer = 0;
+            if (playerBucket != null)
+                foreach (var s in playerBucket.Values)
+                {
+                    totalPlayer++;
+                    if (s.IsUnlocked) unlockedPlayer++;
+                }
+            var unlockedReligion = 0;
+            var totalReligion = 0;
+            if (religionBucket != null)
+                foreach (var s in religionBucket.Values)
+                {
+                    totalReligion++;
+                    if (s.IsUnlocked) unlockedReligion++;
+                }
+
+            list.Add(new DeityBlessingSummary(
+                Domain: domain,
+                FavorRank: rank,
+                TotalFavorEarned: totalFavor,
+                FavorRequiredForNext: requiredForNext,
+                IsMaxRank: rank >= 4,
+                UnlockedPlayer: unlockedPlayer,
+                TotalPlayer: totalPlayer,
+                UnlockedReligion: unlockedReligion,
+                TotalReligion: totalReligion,
+                IsPatron: patronDomain != DeityDomain.None && domain == patronDomain,
+                IsActive: domain == State.ActiveDeity));
+        }
+        return list;
+    }
+
+    public void SetActiveDeity(DeityDomain domain)
+    {
+        if (State.ActiveDeity == domain) return;
+        State.ActiveDeity = domain;
+        State.TreeState.SelectedBlessingId = null;
+        State.TreeState.PlayerScrollState.Reset();
+        State.TreeState.ReligionScrollState.Reset();
+    }
+
     public void ClearSelection()
     {
         State.TreeState.SelectedBlessingId = null;
     }
 
 
-    /// <summary>
-    ///     Select a blessing (for displaying details)
-    /// </summary>
     public void SelectBlessing(string blessingId)
     {
         State.TreeState.SelectedBlessingId = blessingId;
     }
 
-    /// <summary>
-    ///     Sets the branch state received from the server
-    /// </summary>
     public void SetBranchState(Dictionary<int, string> committedBranches, Dictionary<int, List<string>> lockedBranches)
     {
         _committedBranches = committedBranches ?? new Dictionary<int, string>();
         _lockedBranches = lockedBranches ?? new Dictionary<int, List<string>>();
     }
 
-    /// <summary>
-    ///     Check if a branch is locked for a given domain
-    /// </summary>
     private bool IsBranchLocked(DeityDomain domain, string? branch)
     {
         if (string.IsNullOrEmpty(branch))
@@ -319,9 +382,6 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         return _lockedBranches.TryGetValue(domainKey, out var locked) && locked.Contains(branch);
     }
 
-    /// <summary>
-    ///     Get the committed branch for a domain (if any)
-    /// </summary>
     private string? GetCommittedBranch(DeityDomain domain)
     {
         return _committedBranches.GetValueOrDefault((int)domain);

--- a/DivineAscension/GUI/Models/Blessing/Tab/BlessingTabRenderResult.cs
+++ b/DivineAscension/GUI/Models/Blessing/Tab/BlessingTabRenderResult.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using DivineAscension.GUI.Events.Blessing;
+using DivineAscension.Models.Enum;
 
 namespace DivineAscension.GUI.Models.Blessing.Tab;
 
@@ -10,10 +11,17 @@ public readonly struct BlessingTabRenderResult(
     IReadOnlyList<TreeEvent> treeEvents,
     IReadOnlyList<ActionsEvent> actionsEvents,
     string? hoveringBlessingId,
-    float renderedHeight)
+    float renderedHeight,
+    DeityDomain? requestedActiveDeity = null)
 {
     public IReadOnlyList<TreeEvent> TreeEvents { get; } = treeEvents;
     public IReadOnlyList<ActionsEvent> ActionsEvents { get; } = actionsEvents;
     public string? HoveringBlessingId { get; } = hoveringBlessingId;
     public float RenderedHeight { get; } = renderedHeight;
+
+    /// <summary>
+    ///     Non-null when the user clicked a deity tab this frame. Manager swaps active deity
+    ///     and resets tree-state on consumption.
+    /// </summary>
+    public DeityDomain? RequestedActiveDeity { get; } = requestedActiveDeity;
 }

--- a/DivineAscension/GUI/Models/Blessing/Tab/BlessingTabViewModel.cs
+++ b/DivineAscension/GUI/Models/Blessing/Tab/BlessingTabViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using DivineAscension.GUI.State;
 using DivineAscension.Models;
+using DivineAscension.Models.Enum;
 
 namespace DivineAscension.GUI.Models.Blessing.Tab;
 
@@ -16,15 +17,17 @@ public readonly struct BlessingTabViewModel(
     // Data
     string? selectedBlessingId,
     BlessingNodeState? selectedBlessingState,
-    Dictionary<string, BlessingNodeState> playerBlessingStates,
-    Dictionary<string, BlessingNodeState> religionBlessingStates,
+    IReadOnlyDictionary<string, BlessingNodeState> playerBlessingStates,
+    IReadOnlyDictionary<string, BlessingNodeState> religionBlessingStates,
     ScrollState playerTreeScrollState,
     ScrollState religionTreeScrollState,
     int playerFavor,
-    int religionPrestige
+    int religionPrestige,
+    DeityDomain activeDeity,
+    DeityDomain patronDomain,
+    IReadOnlyList<DeityBlessingSummary> deitySummaries
 )
 {
-    // Layout
     public float X { get; } = x;
     public float Y { get; } = y;
     public float Width { get; } = width;
@@ -33,13 +36,15 @@ public readonly struct BlessingTabViewModel(
     public int WindowHeight { get; } = windowHeight;
     public float DeltaTime { get; } = deltaTime;
 
-    // Data
     public string? SelectedBlessingId { get; } = selectedBlessingId;
     public BlessingNodeState? SelectedBlessingState { get; } = selectedBlessingState;
-    public Dictionary<string, BlessingNodeState> PlayerBlessingStates { get; } = playerBlessingStates;
-    public Dictionary<string, BlessingNodeState> ReligionBlessingStates { get; } = religionBlessingStates;
+    public IReadOnlyDictionary<string, BlessingNodeState> PlayerBlessingStates { get; } = playerBlessingStates;
+    public IReadOnlyDictionary<string, BlessingNodeState> ReligionBlessingStates { get; } = religionBlessingStates;
     public ScrollState PlayerTreeScrollState { get; } = playerTreeScrollState;
     public ScrollState ReligionTreeScrollState { get; } = religionTreeScrollState;
     public int PlayerFavor { get; } = playerFavor;
     public int ReligionPrestige { get; } = religionPrestige;
+    public DeityDomain ActiveDeity { get; } = activeDeity;
+    public DeityDomain PatronDomain { get; } = patronDomain;
+    public IReadOnlyList<DeityBlessingSummary> DeitySummaries { get; } = deitySummaries;
 }

--- a/DivineAscension/GUI/Models/Blessing/Tab/DeityBlessingSummary.cs
+++ b/DivineAscension/GUI/Models/Blessing/Tab/DeityBlessingSummary.cs
@@ -1,0 +1,19 @@
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.GUI.Models.Blessing.Tab;
+
+/// <summary>
+///     Per-deity counters rendered in the cross-deity summary strip above the deity selector.
+/// </summary>
+public readonly record struct DeityBlessingSummary(
+    DeityDomain Domain,
+    int FavorRank,
+    int TotalFavorEarned,
+    int FavorRequiredForNext,
+    bool IsMaxRank,
+    int UnlockedPlayer,
+    int TotalPlayer,
+    int UnlockedReligion,
+    int TotalReligion,
+    bool IsPatron,
+    bool IsActive);

--- a/DivineAscension/GUI/State/BlessingTabState.cs
+++ b/DivineAscension/GUI/State/BlessingTabState.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using DivineAscension.Models;
+using DivineAscension.Models.Enum;
 
 namespace DivineAscension.GUI.State;
 
@@ -7,15 +8,50 @@ public class BlessingTabState
 {
     public BlessingTreeState TreeState { get; } = new();
     public BlessingInfoState InfoState { get; } = new();
-    public Dictionary<string, BlessingNodeState> PlayerBlessingStates { get; } = new();
-    public Dictionary<string, BlessingNodeState> ReligionBlessingStates { get; } = new();
+
+    /// <summary>
+    ///     Per-deity player blessing state. Outer key = deity, inner key = blessingId.
+    /// </summary>
+    public Dictionary<DeityDomain, Dictionary<string, BlessingNodeState>> PlayerBlessingStatesByDeity { get; } = new();
+
+    /// <summary>
+    ///     Per-deity religion blessing state. Outer key = deity, inner key = blessingId.
+    /// </summary>
+    public Dictionary<DeityDomain, Dictionary<string, BlessingNodeState>> ReligionBlessingStatesByDeity { get; } = new();
+
+    /// <summary>
+    ///     Currently visible deity tab in the Blessing UI. Defaults to Craft until the
+    ///     handler picks a religion-aware default (patron when in a religion).
+    /// </summary>
+    public DeityDomain ActiveDeity { get; set; } = DeityDomain.Craft;
+
+    /// <summary>
+    ///     Flattened view across every deity. Convenience for tests and lookups that don't
+    ///     care which deity bucket a blessing came from. On id collisions across deities,
+    ///     the first deity bucket iterated wins — collisions are not expected because
+    ///     server-side blessing ids are unique across the registry.
+    /// </summary>
+    public IReadOnlyDictionary<string, BlessingNodeState> PlayerBlessingStates => FlattenView(PlayerBlessingStatesByDeity);
+
+    public IReadOnlyDictionary<string, BlessingNodeState> ReligionBlessingStates => FlattenView(ReligionBlessingStatesByDeity);
+
+    private static IReadOnlyDictionary<string, BlessingNodeState> FlattenView(
+        Dictionary<DeityDomain, Dictionary<string, BlessingNodeState>> source)
+    {
+        var flat = new Dictionary<string, BlessingNodeState>();
+        foreach (var bucket in source.Values)
+            foreach (var kv in bucket)
+                flat[kv.Key] = kv.Value;
+        return flat;
+    }
 
     public void Reset()
     {
         TreeState.Reset();
         InfoState.Reset();
-        PlayerBlessingStates.Clear();
-        ReligionBlessingStates.Clear();
+        PlayerBlessingStatesByDeity.Clear();
+        ReligionBlessingStatesByDeity.Clear();
+        ActiveDeity = DeityDomain.Craft;
     }
 }
 

--- a/DivineAscension/GUI/UI/MainDialogRenderer.cs
+++ b/DivineAscension/GUI/UI/MainDialogRenderer.cs
@@ -150,7 +150,14 @@ internal static class MainDialogRenderer
                     windowHeight,
                     deltaTime,
                     manager.ReligionStateManager.CurrentFavor,
-                    manager.ReligionStateManager.CurrentPrestige);
+                    manager.ReligionStateManager.CurrentPrestige,
+                    manager.ReligionStateManager.CurrentReligionDomain,
+                    manager.ReligionStateManager.FavorRanksByDeity,
+                    manager.ReligionStateManager.TotalFavorEarnedByDeity,
+                    manager.ReligionStateManager.DiscipleThreshold,
+                    manager.ReligionStateManager.ZealotThreshold,
+                    manager.ReligionStateManager.ChampionThreshold,
+                    manager.ReligionStateManager.AvatarThreshold);
                 break;
             case MainDialogTab.Civilization: // Civilization
                 manager.CivilizationManager.DrawCivilizationTab(windowPos.X + x, windowPos.Y + y, width, contentHeight);

--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTabRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTabRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Models.Blessing.Tab;
 using DivineAscension.GUI.Models.Blessing.Tree;
 using DivineAscension.GUI.UI.Renderers.Blessing.Info;
 using DivineAscension.Models;
+using DivineAscension.Models.Enum;
 using ImGuiNET;
 
 namespace DivineAscension.GUI.UI.Renderers.Blessing;
@@ -20,18 +21,25 @@ internal static class BlessingTabRenderer
         const float padding = 16f;
         const float actionButtonHeight = 36f;
         const float actionButtonPadding = 16f;
+        const float strapSpacing = 8f;
 
-        // Track hovering state
         string? hoveringBlessingId = null;
 
-        // Blessing Tree (split view)
-        var treeHeight = vm.Height - infoPanelHeight - padding;
+        var topY = vm.Y;
+        CrossDeitySummaryRenderer.Draw(vm.X, topY, vm.Width, vm.DeitySummaries);
+        topY += CrossDeitySummaryRenderer.Height + strapSpacing;
+
+        var requestedDeity = DeitySelectorRenderer.Draw(vm.X, topY, vm.ActiveDeity, vm.PatronDomain);
+        topY += DeitySelectorRenderer.Height + strapSpacing;
+
+        var consumedTop = topY - vm.Y;
+        var treeHeight = vm.Height - infoPanelHeight - padding - consumedTop;
         var treeVm = new BlessingTreeViewModel(
             vm.PlayerTreeScrollState,
             vm.ReligionTreeScrollState,
             vm.PlayerBlessingStates,
             vm.ReligionBlessingStates,
-            vm.X, vm.Y, vm.Width, treeHeight,
+            vm.X, topY, vm.Width, treeHeight,
             vm.DeltaTime,
             vm.SelectedBlessingId,
             vm.PlayerFavor,
@@ -40,20 +48,16 @@ internal static class BlessingTabRenderer
 
         var treeResult = BlessingTreeRenderer.Draw(treeVm);
 
-        // Extract hovering state from tree events
         foreach (var ev in treeResult.Events)
             if (ev is TreeEvent.Hovered hovered)
                 hoveringBlessingId = hovered.BlessingId;
 
-        // Info Panel
-        var infoY = vm.Y + treeHeight + padding;
+        var infoY = topY + treeHeight + padding;
         var combinedStates = new Dictionary<string, BlessingNodeState>();
         foreach (var kv in vm.PlayerBlessingStates)
-            if (!combinedStates.ContainsKey(kv.Key))
-                combinedStates[kv.Key] = kv.Value;
+            combinedStates.TryAdd(kv.Key, kv.Value);
         foreach (var kv in vm.ReligionBlessingStates)
-            if (!combinedStates.ContainsKey(kv.Key))
-                combinedStates[kv.Key] = kv.Value;
+            combinedStates.TryAdd(kv.Key, kv.Value);
 
         var infoVm = new BlessingInfoViewModel(
             vm.SelectedBlessingState,
@@ -64,9 +68,8 @@ internal static class BlessingTabRenderer
             infoPanelHeight,
             vm.PlayerFavor,
             vm.ReligionPrestige);
-        var infoResult = BlessingInfoRenderer.Draw(infoVm);
+        BlessingInfoRenderer.Draw(infoVm);
 
-        // Action Buttons (overlay bottom-right)
         var buttonY = vm.WindowHeight - actionButtonHeight - actionButtonPadding;
         var buttonX = vm.WindowWidth - actionButtonPadding;
         var actionsVm = new BlessingActionsViewModel(
@@ -79,7 +82,6 @@ internal static class BlessingTabRenderer
 
         var actionsResult = BlessingActionsRenderer.Draw(actionsVm);
 
-        // Tooltips (side effect - rendering only, no state changes)
         if (!string.IsNullOrEmpty(hoveringBlessingId))
         {
             vm.PlayerBlessingStates.TryGetValue(hoveringBlessingId!, out var hoverPlayerState);
@@ -89,11 +91,9 @@ internal static class BlessingTabRenderer
             {
                 var allBlessings = new Dictionary<string, DivineAscension.Models.Blessing>();
                 foreach (var s in vm.PlayerBlessingStates.Values)
-                    if (!allBlessings.ContainsKey(s.Blessing.BlessingId))
-                        allBlessings[s.Blessing.BlessingId] = s.Blessing;
+                    allBlessings.TryAdd(s.Blessing.BlessingId, s.Blessing);
                 foreach (var s in vm.ReligionBlessingStates.Values)
-                    if (!allBlessings.ContainsKey(s.Blessing.BlessingId))
-                        allBlessings[s.Blessing.BlessingId] = s.Blessing;
+                    allBlessings.TryAdd(s.Blessing.BlessingId, s.Blessing);
 
                 var tooltipData = BlessingTooltipData.FromBlessingAndState(
                     hoveringState.Blessing,
@@ -106,12 +106,13 @@ internal static class BlessingTabRenderer
             }
         }
 
-        // Return result with all events
         return new BlessingTabRenderResult(
             treeResult.Events,
             actionsResult.Events,
             hoveringBlessingId,
-            vm.Height
+            vm.Height,
+            requestedDeity
         );
     }
+
 }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.Models.Blessing.Tab;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
+using DivineAscension.Systems;
+using ImGuiNET;
+
+namespace DivineAscension.GUI.UI.Renderers.Blessing;
+
+/// <summary>
+///     Compact strip above the deity selector showing per-deity favor rank +
+///     unlocked/total counts. Read-only — clicks are handled by the selector below it.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class CrossDeitySummaryRenderer
+{
+    public const float Height = 38f;
+    private const float Padding = 4f;
+
+    public static void Draw(float x, float y, float width, IReadOnlyList<DeityBlessingSummary> summaries)
+    {
+        if (summaries.Count == 0) return;
+
+        var drawList = ImGui.GetWindowDrawList();
+
+        var bgMin = new Vector2(x, y);
+        var bgMax = new Vector2(x + width, y + Height);
+        var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.DarkBrown, 0.7f));
+        drawList.AddRectFilled(bgMin, bgMax, bgColor, 4f);
+        var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Gold, 0.4f));
+        drawList.AddRect(bgMin, bgMax, borderColor, 4f, ImDrawFlags.None, 1f);
+
+        var colWidth = (width - Padding * 2) / summaries.Count;
+        var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
+        var gold = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
+
+        for (var i = 0; i < summaries.Count; i++)
+        {
+            var s = summaries[i];
+            var colX = x + Padding + i * colWidth;
+            var colTop = y + 4f;
+
+            var label = $"{DomainShort(s.Domain)} {RankRequirements.GetFavorRankName(s.FavorRank)}";
+            var labelSize = ImGui.CalcTextSize(label);
+            drawList.AddText(ImGui.GetFont(), 12f,
+                new Vector2(colX + (colWidth - labelSize.X) / 2f, colTop),
+                s.IsPatron ? gold : textColor,
+                label);
+
+            var counts = $"P {s.UnlockedPlayer}/{s.TotalPlayer}  R {s.UnlockedReligion}/{s.TotalReligion}";
+            var countsSize = ImGui.CalcTextSize(counts);
+            drawList.AddText(ImGui.GetFont(), 12f,
+                new Vector2(colX + (colWidth - countsSize.X) / 2f, colTop + 16f),
+                textColor,
+                counts);
+
+            if (s.IsPatron)
+            {
+                drawList.AddText(ImGui.GetFont(), 12f,
+                    new Vector2(colX + 2f, colTop), gold, "*");
+            }
+        }
+    }
+
+    private static string DomainShort(DeityDomain d) => d switch
+    {
+        DeityDomain.Craft => "C",
+        DeityDomain.Wild => "W",
+        DeityDomain.Conquest => "Q",
+        DeityDomain.Harvest => "H",
+        DeityDomain.Stone => "S",
+        _ => "?"
+    };
+}

--- a/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
+using ImGuiNET;
+
+namespace DivineAscension.GUI.UI.Renderers.Blessing;
+
+/// <summary>
+///     Five-icon tab strip for switching the active deity in the Blessing tab.
+///     Patron deity is marked with a gold border and ★ glyph.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class DeitySelectorRenderer
+{
+    private const float TabSize = 56f;
+    private const float TabSpacing = 6f;
+    private const float PatronBorderThickness = 2.5f;
+    private const float ActiveBorderThickness = 2f;
+    public const float Height = TabSize + 4f;
+
+    private static readonly DeityDomain[] Order =
+    {
+        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone
+    };
+
+    /// <summary>
+    ///     Draw the deity selector. Returns the deity the user clicked this frame, or null.
+    /// </summary>
+    public static DeityDomain? Draw(float x, float y, DeityDomain activeDeity, DeityDomain patronDomain)
+    {
+        var drawList = ImGui.GetWindowDrawList();
+        var mouse = ImGui.GetMousePos();
+        var clicked = ImGui.IsMouseClicked(ImGuiMouseButton.Left);
+
+        DeityDomain? requested = null;
+        var cursorX = x;
+
+        for (var i = 0; i < Order.Length; i++)
+        {
+            var domain = Order[i];
+            var isPatron = patronDomain != DeityDomain.None && domain == patronDomain;
+            var isActive = domain == activeDeity;
+
+            var min = new Vector2(cursorX, y);
+            var max = new Vector2(cursorX + TabSize, y + TabSize);
+
+            var hovered = mouse.X >= min.X && mouse.X <= max.X && mouse.Y >= min.Y && mouse.Y <= max.Y;
+
+            var bgColor = ImGui.ColorConvertFloat4ToU32(
+                hovered ? ColorPalette.LightBrown : ColorPalette.DarkBrown);
+            drawList.AddRectFilled(min, max, bgColor, 4f);
+
+            var textureId = DeityIconLoader.GetDeityTextureId(domain);
+            if (textureId != IntPtr.Zero)
+            {
+                const float pad = 6f;
+                var imgMin = new Vector2(min.X + pad, min.Y + pad);
+                var imgMax = new Vector2(max.X - pad, max.Y - pad);
+                drawList.AddImage(textureId, imgMin, imgMax,
+                    Vector2.Zero, Vector2.One,
+                    ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f)));
+            }
+            else
+            {
+                var center = new Vector2((min.X + max.X) / 2f, (min.Y + max.Y) / 2f);
+                var fallback = ImGui.ColorConvertFloat4ToU32(DomainHelper.GetDeityColor(domain));
+                drawList.AddCircleFilled(center, TabSize / 3f, fallback, 16);
+            }
+
+            if (isPatron)
+            {
+                var patronBorder = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
+                drawList.AddRect(min, max, patronBorder, 4f, ImDrawFlags.None, PatronBorderThickness);
+                var star = "*";
+                drawList.AddText(ImGui.GetFont(), 14f,
+                    new Vector2(max.X - 12f, min.Y + 2f),
+                    patronBorder, star);
+            }
+            else if (isActive)
+            {
+                var border = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Gold, 0.6f));
+                drawList.AddRect(min, max, border, 4f, ImDrawFlags.None, ActiveBorderThickness);
+            }
+
+            if (isActive)
+            {
+                var underline = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
+                drawList.AddLine(
+                    new Vector2(min.X, max.Y + 1f),
+                    new Vector2(max.X, max.Y + 1f),
+                    underline, 2f);
+            }
+
+            if (hovered && clicked)
+                requested = domain;
+
+            cursorX += TabSize + TabSpacing;
+        }
+
+        return requested;
+    }
+}

--- a/DivineAscension/GUI/UI/Renderers/Blessing/TooltipRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/TooltipRenderer.cs
@@ -213,6 +213,36 @@ internal static class TooltipRenderer
             hasRequirements = true;
         }
 
+        // Capstone lock (RequiresPatron blessing on non-patron deity)
+        if (data.RequiresPatron && data.IsNonPatron)
+        {
+            lines.Add(new TooltipLine
+            {
+                Text = $"Only available to followers of {data.Domain}",
+                Color = ColorPalette.Red,
+                FontSize = Body,
+                SpacingAfter = LINE_SPACING
+            });
+            hasRequirements = true;
+        }
+
+        // Cost line — show base / adjusted multiplier on non-patron blessings
+        if (data.BaseCost > 0)
+        {
+            var costUnit = data.Kind == BlessingKind.Religion ? "prestige" : "favor";
+            var costText = data.IsNonPatron
+                ? $"Cost: {data.AdjustedCost} {costUnit} (base {data.BaseCost} x 1.5)"
+                : $"Cost: {data.BaseCost} {costUnit}";
+            lines.Add(new TooltipLine
+            {
+                Text = costText,
+                Color = data.IsNonPatron ? ColorPalette.Yellow : ColorPalette.Gold,
+                FontSize = Body,
+                SpacingAfter = LINE_SPACING
+            });
+            hasRequirements = true;
+        }
+
         // Add spacing after requirements
         if (hasRequirements && lines.Count > 0)
             lines[lines.Count - 1].SpacingAfter = SECTION_SPACING;

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
@@ -184,9 +184,13 @@ internal static class ReligionCreateRenderer
     private static string? DrawDomainGroup(ReligionCreateViewModel viewModel, ImDrawListPtr drawList, float formX,
         float fieldWidth, List<CreateEvent> events, ref float currentY)
     {
-        TextRenderer.DrawLabel(drawList, LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_DOMAIN_LABEL),
+        TextRenderer.DrawLabel(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_PATRON_HEADING),
             formX, currentY);
-        currentY += 25f;
+        currentY += 22f;
+        var explainer = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_PATRON_EXPLAINER);
+        TextRenderer.DrawInfoText(drawList, explainer, formX, currentY, fieldWidth);
+        currentY += TextRenderer.MeasureWrappedHeight(explainer, fieldWidth) + 6f;
 
         var currentDomainIndex = viewModel.GetCurrentDomainIndex();
 

--- a/DivineAscension/Models/BlessingTooltipData.cs
+++ b/DivineAscension/Models/BlessingTooltipData.cs
@@ -78,11 +78,37 @@ public class BlessingTooltipData
     public string UnlockBlockReason { get; set; } = string.Empty;
 
     /// <summary>
+    ///     Base cost in favor (player blessings) or prestige (religion blessings).
+    /// </summary>
+    public int BaseCost { get; set; }
+
+    /// <summary>
+    ///     Cost after the 1.5× non-patron multiplier is applied (or BaseCost when patron).
+    /// </summary>
+    public int AdjustedCost { get; set; }
+
+    /// <summary>
+    ///     True when the blessing's domain differs from the religion's patron domain.
+    /// </summary>
+    public bool IsNonPatron { get; set; }
+
+    /// <summary>
+    ///     True for capstones (<see cref="Blessing.RequiresPatron"/>) gated to the patron deity.
+    /// </summary>
+    public bool RequiresPatron { get; set; }
+
+    /// <summary>
+    ///     Deity this blessing belongs to. Used by the capstone-lock message.
+    /// </summary>
+    public DeityDomain Domain { get; set; } = DeityDomain.None;
+
+    /// <summary>
     ///     Create tooltip data from a Blessing and BlessingNodeState
     /// </summary>
     public static BlessingTooltipData FromBlessingAndState(Blessing blessing, BlessingNodeState state,
         Dictionary<string, Blessing>? blessingRegistry = null)
     {
+        var adjustedCost = (int)System.Math.Ceiling(blessing.Cost * state.NonPatronCostMultiplier);
         var tooltip = new BlessingTooltipData
         {
             Name = blessing.Name,
@@ -91,7 +117,12 @@ public class BlessingTooltipData
             Kind = blessing.Kind,
             Tier = state.Tier,
             IsUnlocked = state.IsUnlocked,
-            CanUnlock = state.CanUnlock
+            CanUnlock = state.CanUnlock,
+            BaseCost = blessing.Cost,
+            AdjustedCost = adjustedCost,
+            IsNonPatron = state.NonPatronCostMultiplier > 1.0f,
+            RequiresPatron = blessing.RequiresPatron,
+            Domain = blessing.Domain
         };
 
         // Add requirement text based on blessing kind

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -26,6 +26,8 @@
   "divineascension:ui.religion.name.error.too_long": "Religion name must be less than 32 characters",
   "divineascension:ui.religion.name.error.profanity": "Name contains inappropriate content: \"{0}\"",
   "divineascension:ui.religion.domain.label": "Domain:",
+  "divineascension:ui.religion.patron.heading": "Choose your patron deity.",
+  "divineascension:ui.religion.patron.explainer": "All deities are worshipped in your temple, but your patron grants faster favor accrual and exclusive capstone blessings.",
   "divineascension:ui.religion.deity_name.label": "Deity Name:",
   "divineascension:ui.religion.deity_name.placeholder": "Name your deity (e.g. Forge Lord, The Huntress)",
   "divineascension:ui.religion.deity_name.error.too_short": "Deity name must be at least 2 characters",


### PR DESCRIPTION
## Summary
- Five-deity navigator inside the Blessing tab: cross-deity summary strip + icon selector + per-deity tree + info panel. Patron deity gets a gold border and a `*` glyph. Clicking a deity tab swaps trees, info panel, and tooltip costs in one frame.
- Server has been sending all five deities since #240; the client filter at `GuiDialogHandlers.cs:107-108` is gone. Active deity defaults to patron when in a religion, **Craft** otherwise.
- Tooltips now show base / adjusted cost on non-patron blessings (`Cost: 15 favor (base 10 x 1.5)`) and lock capstones with `Only available to followers of <Domain>` when viewed from the wrong deity tab.
- Religion-creation form gains a `Choose your patron deity.` heading and an explainer about patron mechanics (founder-only copy + new localization keys).

Closes #244.

## Known holdovers (out of scope)
- `ReligionHeaderViewModel.CurrentDeity` stays patron-centric — it drives the always-on religion banner (top of dialog), not the per-deity blessing content. Renaming to `PatronDeity` is a noisy sweep deferred to a follow-up.
- `BlessingTreeRenderer` keeps left/right (Player | Religion) split rather than vertical stack — same layout, just per-active-deity data now. Vertical stack is a follow-up if needed.
- `CivilizationInfoResponsePacket.MemberReligion.Domain` → `PatronDomain` packet rename — server-side, separate PR.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` — clean.
- [x] `dotnet test` — 2132/2132 (7 new `BlessingStateManagerPantheonTests`).
- [ ] Manual playtest (`VINTAGE_STORY` set):
  - Open Blessing tab as Wild patron → Wild tab is active with gold border.
  - Open Blessing tab with no religion → Craft active, no patron border anywhere.
  - Click Stone tab → tree + info + tooltips rebuild for Stone.
  - As Wild patron, hover a Craft blessing → tooltip shows `(base N x 1.5)`.
  - As Wild patron, hover `avatar_of_craft` → `Only available to followers of Craft` line.
  - Unlock a Wild blessing → patron cost deducted; summary row counter ticks `0/N → 1/N`.
  - Kill a drifter → Conquest favor advances on next tick (HUD + summary row).
  - New religion flow → patron heading + explainer visible.