### PR TITLE
feat(ui): phase 1 — layout primitives + state scaffolding

### DIFF
--- a/DivineAscension.Tests/Data/UiPrefsTests.cs
+++ b/DivineAscension.Tests/Data/UiPrefsTests.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Data;
+using DivineAscension.GUI.State;
+using Vintagestory.API.Util;
+
+namespace DivineAscension.Tests.Data;
+
+[ExcludeFromCodeCoverage]
+public class UiPrefsTests
+{
+    [Fact]
+    public void Defaults_MatchWindowBaseDimensions()
+    {
+        var prefs = new UiPrefs();
+
+        Assert.Equal(1400, prefs.WindowWidth);
+        Assert.Equal(900, prefs.WindowHeight);
+        Assert.False(prefs.SidebarCollapsed);
+        Assert.Empty(prefs.CollapsedGroups);
+        Assert.Equal(SidebarNavId.ReligionInfo, prefs.LastNavId);
+    }
+
+    [Fact]
+    public void SerializerUtil_RoundTrip_PreservesAllFields()
+    {
+        var prefs = new UiPrefs
+        {
+            WindowWidth = 1600,
+            WindowHeight = 1000,
+            SidebarCollapsed = true,
+            LastNavId = SidebarNavId.CivilizationDiplomacy
+        };
+        prefs.CollapsedGroups["religion"] = true;
+        prefs.CollapsedGroups["blessings"] = false;
+
+        var bytes = SerializerUtil.Serialize(prefs);
+        var roundtripped = SerializerUtil.Deserialize<UiPrefs>(bytes);
+
+        Assert.Equal(prefs.WindowWidth, roundtripped.WindowWidth);
+        Assert.Equal(prefs.WindowHeight, roundtripped.WindowHeight);
+        Assert.Equal(prefs.SidebarCollapsed, roundtripped.SidebarCollapsed);
+        Assert.Equal(prefs.LastNavId, roundtripped.LastNavId);
+        Assert.True(roundtripped.CollapsedGroups["religion"]);
+        Assert.False(roundtripped.CollapsedGroups["blessings"]);
+    }
+
+    [Fact]
+    public void ModConfigData_RoundTrip_PreservesNestedUiPrefs()
+    {
+        var config = new ModConfigData
+        {
+            UiPrefs =
+            {
+                WindowWidth = 1280,
+                LastNavId = SidebarNavId.Blessings
+            }
+        };
+        config.UiPrefs.CollapsedGroups["x"] = true;
+
+        var bytes = SerializerUtil.Serialize(config);
+        var roundtripped = SerializerUtil.Deserialize<ModConfigData>(bytes);
+
+        Assert.Equal(1280, roundtripped.UiPrefs.WindowWidth);
+        Assert.Equal(SidebarNavId.Blessings, roundtripped.UiPrefs.LastNavId);
+        Assert.True(roundtripped.UiPrefs.CollapsedGroups["x"]);
+    }
+}

