### PR TITLE
feat(ui): phase 2 — resizable window with persisted size

### DIFF
--- a/DivineAscension.Tests/GUI/State/GuiDialogStateTests.cs
+++ b/DivineAscension.Tests/GUI/State/GuiDialogStateTests.cs
@@ -67,6 +67,8 @@ public class GuiDialogStateTests
         state.Sidebar.CollapsedGroups["g"] = true;
         state.RightRail.ScrollY = 42f;
         state.RightRail.ShowUnreadOnly = true;
+        state.WindowWidth = 1234f;
+        state.WindowHeight = 567f;
 
         // Act
         state.Reset();
@@ -81,6 +83,8 @@ public class GuiDialogStateTests
         Assert.Empty(state.Sidebar.CollapsedGroups);
         Assert.Equal(0f, state.RightRail.ScrollY);
         Assert.False(state.RightRail.ShowUnreadOnly);
+        Assert.Equal(0f, state.WindowWidth);
+        Assert.Equal(0f, state.WindowHeight);
     }
 
     [Fact]

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -543,5 +543,18 @@ public class DivineAscensionModSystem : ModSystem
         SaveModConfig();
     }
 
+    /// <summary>
+    ///     Persists the user's chosen dialog window size into <c>UiPrefs</c> and
+    ///     writes the mod config. Safe to call on the client; <c>SaveModConfig</c>
+    ///     silently no-ops if no server save-game is available.
+    /// </summary>
+    public void SaveUiPrefs(int width, int height)
+    {
+        if (width <= 0 || height <= 0) return;
+        _configData.UiPrefs.WindowWidth = width;
+        _configData.UiPrefs.WindowHeight = height;
+        SaveModConfig();
+    }
+
     #endregion
 }

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -201,6 +201,13 @@ public partial class GuiDialog : ModSystem
 
         _state.IsOpen = false;
 
+        // Persist the most recent window size captured during DrawWindow.
+        // Snapshot lives on _state; DrawWindow refreshes it each frame.
+        if (_state.WindowWidth > 0f && _state.WindowHeight > 0f)
+        {
+            _divineAscensionModSystem?.SaveUiPrefs((int)_state.WindowWidth, (int)_state.WindowHeight);
+        }
+
         _logger?.Debug("[DivineAscension] Blessing Dialog closed");
     }
 
@@ -414,9 +421,16 @@ public partial class GuiDialog : ModSystem
         var deltaTime = _stopwatch!.ElapsedMilliseconds / 1000f;
         _stopwatch.Restart();
 
-        // Calculate window size (constrained to screen)
-        var windowWidth = Math.Min(WindowBaseWidth, (int)window.OuterWidth - 128);
-        var windowHeight = Math.Min(WindowBaseHeight, (int)window.OuterHeight - 128);
+        // Initial window size from persisted UiPrefs (clamped to screen).
+        // Applied only on first use; user-driven resizes within a session and
+        // restored sizes across sessions stick from then on.
+        var uiPrefs = _divineAscensionModSystem?.Config.UiPrefs;
+        var prefsW = uiPrefs?.WindowWidth ?? WindowBaseWidth;
+        var prefsH = uiPrefs?.WindowHeight ?? WindowBaseHeight;
+        if (prefsW <= 0) prefsW = WindowBaseWidth;
+        if (prefsH <= 0) prefsH = WindowBaseHeight;
+        var initialW = Math.Min(prefsW, (int)window.OuterWidth - 128);
+        var initialH = Math.Min(prefsH, (int)window.OuterHeight - 128);
 
         // Set window style (no borders, no title bar, no padding, centered)
         ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0);
@@ -424,15 +438,14 @@ public partial class GuiDialog : ModSystem
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
         ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 0);
 
-        // Position window at center of screen
-        ImGui.SetNextWindowSize(new Vector2(windowWidth, windowHeight));
+        // Size + center on first open only — afterwards ImGui keeps user resizes.
+        ImGui.SetNextWindowSize(new Vector2(initialW, initialH), ImGuiCond.FirstUseEver);
         ImGui.SetNextWindowPos(new Vector2(
-            _viewport.Pos.X + (_viewport.Size.X - windowWidth) / 2,
-            _viewport.Pos.Y + (_viewport.Size.Y - windowHeight) / 2
-        ));
+            _viewport.Pos.X + (_viewport.Size.X - initialW) / 2,
+            _viewport.Pos.Y + (_viewport.Size.Y - initialH) / 2
+        ), ImGuiCond.FirstUseEver);
 
         var flags = ImGuiWindowFlags.NoTitleBar |
-                    ImGuiWindowFlags.NoResize |
                     ImGuiWindowFlags.NoMove |
                     ImGuiWindowFlags.NoScrollbar |
                     ImGuiWindowFlags.NoScrollWithMouse;
@@ -442,10 +455,17 @@ public partial class GuiDialog : ModSystem
 
         ImGui.Begin("DivineAscension Blessing Dialog", flags);
 
-        // Track window position for drawing
+        // Track live window position + size (drives renderer layout and the
+        // size-on-close persistence in Close()).
         var windowPos = ImGui.GetWindowPos();
+        var windowSize = ImGui.GetWindowSize();
         _state.WindowPosX = windowPos.X;
         _state.WindowPosY = windowPos.Y;
+        _state.WindowWidth = windowSize.X;
+        _state.WindowHeight = windowSize.Y;
+
+        var windowWidth = (int)windowSize.X;
+        var windowHeight = (int)windowSize.Y;
 
         // Draw content
         DrawBackground(windowWidth, windowHeight);

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -452,6 +452,13 @@ public partial class GuiDialog : ModSystem
 
         // Set window background color (Issue #71: Use ColorPalette.Background)
         ImGui.PushStyleColor(ImGuiCol.WindowBg, ColorPalette.Background);