--- a/DivineAscension.Tests/GUI/Managers/NotificationManagerHistoryTests.cs
+++ b/DivineAscension.Tests/GUI/Managers/NotificationManagerHistoryTests.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.GUI.Interfaces;
+using DivineAscension.GUI.Managers;
+using DivineAscension.GUI.State;
+using DivineAscension.Models.Enum;
+using Moq;
+
+namespace DivineAscension.Tests.GUI.Managers;
+
+[ExcludeFromCodeCoverage]
+public class NotificationManagerHistoryTests
+{
+    private readonly NotificationManager _sut;
+
+    public NotificationManagerHistoryTests()
+    {
+        var mockSound = new Mock<ISoundManager>();
+        _sut = new NotificationManager(mockSound.Object);
+        // Disable the show-callback path so QueueRankUp does not eagerly recurse into sound.
+        _sut.SetShowImGuiCallback(() => { });
+    }
+
+    [Fact]
+    public void QueueRankUpNotification_PushesEntryIntoHistory()
+    {
+        _sut.QueueRankUpNotification(NotificationType.FavorRankUp, "Disciple", "desc", DeityDomain.Craft);
+
+        Assert.Single(_sut.State.History);
+        var entry = _sut.State.History[0];
+        Assert.Equal(NotificationType.FavorRankUp, entry.Type);
+        Assert.Equal("Disciple", entry.Title);
+        Assert.Equal("desc", entry.Body);
+        Assert.Equal(DeityDomain.Craft, entry.Deity);
+        Assert.False(entry.Read);
+    }
+
+    [Fact]
+    public void QueueRankUpNotification_BeyondCap_KeepsNewestFifty()
+    {
+        for (var i = 0; i < NotificationState.HistoryCap + 10; i++)
+        {
+            _sut.QueueRankUpNotification(NotificationType.FavorRankUp, $"R{i}", "d", DeityDomain.Craft);
+        }
+
+        Assert.Equal(NotificationState.HistoryCap, _sut.State.History.Count);
+        Assert.Equal("R10", _sut.State.History[0].Title);
+        Assert.Equal($"R{NotificationState.HistoryCap + 9}", _sut.State.History[^1].Title);
+    }
+
+    [Fact]
+    public void MarkRead_SetsReadTrue()
+    {
+        _sut.QueueRankUpNotification(NotificationType.FavorRankUp, "Disciple", "d", DeityDomain.Craft);
+
+        _sut.MarkRead(0);
+
+        Assert.True(_sut.State.History[0].Read);
+    }
+
+    [Fact]
+    public void MarkRead_OutOfRange_IsNoOp()
+    {
+        _sut.QueueRankUpNotification(NotificationType.FavorRankUp, "Disciple", "d", DeityDomain.Craft);
+
+        _sut.MarkRead(-1);
+        _sut.MarkRead(99);
+
+        Assert.False(_sut.State.History[0].Read);
+    }
+
+    [Fact]
+    public void ClearHistory_EmptiesHistory_LeavesPendingQueueAlone()
+    {
+        _sut.QueueRankUpNotification(NotificationType.FavorRankUp, "A", "d", DeityDomain.Craft);
+        _sut.QueueRankUpNotification(NotificationType.FavorRankUp, "B", "d", DeityDomain.Craft);
+
+        _sut.ClearHistory();
+
+        Assert.Empty(_sut.State.History);
+        // PendingNotifications is independent of history; the first toast becomes
+        // visible immediately (ShowNextNotification dequeues it), the second stays queued.
+        Assert.Single(_sut.State.PendingNotifications);
+    }
+}

--- a/DivineAscension.Tests/GUI/State/GuiDialogStateTests.cs
+++ b/DivineAscension.Tests/GUI/State/GuiDialogStateTests.cs
@@ -62,6 +62,11 @@ public class GuiDialogStateTests
             WindowPosX = 100f,
             WindowPosY = 200f
         };
+        state.Sidebar.IsCollapsed = true;
+        state.Sidebar.CurrentNav = SidebarNavId.CivilizationDiplomacy;
+        state.Sidebar.CollapsedGroups["g"] = true;
+        state.RightRail.ScrollY = 42f;
+        state.RightRail.ShowUnreadOnly = true;
 
         // Act
         state.Reset();
@@ -71,6 +76,11 @@ public class GuiDialogStateTests
         Assert.False(state.IsReady);
         Assert.Equal(0f, state.WindowPosX);
         Assert.Equal(0f, state.WindowPosY);
+        Assert.False(state.Sidebar.IsCollapsed);
+        Assert.Equal(SidebarNavId.ReligionInfo, state.Sidebar.CurrentNav);
+        Assert.Empty(state.Sidebar.CollapsedGroups);
+        Assert.Equal(0f, state.RightRail.ScrollY);
+        Assert.False(state.RightRail.ShowUnreadOnly);
     }
 
     [Fact]

--- a/DivineAscension.Tests/GUI/State/SidebarStateTests.cs
+++ b/DivineAscension.Tests/GUI/State/SidebarStateTests.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.GUI.State;
+
+namespace DivineAscension.Tests.GUI.State;
+
+[ExcludeFromCodeCoverage]
+public class SidebarStateTests
+{
+    [Fact]
+    public void Constructor_DefaultsToReligionInfoAndExpanded()
+    {
+        var state = new SidebarState();
+
+        Assert.False(state.IsCollapsed);
+        Assert.Empty(state.CollapsedGroups);
+        Assert.Equal(SidebarNavId.ReligionInfo, state.CurrentNav);
+    }
+
+    [Fact]
+    public void CollapsedGroups_RoundTrip()
+    {
+        var state = new SidebarState();
+
+        state.CollapsedGroups["religion"] = true;
+        state.CollapsedGroups["blessings"] = false;
+
+        Assert.True(state.CollapsedGroups["religion"]);
+        Assert.False(state.CollapsedGroups["blessings"]);
+    }
+
+    [Fact]
+    public void Reset_ClearsGroupsAndRestoresDefaults()
+    {
+        var state = new SidebarState
+        {
+            IsCollapsed = true,
+            CurrentNav = SidebarNavId.CivilizationDiplomacy
+        };
+        state.CollapsedGroups["religion"] = true;
+
+        state.Reset();
+
+        Assert.False(state.IsCollapsed);
+        Assert.Empty(state.CollapsedGroups);
+        Assert.Equal(SidebarNavId.ReligionInfo, state.CurrentNav);
+    }
+}

--- a/DivineAscension.Tests/GUI/UI/Layout/UiRectTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Layout/UiRectTests.cs
@@ -1,0 +1,107 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.GUI.UI.Layout;
+
+namespace DivineAscension.Tests.GUI.UI.Layout;
+
+[ExcludeFromCodeCoverage]
+public class UiRectTests
+{
+    private static readonly UiRect Source = new(10f, 20f, 200f, 100f);
+
+    [Fact]
+    public void SplitLeft_NormalCase_ReturnsSliceAndRemainder()
+    {
+        var (left, remainder) = Source.SplitLeft(60f, 8f);
+
+        Assert.Equal(new UiRect(10f, 20f, 60f, 100f), left);
+        Assert.Equal(new UiRect(78f, 20f, 132f, 100f), remainder);
+    }
+
+    [Fact]
+    public void SplitLeft_NoGap_RemainderAbutsSlice()
+    {
+        var (left, remainder) = Source.SplitLeft(50f);
+        Assert.Equal(left.Right, remainder.X);
+    }
+
+    [Fact]
+    public void SplitLeft_OversizeWidth_ClampsToRectAndRemainderIsZero()
+    {
+        var (left, remainder) = Source.SplitLeft(500f);
+
+        Assert.Equal(Source.W, left.W);
+        Assert.Equal(0f, remainder.W);
+    }
+
+    [Fact]
+    public void SplitLeft_ZeroWidth_LeftIsEmptyRemainderFull()
+    {
+        var (left, remainder) = Source.SplitLeft(0f);
+
+        Assert.Equal(0f, left.W);
+        Assert.Equal(Source.W, remainder.W);
+    }
+
+    [Fact]
+    public void SplitLeft_NegativeGap_ClampsToZero()
+    {
+        var (_, withZero) = Source.SplitLeft(40f, 0f);
+        var (_, withNegative) = Source.SplitLeft(40f, -10f);
+
+        Assert.Equal(withZero, withNegative);
+    }
+
+    [Fact]
+    public void SplitRight_NormalCase_ReturnsRemainderAndSlice()
+    {
+        var (remainder, right) = Source.SplitRight(60f, 8f);
+
+        Assert.Equal(new UiRect(10f, 20f, 132f, 100f), remainder);
+        Assert.Equal(new UiRect(150f, 20f, 60f, 100f), right);
+    }
+
+    [Fact]
+    public void SplitRight_OversizeWidth_RemainderIsZero()
+    {
+        var (remainder, right) = Source.SplitRight(500f);
+
+        Assert.Equal(0f, remainder.W);
+        Assert.Equal(Source.W, right.W);
+    }
+
+    [Fact]
+    public void Inset_NormalCase_ShrinksAllSides()
+    {
+        var inset = Source.Inset(5f);
+        Assert.Equal(new UiRect(15f, 25f, 190f, 90f), inset);
+    }
+
+    [Fact]
+    public void Inset_OversizedPx_ClampsToZeroDimensions()
+    {
+        var inset = Source.Inset(200f);
+
+        Assert.Equal(0f, inset.W);
+        Assert.Equal(0f, inset.H);
+    }
+
+    [Fact]
+    public void Inset_NegativePx_ClampsToZero()
+    {
+        Assert.Equal(Source, Source.Inset(-3f));
+    }
+
+    [Fact]
+    public void Cut_NormalCase_TrimsTopAndBottom()
+    {
+        var cut = Source.Cut(10f, 5f);
+        Assert.Equal(new UiRect(10f, 30f, 200f, 85f), cut);
+    }
+
+    [Fact]
+    public void Cut_OversizedTrim_HeightClampsToZero()
+    {
+        var cut = Source.Cut(80f, 80f);
+        Assert.Equal(0f, cut.H);
+    }
+}