+        // Make ImGui's native resize grip visible (it ships nearly invisible against
+        // our dark background). Also drives the resize cursor on hover.
+        ImGui.PushStyleColor(ImGuiCol.ResizeGrip,
+            ColorPalette.WithAlpha(ColorPalette.BorderColor, 0.6f));
+        ImGui.PushStyleColor(ImGuiCol.ResizeGripHovered,
+            ColorPalette.WithAlpha(ColorPalette.Gold, 0.85f));
+        ImGui.PushStyleColor(ImGuiCol.ResizeGripActive, ColorPalette.Gold);
 
         ImGui.Begin("DivineAscension Blessing Dialog", flags);
 
@@ -480,7 +487,7 @@ public partial class GuiDialog : ModSystem
         );
 
         ImGui.End();
-        ImGui.PopStyleColor(); // Pop window background color
+        ImGui.PopStyleColor(4); // WindowBg + 3 ResizeGrip variants
         ImGui.PopStyleVar(4); // Pop all 4 style vars
     }
 
@@ -531,6 +538,35 @@ public partial class GuiDialog : ModSystem
         // Draw main window border (Issue #71: Use ColorPalette.BorderColor #59422f, 4px width)
         var frameColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor);
         drawList.AddRect(pos, new Vector2(pos.X + width, pos.Y + height), frameColor, 0, ImDrawFlags.None, 4);
+
+        // Resize affordance: three diagonal strokes in the bottom-right corner.
+        // Pairs with the brightened ImGuiCol.ResizeGrip so the resize area is
+        // visible even before hover.
+        DrawResizeHandleGlyph(drawList, pos, width, height);
+    }
+
+    /// <summary>
+    ///     Three diagonal strokes inset from the bottom-right corner, indicating
+    ///     the window can be dragged to resize.
+    /// </summary>
+    private static void DrawResizeHandleGlyph(ImDrawListPtr drawList, Vector2 pos, int width, int height)
+    {
+        const float inset = 6f;
+        const float stroke = 1.5f;
+        var color = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Gold, 0.85f));
+        var cornerX = pos.X + width - inset;
+        var cornerY = pos.Y + height - inset;
+
+        // Three nested diagonals at 4/8/12 px lengths, parallel to the corner.
+        for (var i = 0; i < 3; i++)
+        {
+            var len = 4f + i * 4f;
+            drawList.AddLine(
+                new Vector2(cornerX - len, cornerY),
+                new Vector2(cornerX, cornerY - len),
+                color,
+                stroke);
+        }
     }
 
     public override void Dispose()

--- a/DivineAscension/GUI/State/GuiDialogState.cs
+++ b/DivineAscension/GUI/State/GuiDialogState.cs
@@ -35,6 +35,18 @@ public class GuiDialogState
     /// </summary>
     public float WindowPosY { get; set; }
 
+    /// <summary>
+    ///     Live window width snapshot, captured each frame inside <c>DrawWindow</c>.
+    ///     Persisted on <c>Close()</c> via <c>UiPrefs</c>.
+    /// </summary>
+    public float WindowWidth { get; set; }
+
+    /// <summary>
+    ///     Live window height snapshot, captured each frame inside <c>DrawWindow</c>.
+    ///     Persisted on <c>Close()</c> via <c>UiPrefs</c>.
+    /// </summary>
+    public float WindowHeight { get; set; }
+
     public NotificationState? NotificationState { get; set; }
     public string? PreviousFavorRank { get; set; }
     public string? PreviousPrestigeRank { get; set; }
@@ -65,6 +77,8 @@ public class GuiDialogState
         CurrentMainTab = MainDialogTab.Religion;
         WindowPosX = 0f;
         WindowPosY = 0f;
+        WindowWidth = 0f;
+        WindowHeight = 0f;
         NotificationState?.Reset();
         HudState.Reset();
         Sidebar.Reset();


### PR DESCRIPTION
## Summary

Phase 2 of the GuiDialog UI refactor (epic #258, issue #260). Builds on the `UiPrefs` plumbing from Phase 1 (#263) to make the main dialog resizable and remember the user's chosen size across sessions.

- Drop `ImGuiWindowFlags.NoResize` from the main dialog only — notification overlay and rank-progress HUD stay non-resizable.
- `ImGui.SetNextWindowSize` / `SetNextWindowPos` now use `ImGuiCond.FirstUseEver` so the renderer no longer fights user resizes every frame.
- Initial size sourced from `ModConfigData.UiPrefs` (clamped to screen, falls back to `WindowBaseWidth = 1400` / `WindowBaseHeight = 900`).
- `DrawWindow` captures live `ImGui.GetWindowSize()` into `_state.WindowWidth/Height` each frame, then feeds those numbers to `MainDialogRenderer.Draw` so the layout follows the user's drag immediately.
- `Close()` pushes the most recent snapshot through new `DivineAscensionModSystem.SaveUiPrefs(int, int)` which writes `UiPrefs` and calls `SaveModConfig()`.

## Test plan

- [x] `dotnet build DivineAscension.sln -c Debug` — clean
- [x] `dotnet test` — 2155 passing, 0 failures
- [ ] Manual: `Shift+G`, drag corner to resize, close, reopen — size restored
- [ ] Manual: restart the game — size still restored (verifies `SerializerUtil` round-trip)
- [ ] Manual: trigger a rank-up — notification toast still non-resizable
- [ ] Manual: rank-progress HUD overlay still non-resizable

Closes #260.