--- a/DivineAscension/Data/ModConfigData.cs
+++ b/DivineAscension/Data/ModConfigData.cs
@@ -77,4 +77,10 @@ public class ModConfigData
     /// </summary>
     [ProtoMember(9)]
     public int WarDeclarationCooldown { get; set; } = 60;
+
+    /// <summary>
+    ///     Persisted UI preferences (window size, sidebar collapsed state, last nav, etc.).
+    /// </summary>
+    [ProtoMember(11)]
+    public UiPrefs UiPrefs { get; set; } = new();
 }

--- a/DivineAscension/Data/UiPrefs.cs
+++ b/DivineAscension/Data/UiPrefs.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using DivineAscension.GUI.State;
+using ProtoBuf;
+
+namespace DivineAscension.Data;
+
+/// <summary>
+///     Persisted UI preferences. Round-tripped via <c>SerializerUtil</c> as part
+///     of <see cref="ModConfigData" />.
+/// </summary>
+[ProtoContract]
+public class UiPrefs
+{
+    [ProtoMember(1)] public int WindowWidth { get; set; } = 1400;
+
+    [ProtoMember(2)] public int WindowHeight { get; set; } = 900;
+
+    [ProtoMember(3)] public bool SidebarCollapsed { get; set; }
+
+    [ProtoMember(4)] public Dictionary<string, bool> CollapsedGroups { get; set; } = new();
+
+    [ProtoMember(5)] public SidebarNavId LastNavId { get; set; } = SidebarNavId.ReligionInfo;
+}

--- a/DivineAscension/GUI/Managers/NotificationManager.cs
+++ b/DivineAscension/GUI/Managers/NotificationManager.cs
@@ -31,6 +31,14 @@ public class NotificationManager(ISoundManager soundManager) : INotificationMana
     {
         var notification = new PendingNotification(type, rankName, rankDescription, deity);
 
+        // Push into persistent history (capped, ring-style). Every queued toast
+        // lands in history without retrofitting individual callers.
+        State.History.Add(new NotificationHistoryEntry(type, rankName, rankDescription, deity, DateTime.UtcNow));
+        while (State.History.Count > NotificationState.HistoryCap)
+        {
+            State.History.RemoveAt(0);
+        }
+
         // If queue is at max size, remove the oldest notification
         if (State.PendingNotifications.Count >= MaxQueueSize)
         {
@@ -44,6 +52,26 @@ public class NotificationManager(ISoundManager soundManager) : INotificationMana
         {
             ShowNextNotification();
         }
+    }
+
+    /// <summary>
+    ///     Marks the history entry at <paramref name="index" /> as read. Out-of-range
+    ///     indices are a no-op so callers can fire without bounds checks.
+    /// </summary>
+    public void MarkRead(int index)
+    {
+        if (index < 0 || index >= State.History.Count) return;
+        var entry = State.History[index];
+        if (entry.Read) return;
+        State.History[index] = entry with { Read = true };
+    }
+
+    /// <summary>
+    ///     Clears the notification history. Does not affect the live toast queue.
+    /// </summary>
+    public void ClearHistory()
+    {
+        State.History.Clear();
     }
 
     /// <summary>
@@ -176,4 +204,6 @@ public interface INotificationManager
     void Update(float deltaTime);
     void DismissCurrentNotification();
     void OnViewBlessingsClicked(Action openCallback, Action setTabCallback);
+    void MarkRead(int index);
+    void ClearHistory();
 }

--- a/DivineAscension/GUI/State/GuiDialogState.cs
+++ b/DivineAscension/GUI/State/GuiDialogState.cs
@@ -45,6 +45,16 @@ public class GuiDialogState
     public RankProgressHudState HudState { get; set; } = new();
 
     /// <summary>
+    ///     Sidebar nav state (Phase 1 scaffold; wired in Phase 3).
+    /// </summary>
+    public SidebarState Sidebar { get; } = new();
+
+    /// <summary>
+    ///     Right-rail state (Phase 1 scaffold; wired in Phase 3).
+    /// </summary>
+    public RightRailState RightRail { get; } = new();
+
+    /// <summary>
     ///     Initialize/reset all state to defaults
     /// </summary>
     public void Reset()
@@ -57,6 +67,8 @@ public class GuiDialogState
         WindowPosY = 0f;
         NotificationState?.Reset();
         HudState.Reset();
+        Sidebar.Reset();
+        RightRail.Reset();
     }
 }
 

--- a/DivineAscension/GUI/State/NotificationHistoryEntry.cs
+++ b/DivineAscension/GUI/State/NotificationHistoryEntry.cs
@@ -1,0 +1,18 @@
+using System;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.GUI.State;
+
+/// <summary>
+///     One row in the persistent notification history. Pushed by
+///     <c>NotificationManager.QueueRankUpNotification</c> at the moment a toast
+///     is queued. The right-rail feed renders these.
+/// </summary>
+public record NotificationHistoryEntry(
+    NotificationType Type,
+    string Title,
+    string Body,
+    DeityDomain Deity,
+    DateTime Timestamp,
+    bool Read = false
+);

--- a/DivineAscension/GUI/State/NotificationState.cs
+++ b/DivineAscension/GUI/State/NotificationState.cs
@@ -5,6 +5,8 @@ namespace DivineAscension.GUI.State;
 
 public class NotificationState
 {
+    public const int HistoryCap = 50;
+
     public bool IsVisible { get; set; }
     public NotificationType Type { get; set; }
     public string RankName { get; set; } = string.Empty;
@@ -13,6 +15,13 @@ public class NotificationState
     public float DisplayDuration { get; set; } = 8f;
     public float ElapsedTime { get; set; }
     public Queue<PendingNotification> PendingNotifications { get; set; } = new();
+
+    /// <summary>
+    ///     Ring-style history of every notification that has been queued. Capped at
+    ///     <see cref="HistoryCap" /> entries (oldest evicted). Surfaced by the
+    ///     right-rail notification feed in Phase 3.
+    /// </summary>
+    public List<NotificationHistoryEntry> History { get; } = new();
 
     public void Reset()
     {
@@ -24,6 +33,7 @@ public class NotificationState
         DisplayDuration = 8f;
         ElapsedTime = 0f;
         PendingNotifications.Clear();
+        History.Clear();
     }
 }
 

--- a/DivineAscension/GUI/State/RightRailState.cs
+++ b/DivineAscension/GUI/State/RightRailState.cs
@@ -1,0 +1,18 @@
+namespace DivineAscension.GUI.State;
+
+/// <summary>
+///     Runtime state for the right-hand rail introduced by the UI refactor.
+///     Currently tracks scroll position for the notification feed and an
+///     unread-only filter toggle.
+/// </summary>
+public class RightRailState
+{
+    public float ScrollY { get; set; }
+    public bool ShowUnreadOnly { get; set; }
+
+    public void Reset()
+    {
+        ScrollY = 0f;
+        ShowUnreadOnly = false;
+    }
+}

--- a/DivineAscension/GUI/State/SidebarNavId.cs
+++ b/DivineAscension/GUI/State/SidebarNavId.cs
@@ -1,0 +1,23 @@
+namespace DivineAscension.GUI.State;
+
+/// <summary>
+///     Flat navigation identifier for the upcoming sidebar layout. Each value names
+///     one selectable destination (master pane). Routing wiring lands in Phase 3 of
+///     the UI refactor; defined now because <see cref="SidebarState.CurrentNav" />
+///     needs a type.
+/// </summary>
+public enum SidebarNavId
+{
+    ReligionInfo = 0,
+    ReligionActivity,
+    ReligionRoles,
+    ReligionInvites,
+    ReligionCreate,
+    Blessings,
+    CivilizationInfo,
+    CivilizationInvites,
+    CivilizationCreate,
+    CivilizationDiplomacy,
+    CivilizationHolySites,
+    CivilizationMilestones
+}

--- a/DivineAscension/GUI/State/SidebarState.cs
+++ b/DivineAscension/GUI/State/SidebarState.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace DivineAscension.GUI.State;
+
+/// <summary>
+///     Runtime state for the sidebar nav surface. Persisted bits live in
+///     <c>UiPrefs</c>; this object holds the live, in-session view.
+/// </summary>
+public class SidebarState
+{
+    public bool IsCollapsed { get; set; }
+
+    public Dictionary<string, bool> CollapsedGroups { get; } = new();
+
+    public SidebarNavId CurrentNav { get; set; } = SidebarNavId.ReligionInfo;
+
+    public void Reset()
+    {
+        IsCollapsed = false;
+        CollapsedGroups.Clear();
+        CurrentNav = SidebarNavId.ReligionInfo;
+    }
+}

--- a/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
+++ b/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.GUI.State;
+
+namespace DivineAscension.GUI.UI.Layout;
+
+/// <summary>
+///     Top-level dispatcher for the dialog body. Phase 1 forwards verbatim to the
+///     existing tab-based <see cref="MainDialogRenderer" />; Phase 3 swaps the body
+///     to a sidebar + master/detail + right-rail layout.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class MainLayoutCoordinator
+{
+    public static void Draw(
+        GuiDialogManager manager,
+        GuiDialogState state,
+        int windowWidth,
+        int windowHeight,
+        float deltaTime)
+    {
+        MainDialogRenderer.Draw(manager, state, windowWidth, windowHeight, deltaTime);
+    }
+}

--- a/DivineAscension/GUI/UI/Layout/UiRect.cs
+++ b/DivineAscension/GUI/UI/Layout/UiRect.cs
@@ -1,0 +1,69 @@
+namespace DivineAscension.GUI.UI.Layout;
+
+/// <summary>
+///     Immutable rectangle in screen-space pixels. Used to flow layout regions
+///     down through renderer chains without leaking raw <c>ImGui.GetWindowPos()</c>
+///     calls into leaf renderers.
+/// </summary>
+public readonly record struct UiRect(float X, float Y, float W, float H)
+{
+    public float Right => X + W;
+    public float Bottom => Y + H;
+
+    /// <summary>
+    ///     Cut a fixed-width slice off the left. Returns the slice and the remainder
+    ///     (separated by <paramref name="gap" /> pixels). If <paramref name="width" />
+    ///     exceeds available width, the slice clamps to the rect and the remainder
+    ///     becomes a zero-width rect on the right edge.
+    /// </summary>
+    public (UiRect Left, UiRect Remainder) SplitLeft(float width, float gap = 0f)
+    {
+        var clampedGap = gap < 0f ? 0f : gap;
+        var sliceW = width < 0f ? 0f : (width > W ? W : width);
+        var left = new UiRect(X, Y, sliceW, H);
+        var remainderX = X + sliceW + clampedGap;
+        var remainderW = Right - remainderX;
+        if (remainderW < 0f) remainderW = 0f;
+        return (left, new UiRect(remainderX, Y, remainderW, H));
+    }
+
+    /// <summary>
+    ///     Cut a fixed-width slice off the right. Returns the remainder and the slice
+    ///     (separated by <paramref name="gap" /> pixels).
+    /// </summary>
+    public (UiRect Remainder, UiRect Right) SplitRight(float width, float gap = 0f)
+    {
+        var clampedGap = gap < 0f ? 0f : gap;
+        var sliceW = width < 0f ? 0f : (width > W ? W : width);
+        var right = new UiRect(Right - sliceW, Y, sliceW, H);
+        var remainderW = W - sliceW - clampedGap;
+        if (remainderW < 0f) remainderW = 0f;
+        return (new UiRect(X, Y, remainderW, H), right);
+    }
+
+    /// <summary>
+    ///     Shrink the rect inward by <paramref name="px" /> pixels on every side.
+    /// </summary>
+    public UiRect Inset(float px)
+    {
+        var inset = px < 0f ? 0f : px;
+        var newW = W - inset * 2f;
+        var newH = H - inset * 2f;
+        if (newW < 0f) newW = 0f;
+        if (newH < 0f) newH = 0f;
+        return new UiRect(X + inset, Y + inset, newW, newH);
+    }
+
+    /// <summary>
+    ///     Trim <paramref name="top" /> pixels off the top and <paramref name="bottom" />
+    ///     pixels off the bottom.
+    /// </summary>
+    public UiRect Cut(float top, float bottom)
+    {
+        var t = top < 0f ? 0f : top;
+        var b = bottom < 0f ? 0f : bottom;
+        var newH = H - t - b;
+        if (newH < 0f) newH = 0f;
+        return new UiRect(X, Y + t, W, newH);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the GuiDialog UI refactor (epic #258, issue #259). Pure plumbing — no visible UI change.

- `UiRect` value type with `SplitLeft` / `SplitRight` / `Inset` / `Cut`
- `SidebarState`, `RightRailState`, `SidebarNavId` (flat enum, 12 destinations)
- `NotificationHistoryEntry` + 50-entry ring buffer on `NotificationState`; `NotificationManager.QueueRankUpNotification` pushes into history, new `MarkRead(int)` / `ClearHistory()`
- `UiPrefs` ProtoBuf POCO wired onto `ModConfigData` as `[ProtoMember(11)]`
- `MainLayoutCoordinator` forwards verbatim to `MainDialogRenderer` (lit up in Phase 3)
- `GuiDialogState.Reset()` cascades to new substates

## Test plan

- [x] `dotnet build DivineAscension.sln -c Debug` — clean
- [x] `dotnet test` — 2155 passing, 0 failures (23 new tests across `UiRectTests`, `SidebarStateTests`, `NotificationManagerHistoryTests`, `UiPrefsTests`, plus extended `GuiDialogStateTests`)
- [x] Manual: launch VS, `Shift+G` — dialog identical to Phase 5b
- [x] Manual: trigger a rank-up, confirm toast still appears and `NotificationState.History` grows

Closes #259.