### PR TITLE
feat(ui): phase 3a — sidebar + right rail scaffold (no visible change)

### DIFF
--- a/DivineAscension.Tests/GUI/UI/Sidebar/SidebarNavMapperTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Sidebar/SidebarNavMapperTests.cs
@@ -1,0 +1,233 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.Constants;
+using DivineAscension.GUI.State;
+using DivineAscension.GUI.State.Religion;
+using DivineAscension.GUI.UI.Renderers.Sidebar;
+
+namespace DivineAscension.Tests.GUI.UI.Sidebar;
+
+[ExcludeFromCodeCoverage]
+public class SidebarNavMapperTests
+{
+    private static SidebarNavMapper.Context Ctx(
+        bool hasReligion = false,
+        bool hasCivilization = false,
+        bool isCivFounder = false,
+        bool isReligionFounder = false,
+        int religionInvites = 0,
+        int civInvites = 0,
+        SidebarNavId currentNav = SidebarNavId.ReligionInfo,
+        IReadOnlyDictionary<string, bool>? collapsed = null)
+    {
+        return new SidebarNavMapper.Context(
+            hasReligion,
+            hasCivilization,
+            isCivFounder,
+            isReligionFounder,
+            religionInvites,
+            civInvites,
+            currentNav,
+            collapsed);
+    }
+
+    private static SidebarItemViewModel Find(SidebarViewModel vm, SidebarNavId id)
+    {
+        return vm.Groups.SelectMany(g => g.Items).First(i => i.Id == id);
+    }
+
+    [Fact]
+    public void NoReligion_NoCivilization_RestrictedItemsAreDisabledWithTooltips()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(Ctx());
+
+        var info = Find(vm, SidebarNavId.ReligionInfo);
+        Assert.True(info.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION, info.DisabledTooltipKey);
+
+        var roles = Find(vm, SidebarNavId.ReligionRoles);
+        Assert.True(roles.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION, roles.DisabledTooltipKey);
+
+        var invites = Find(vm, SidebarNavId.ReligionInvites);
+        Assert.False(invites.IsDisabled);
+
+        var create = Find(vm, SidebarNavId.ReligionCreate);
+        Assert.False(create.IsDisabled);
+
+        var civInfo = Find(vm, SidebarNavId.CivilizationInfo);
+        Assert.True(civInfo.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_NEED_CIVILIZATION, civInfo.DisabledTooltipKey);
+
+        var civInvites = Find(vm, SidebarNavId.CivilizationInvites);
+        Assert.True(civInvites.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION, civInvites.DisabledTooltipKey);
+    }
+
+    [Fact]
+    public void HasReligion_NotFounder_RolesDisabledWithFounderOnly()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true, isReligionFounder: false));
+
+        Assert.False(Find(vm, SidebarNavId.ReligionInfo).IsDisabled);
+        Assert.False(Find(vm, SidebarNavId.ReligionActivity).IsDisabled);
+
+        var roles = Find(vm, SidebarNavId.ReligionRoles);
+        Assert.True(roles.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_FOUNDER_ONLY, roles.DisabledTooltipKey);
+    }
+
+    [Fact]
+    public void HasReligion_AsFounder_RolesEnabled()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true, isReligionFounder: true));
+
+        Assert.False(Find(vm, SidebarNavId.ReligionRoles).IsDisabled);
+    }
+
+    [Fact]
+    public void HasReligion_InvitesAndCreateBlockedAsAlreadyInReligion()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true, isReligionFounder: false));
+
+        var invites = Find(vm, SidebarNavId.ReligionInvites);
+        Assert.True(invites.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_RELIGION, invites.DisabledTooltipKey);
+
+        var create = Find(vm, SidebarNavId.ReligionCreate);
+        Assert.True(create.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_RELIGION, create.DisabledTooltipKey);
+    }
+
+    [Fact]
+    public void HasReligion_NoCivilization_CivilizationInvitesEnabled()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true));
+
+        var invites = Find(vm, SidebarNavId.CivilizationInvites);
+        Assert.False(invites.IsDisabled);
+
+        var create = Find(vm, SidebarNavId.CivilizationCreate);
+        Assert.False(create.IsDisabled);
+    }
+
+    [Fact]
+    public void HasCivilization_InvitesAndCreateBlockedAsAlreadyInCivilization()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true, hasCivilization: true));
+
+        var invites = Find(vm, SidebarNavId.CivilizationInvites);
+        Assert.True(invites.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_CIVILIZATION, invites.DisabledTooltipKey);
+
+        var create = Find(vm, SidebarNavId.CivilizationCreate);
+        Assert.True(create.IsDisabled);
+        Assert.Equal(LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_CIVILIZATION, create.DisabledTooltipKey);
+    }
+
+    [Fact]
+    public void HasCivilization_AllCivilizationContentItemsEnabled()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true, hasCivilization: true));
+
+        Assert.False(Find(vm, SidebarNavId.CivilizationInfo).IsDisabled);
+        Assert.False(Find(vm, SidebarNavId.CivilizationDiplomacy).IsDisabled);
+        Assert.False(Find(vm, SidebarNavId.CivilizationHolySites).IsDisabled);
+        Assert.False(Find(vm, SidebarNavId.CivilizationMilestones).IsDisabled);
+    }
+
+    [Fact]
+    public void Blessings_AlwaysEnabled()
+    {
+        var vmOut = SidebarNavMapper.BuildViewModel(Ctx());
+        Assert.False(Find(vmOut, SidebarNavId.Blessings).IsDisabled);
+
+        var vmFull = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true, hasCivilization: true,
+                isCivFounder: true, isReligionFounder: true));
+        Assert.False(Find(vmFull, SidebarNavId.Blessings).IsDisabled);
+    }
+
+    [Fact]
+    public void BadgeCounts_FlowFromContextToInviteItems()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(hasReligion: true, religionInvites: 3, civInvites: 5));
+
+        // Religion invites is disabled (already in religion) but badge still passes through.
+        Assert.Equal(3, Find(vm, SidebarNavId.ReligionInvites).Badge);
+        Assert.Equal(5, Find(vm, SidebarNavId.CivilizationInvites).Badge);
+    }
+
+    [Fact]
+    public void CurrentNav_MarksMatchingItemActive()
+    {
+        var vm = SidebarNavMapper.BuildViewModel(
+            Ctx(currentNav: SidebarNavId.Blessings));
+
+        Assert.True(Find(vm, SidebarNavId.Blessings).IsActive);
+        Assert.False(Find(vm, SidebarNavId.ReligionInfo).IsActive);
+    }
+
+    [Fact]
+    public void CollapsedGroups_FlowIntoGroupViewModel()
+    {
+        var collapsed = new Dictionary<string, bool>
+        {
+            [SidebarNavMapper.GroupReligionKey] = true
+        };
+        var vm = SidebarNavMapper.BuildViewModel(Ctx(collapsed: collapsed));
+
+        var religionGroup = vm.Groups.First(g => g.Key == SidebarNavMapper.GroupReligionKey);
+        Assert.True(religionGroup.IsCollapsed);
+
+        var civGroup = vm.Groups.First(g => g.Key == SidebarNavMapper.GroupCivilizationKey);
+        Assert.False(civGroup.IsCollapsed);
+    }
+
+    [Fact]
+    public void Apply_BlessingsNav_SwitchesMainTabAndClearsSubTab()
+    {
+        var state = new GuiDialogState { CurrentMainTab = MainDialogTab.Religion };
+        var religion = new ReligionTabState();
+        var civ = new CivilizationTabState();
+
+        SidebarNavMapper.Apply(SidebarNavId.Blessings, state, religion, civ);
+
+        Assert.Equal(MainDialogTab.Blessings, state.CurrentMainTab);
+        Assert.Equal(SidebarNavId.Blessings, state.Sidebar.CurrentNav);
+    }
+
+    [Fact]
+    public void Apply_ReligionRoles_SetsMainTabAndSubTab()
+    {
+        var state = new GuiDialogState();
+        var religion = new ReligionTabState();
+        var civ = new CivilizationTabState();
+
+        SidebarNavMapper.Apply(SidebarNavId.ReligionRoles, state, religion, civ);
+
+        Assert.Equal(MainDialogTab.Religion, state.CurrentMainTab);
+        Assert.Equal(SubTab.Roles, religion.CurrentSubTab);
+    }
+
+    [Fact]
+    public void Apply_CivilizationMilestones_SetsMainTabAndSubTab()
+    {
+        var state = new GuiDialogState();
+        var religion = new ReligionTabState();
+        var civ = new CivilizationTabState();
+
+        SidebarNavMapper.Apply(SidebarNavId.CivilizationMilestones, state, religion, civ);
+
+        Assert.Equal(MainDialogTab.Civilization, state.CurrentMainTab);
+        Assert.Equal(CivilizationSubTab.Milestones, civ.CurrentSubTab);
+    }
+}

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -272,6 +272,21 @@ public static class LocalizationKeys
 
     #endregion
 
+    #region Sidebar Nav (Phase 3 UI refactor)
+
+    public const string SIDEBAR_GROUP_RELIGION = "divineascension:ui.sidebar.group.religion";
+    public const string SIDEBAR_GROUP_CIVILIZATION = "divineascension:ui.sidebar.group.civilization";
+    public const string SIDEBAR_GROUP_PERSONAL = "divineascension:ui.sidebar.group.personal";
+
+    public const string SIDEBAR_DISABLED_NEED_RELIGION = "divineascension:ui.sidebar.disabled.need_religion";
+    public const string SIDEBAR_DISABLED_NEED_CIVILIZATION = "divineascension:ui.sidebar.disabled.need_civilization";
+    public const string SIDEBAR_DISABLED_NEED_INVITE = "divineascension:ui.sidebar.disabled.need_invite";
+    public const string SIDEBAR_DISABLED_FOUNDER_ONLY = "divineascension:ui.sidebar.disabled.founder_only";
+    public const string SIDEBAR_DISABLED_ALREADY_IN_RELIGION = "divineascension:ui.sidebar.disabled.already_in_religion";
+    public const string SIDEBAR_DISABLED_ALREADY_IN_CIVILIZATION = "divineascension:ui.sidebar.disabled.already_in_civilization";
+
+    #endregion
+
     #region Civilization - Holy Sites
 
     public const string UI_CIVILIZATION_HOLYSITES_TITLE = "divineascension:ui.civilization.holysites.title";

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -52,6 +52,11 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     public DiplomacyState DiplomacyState => State.DiplomacyState;
 
     /// <summary>
+    ///     Public accessor for invite state (used by sidebar nav badge counts).
+    /// </summary>
+    public InviteState InviteState => State.InviteState;
+
+    /// <summary>
     ///     Public accessor for current sub-tab (for network client access)
     /// </summary>
     public CivilizationSubTab CurrentSubTab => State.CurrentSubTab;

--- a/DivineAscension/GUI/UI/Renderers/RightRail/RightRailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/RightRail/RightRailRenderer.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.Constants;
+using DivineAscension.Extensions;
+using DivineAscension.GUI.UI.Layout;
+using DivineAscension.GUI.UI.Renderers.Components;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems;
+using ImGuiNET;
+using static DivineAscension.GUI.UI.Utilities.FontSizes;
+
+namespace DivineAscension.GUI.UI.Renderers.RightRail;
+
+/// <summary>
+///     Vertical layout in a 340px-wide column: religion block, civilization block,
+///     notification feed. Anchored to a passed <see cref="UiRect" />. Phase 3b
+///     wires this into <c>MainLayoutCoordinator</c>; in Phase 3a the file is
+///     intentionally not called from production code.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class RightRailRenderer
+{
+    private const float Padding = 12f;
+    private const float BlockSpacing = 10f;
+    private const float IconSize = 40f;
+    private const float ProgressBarHeight = 12f;
+    private const float ProgressBarSpacing = 18f;
+
+    public static void Draw(UiRect rect, RightRailViewModel vm)
+    {
+        if (rect.W <= 0f || rect.H <= 0f) return;
+
+        var drawList = ImGui.GetWindowDrawList();
+
+        // Outer panel background + border.
+        var bg = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
+        var border = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.5f);
+        drawList.AddRectFilled(new Vector2(rect.X, rect.Y),
+            new Vector2(rect.Right, rect.Bottom), bg, 4f);
+        drawList.AddRect(new Vector2(rect.X, rect.Y),
+            new Vector2(rect.Right, rect.Bottom), border, 4f, ImDrawFlags.None, 2f);
+
+        var inner = rect.Inset(Padding);
+        var cursorY = inner.Y;
+
+        cursorY = DrawReligionBlock(drawList, inner, cursorY, vm);
+        cursorY = DrawCivilizationBlock(drawList, inner, cursorY + BlockSpacing, vm);
+        DrawNotificationFeed(rect, inner, cursorY + BlockSpacing, vm);
+    }
+
+    private static float DrawReligionBlock(ImDrawListPtr drawList, UiRect inner, float y,
+        RightRailViewModel vm)
+    {
+        var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
+        var labelColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
+
+        if (!vm.HasReligion)
+        {
+            var msg = LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_NO_RELIGION);
+            drawList.AddText(ImGui.GetFont(), Body, new Vector2(inner.X, y),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), msg);
+            return y + 24f;
+        }
+
+        var iconPos = new Vector2(inner.X, y);
+        var deityTexture = DeityIconLoader.GetDeityTextureId(vm.CurrentDeity);
+        if (deityTexture != IntPtr.Zero)
+        {
+            drawList.AddImage(deityTexture, iconPos,
+                new Vector2(iconPos.X + IconSize, iconPos.Y + IconSize),
+                Vector2.Zero, Vector2.One,
+                ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f)));
+            drawList.AddRect(iconPos,
+                new Vector2(iconPos.X + IconSize, iconPos.Y + IconSize),
+                ImGui.ColorConvertFloat4ToU32(DomainHelper.GetDeityColor(vm.CurrentDeity) * 0.8f),
+                4f, ImDrawFlags.None, 2f);
+        }
+
+        var textX = inner.X + IconSize + 8f;
+        var religionName = vm.CurrentReligionName
+            ?? LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_UNKNOWN_RELIGION);
+        var deityName = !string.IsNullOrEmpty(vm.CurrentDeityName)
+            ? vm.CurrentDeityName!
+            : vm.CurrentDeity.ToLocalizedString();
+
+        drawList.AddText(ImGui.GetFont(), SectionHeader, new Vector2(textX, y),
+            labelColor, religionName);
+        drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(textX, y + 22f),
+            textColor, deityName);
+
+        var afterIconY = y + IconSize + 6f;
+
+        // Favor progress
+        var favor = vm.PlayerFavorProgress;
+        var favorLabel = favor.IsMaxRank
+            ? $"{RankRequirements.GetFavorRankName(favor.CurrentRank)} (MAX)"
+            : $"{RankRequirements.GetFavorRankName(favor.CurrentRank)} ({favor.CurrentFavor}/{favor.RequiredFavor})";
+        ProgressBarRenderer.DrawProgressBar(drawList,
+            inner.X, afterIconY, inner.W, ProgressBarHeight,
+            favor.ProgressPercentage, ColorPalette.Gold, ColorPalette.DarkBrown,
+            favorLabel, favor.ProgressPercentage > 0.8f);
+
+        afterIconY += ProgressBarSpacing;
+
+        // Prestige progress
+        var prestige = vm.ReligionPrestigeProgress;
+        var prestigeLabel = prestige.IsMaxRank
+            ? $"{RankRequirements.GetPrestigeRankName(prestige.CurrentRank)} (MAX)"
+            : $"{RankRequirements.GetPrestigeRankName(prestige.CurrentRank)} ({prestige.CurrentPrestige}/{prestige.RequiredPrestige})";
+        ProgressBarRenderer.DrawProgressBar(drawList,
+            inner.X, afterIconY, inner.W, ProgressBarHeight,
+            prestige.ProgressPercentage, new Vector4(0.48f, 0.41f, 0.93f, 1f),
+            ColorPalette.DarkBrown, prestigeLabel, prestige.ProgressPercentage > 0.8f);
+
+        return afterIconY + ProgressBarHeight + 4f;
+    }
+
+    private static float DrawCivilizationBlock(ImDrawListPtr drawList, UiRect inner, float y,
+        RightRailViewModel vm)
+    {
+        // Separator
+        var sepColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.3f);
+        drawList.AddLine(new Vector2(inner.X, y - BlockSpacing / 2f),
+            new Vector2(inner.Right, y - BlockSpacing / 2f), sepColor, 1f);
+
+        if (!vm.HasCivilization && string.IsNullOrEmpty(vm.CurrentCivilizationName))
+        {
+            var msg = LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_UNKNOWN_CIVILIZATION);
+            drawList.AddText(ImGui.GetFont(), Body, new Vector2(inner.X, y),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), msg);
+            return y + 24f;
+        }
+
+        var iconPos = new Vector2(inner.X, y);
+        var civTexture = CivilizationIconLoader.GetIconTextureId(vm.CivilizationIcon ?? "default");
+        drawList.AddImage(civTexture, iconPos,
+            new Vector2(iconPos.X + IconSize, iconPos.Y + IconSize),
+            Vector2.Zero, Vector2.One,
+            ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f)));
+        drawList.AddRect(iconPos,
+            new Vector2(iconPos.X + IconSize, iconPos.Y + IconSize),
+            ImGui.ColorConvertFloat4ToU32(new Vector4(0.8f, 0.8f, 0.8f, 1f)),
+            4f, ImDrawFlags.None, 2f);
+
+        var textX = inner.X + IconSize + 8f;
+        var civName = vm.CurrentCivilizationName
+            ?? LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_UNKNOWN_CIVILIZATION);
+        var rankName = RankRequirements.GetCivilizationRankName(vm.CivilizationRank);
+
+        drawList.AddText(ImGui.GetFont(), SectionHeader, new Vector2(textX, y),
+            ImGui.ColorConvertFloat4ToU32(new Vector4(0.5f, 0.8f, 1f, 1f)), civName);
+        drawList.AddText(ImGui.GetFont(), Body, new Vector2(textX, y + 22f),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.8f), $"[{rankName}]");
+
+        var rowY = y + IconSize + 6f;
+        var memberCount = vm.CivilizationMemberReligions.Count;
+        var memberText = LocalizationService.Instance.Get(
+            LocalizationKeys.UI_BLESSING_RELIGIONS_COUNT, memberCount);
+        drawList.AddText(ImGui.GetFont(), Body, new Vector2(inner.X, rowY),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), memberText);
+        rowY += 18f;
+
+        // Member-religion deity icons.
+        if (memberCount > 0)
+        {
+            var deityX = inner.X;
+            const float deityIconSize = 18f;
+            const float deityIconSpacing = 4f;
+            foreach (var member in vm.CivilizationMemberReligions)
+            {
+                if (!Enum.TryParse<DeityDomain>(member.Domain, out var deity)) continue;
+                var tex = DeityIconLoader.GetDeityTextureId(deity);
+                drawList.AddImage(tex,
+                    new Vector2(deityX, rowY),
+                    new Vector2(deityX + deityIconSize, rowY + deityIconSize),
+                    Vector2.Zero, Vector2.One,
+                    ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f)));
+                deityX += deityIconSize + deityIconSpacing;
+                if (deityX + deityIconSize > inner.Right) break;
+            }
+            rowY += deityIconSize + 4f;
+        }
+
+        if (vm.IsCivilizationFounder)
+        {
+            drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(inner.X, rowY),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), "*** Founder ***");
+            rowY += 18f;
+        }
+
+        return rowY;
+    }
+
+    private static void DrawNotificationFeed(UiRect outer, UiRect inner, float y,
+        RightRailViewModel vm)
+    {
+        var available = outer.Bottom - y - Padding;
+        if (available <= 0f) return;
+
+        ImGui.SetCursorScreenPos(new Vector2(inner.X, y));
+        ImGui.BeginChild("##da-rightrail-feed",
+            new Vector2(inner.W, available), false,
+            ImGuiWindowFlags.None);
+
+        var count = 0;
+        for (var i = vm.Notifications.Count - 1; i >= 0; i--)
+        {
+            var entry = vm.Notifications[i];
+            if (vm.ShowUnreadOnly && entry.Read) continue;
+
+            DrawNotificationRow(entry);
+            count++;
+        }
+
+        if (count == 0)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ColorPalette.Grey);
+            ImGui.TextWrapped("(no notifications)");
+            ImGui.PopStyleColor();
+        }
+
+        ImGui.EndChild();
+    }
+
+    private static void DrawNotificationRow(GUI.State.NotificationHistoryEntry entry)
+    {
+        var color = entry.Read ? ColorPalette.Grey : ColorPalette.White;
+        ImGui.PushStyleColor(ImGuiCol.Text, color);
+        ImGui.TextWrapped($"{entry.Timestamp:HH:mm}  {entry.Title}");
+        ImGui.PopStyleColor();
+        if (!string.IsNullOrEmpty(entry.Body))
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ColorPalette.Grey);
+            ImGui.TextWrapped($"  {entry.Body}");
+            ImGui.PopStyleColor();
+        }
+        ImGui.Spacing();
+    }
+}

--- a/DivineAscension/GUI/UI/Renderers/RightRail/RightRailViewModel.cs
+++ b/DivineAscension/GUI/UI/Renderers/RightRail/RightRailViewModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using DivineAscension.GUI.State;
+using DivineAscension.Models;
+using DivineAscension.Models.Enum;
+using DivineAscension.Network.Civilization;
+
+namespace DivineAscension.GUI.UI.Renderers.RightRail;
+
+/// <summary>
+///     Data needed to render the right-rail religion + civilization status blocks
+///     and the notification feed. Fields mirror what <c>ReligionHeaderViewModel</c>
+///     already carries today (Phase 5b's expanded two-column dataset) so the rail
+///     can stand in for the existing top banner once Phase 3b flips the layout.
+/// </summary>
+public sealed record RightRailViewModel(
+    // Religion block --------------------------------------------------------
+    bool HasReligion,
+    string? CurrentReligionName,
+    string? CurrentDeityName,
+    DeityDomain CurrentDeity,
+    int ReligionMemberCount,
+    string? PlayerRoleInReligion,
+    PlayerFavorProgress PlayerFavorProgress,
+    ReligionPrestigeProgress ReligionPrestigeProgress,
+    // Civilization block ---------------------------------------------------
+    bool HasCivilization,
+    string? CurrentCivilizationName,
+    string? CivilizationIcon,
+    int CivilizationRank,
+    IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> CivilizationMemberReligions,
+    bool IsCivilizationFounder,
+    // Notification feed -----------------------------------------------------
+    IReadOnlyList<NotificationHistoryEntry> Notifications,
+    bool ShowUnreadOnly
+);

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarNavMapper.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarNavMapper.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using DivineAscension.Constants;
+using DivineAscension.GUI.State;
+using DivineAscension.GUI.State.Religion;
+using DivineAscension.Services;
+
+namespace DivineAscension.GUI.UI.Renderers.Sidebar;
+
+/// <summary>
+///     Pure mapping from manager-derived flags + counts into a
+///     <see cref="SidebarViewModel" />, plus an <see cref="Apply" /> helper
+///     that translates clicks into the legacy
+///     <c>CurrentMainTab</c> / <c>CurrentSubTab</c> writes the existing
+///     state managers still consume until Phase 4 retires those fields.
+/// </summary>
+public static class SidebarNavMapper
+{
+    public const string GroupReligionKey = "religion";
+    public const string GroupCivilizationKey = "civilization";
+    public const string GroupPersonalKey = "personal";
+
+    /// <summary>
+    ///     Input snapshot. Kept primitive so tests don't have to construct a
+    ///     <c>GuiDialogManager</c>. Production code builds one of these from the
+    ///     manager via <see cref="ContextFromManager" />.
+    /// </summary>
+    public readonly record struct Context(
+        bool HasReligion,
+        bool HasCivilization,
+        bool IsCivilizationFounder,
+        bool IsReligionFounder,
+        int ReligionInviteCount,
+        int CivilizationInviteCount,
+        SidebarNavId CurrentNav,
+        IReadOnlyDictionary<string, bool>? CollapsedGroups
+    );
+
+    /// <summary>
+    ///     Build a <see cref="SidebarViewModel" /> from a context snapshot.
+    ///     Conditional items render as disabled-with-tooltip rather than absent —
+    ///     this is the visibility contract for the new sidebar.
+    /// </summary>
+    public static SidebarViewModel BuildViewModel(Context ctx)
+    {
+        var groups = new List<SidebarGroupViewModel>(3)
+        {
+            BuildReligionGroup(ctx),
+            BuildCivilizationGroup(ctx),
+            BuildPersonalGroup(ctx)
+        };
+
+        var sidebarCollapsed = false;
+        return new SidebarViewModel(sidebarCollapsed, ctx.CurrentNav, groups);
+    }
+
+    /// <summary>
+    ///     Project the active <see cref="SidebarNavId" /> back onto the legacy
+    ///     <c>MainDialogTab</c> + sub-tab fields so the existing state managers
+    ///     keep rendering until Phase 4 cuts them.
+    /// </summary>
+    public static void Apply(SidebarNavId nav, GuiDialogState state, ReligionTabState religion,
+        CivilizationTabState civilization)
+    {
+        state.Sidebar.CurrentNav = nav;
+        switch (nav)
+        {
+            case SidebarNavId.ReligionInfo:
+                state.CurrentMainTab = MainDialogTab.Religion;
+                religion.CurrentSubTab = SubTab.Info;
+                break;
+            case SidebarNavId.ReligionActivity:
+                state.CurrentMainTab = MainDialogTab.Religion;
+                religion.CurrentSubTab = SubTab.Activity;
+                break;
+            case SidebarNavId.ReligionRoles:
+                state.CurrentMainTab = MainDialogTab.Religion;
+                religion.CurrentSubTab = SubTab.Roles;
+                break;
+            case SidebarNavId.ReligionInvites:
+                state.CurrentMainTab = MainDialogTab.Religion;
+                religion.CurrentSubTab = SubTab.Invites;
+                break;
+            case SidebarNavId.ReligionCreate:
+                state.CurrentMainTab = MainDialogTab.Religion;
+                religion.CurrentSubTab = SubTab.Create;
+                break;
+            case SidebarNavId.Blessings:
+                state.CurrentMainTab = MainDialogTab.Blessings;
+                break;
+            case SidebarNavId.CivilizationInfo:
+                state.CurrentMainTab = MainDialogTab.Civilization;
+                civilization.CurrentSubTab = CivilizationSubTab.Info;
+                break;
+            case SidebarNavId.CivilizationInvites:
+                state.CurrentMainTab = MainDialogTab.Civilization;
+                civilization.CurrentSubTab = CivilizationSubTab.Invites;
+                break;
+            case SidebarNavId.CivilizationCreate:
+                state.CurrentMainTab = MainDialogTab.Civilization;
+                civilization.CurrentSubTab = CivilizationSubTab.Create;
+                break;
+            case SidebarNavId.CivilizationDiplomacy:
+                state.CurrentMainTab = MainDialogTab.Civilization;
+                civilization.CurrentSubTab = CivilizationSubTab.Diplomacy;
+                break;
+            case SidebarNavId.CivilizationHolySites:
+                state.CurrentMainTab = MainDialogTab.Civilization;
+                civilization.CurrentSubTab = CivilizationSubTab.HolySites;
+                break;
+            case SidebarNavId.CivilizationMilestones:
+                state.CurrentMainTab = MainDialogTab.Civilization;
+                civilization.CurrentSubTab = CivilizationSubTab.Milestones;
+                break;
+        }
+    }
+
+    /// <summary>
+    ///     Convenience adapter — production builds the context off the live
+    ///     <c>GuiDialogManager</c>. Kept here so the mapper is the single place
+    ///     that knows the manager surface; renderers only see the view model.
+    /// </summary>
+    public static Context ContextFromManager(GuiDialogManager manager, SidebarState sidebar)
+    {
+        var hasReligion = manager.HasReligion();
+        var hasCivilization = manager.HasCivilization();
+        var religionInvites = manager.ReligionStateManager.State.InvitesState.MyInvites?.Count ?? 0;
+        var civInvites = manager.CivilizationManager.InviteState.MyInvites?.Count ?? 0;
+        var isReligionFounder = manager.ReligionStateManager.State.InfoState.MyReligionInfo?.IsFounder ?? false;
+
+        return new Context(
+            hasReligion,
+            hasCivilization,
+            manager.IsCivilizationFounder,
+            isReligionFounder,
+            religionInvites,
+            civInvites,
+            sidebar.CurrentNav,
+            sidebar.CollapsedGroups);
+    }
+
+    private static SidebarGroupViewModel BuildReligionGroup(Context ctx)
+    {
+        var items = new List<SidebarItemViewModel>(5)
+        {
+            // Info — needs a religion to make sense.
+            Item(SidebarNavId.ReligionInfo,
+                LocalizationKeys.UI_RELIGION_TAB_INFO, "info",
+                ctx, !ctx.HasReligion, LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION),
+            // Activity log — same gate.
+            Item(SidebarNavId.ReligionActivity,
+                LocalizationKeys.UI_RELIGION_TAB_ACTIVITY, "activity",
+                ctx, !ctx.HasReligion, LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION),
+            // Roles — needs religion AND founder permission.
+            Item(SidebarNavId.ReligionRoles,
+                LocalizationKeys.UI_RELIGION_TAB_ROLES, "roles",
+                ctx,
+                !ctx.HasReligion || !ctx.IsReligionFounder,
+                !ctx.HasReligion ? LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION
+                                 : LocalizationKeys.SIDEBAR_DISABLED_FOUNDER_ONLY),
+            // Invites — only when player is religion-less, badge with count.
+            Item(SidebarNavId.ReligionInvites,
+                LocalizationKeys.UI_RELIGION_TAB_INVITES, "invites",
+                ctx, ctx.HasReligion, LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_RELIGION,
+                badge: ctx.ReligionInviteCount),
+            // Create — same as invites (mutually exclusive with membership).
+            Item(SidebarNavId.ReligionCreate,
+                LocalizationKeys.UI_RELIGION_TAB_CREATE, "create",
+                ctx, ctx.HasReligion, LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_RELIGION)
+        };
+
+        var collapsed = ctx.CollapsedGroups != null
+                        && ctx.CollapsedGroups.TryGetValue(GroupReligionKey, out var c) && c;
+        return new SidebarGroupViewModel(GroupReligionKey,
+            LocalizationService.Instance.Get(LocalizationKeys.SIDEBAR_GROUP_RELIGION), collapsed, items);
+    }
+
+    private static SidebarGroupViewModel BuildCivilizationGroup(Context ctx)
+    {
+        var items = new List<SidebarItemViewModel>(6)
+        {
+            Item(SidebarNavId.CivilizationInfo,
+                LocalizationKeys.UI_CIVILIZATION_TAB_INFO, "info",
+                ctx, !ctx.HasCivilization, LocalizationKeys.SIDEBAR_DISABLED_NEED_CIVILIZATION),
+            // Invites — only when player has a religion but no civ membership.
+            Item(SidebarNavId.CivilizationInvites,
+                LocalizationKeys.UI_CIVILIZATION_TAB_INVITES, "invites",
+                ctx,
+                !ctx.HasReligion || ctx.HasCivilization,
+                !ctx.HasReligion ? LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION
+                                 : LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_CIVILIZATION,
+                badge: ctx.CivilizationInviteCount),
+            Item(SidebarNavId.CivilizationCreate,
+                LocalizationKeys.UI_CIVILIZATION_TAB_CREATE, "create",
+                ctx,
+                !ctx.HasReligion || ctx.HasCivilization,
+                !ctx.HasReligion ? LocalizationKeys.SIDEBAR_DISABLED_NEED_RELIGION
+                                 : LocalizationKeys.SIDEBAR_DISABLED_ALREADY_IN_CIVILIZATION),
+            Item(SidebarNavId.CivilizationDiplomacy,
+                LocalizationKeys.UI_CIVILIZATION_TAB_DIPLOMACY, "diplomacy",
+                ctx, !ctx.HasCivilization, LocalizationKeys.SIDEBAR_DISABLED_NEED_CIVILIZATION),
+            Item(SidebarNavId.CivilizationHolySites,
+                LocalizationKeys.UI_CIVILIZATION_TAB_HOLYSITES, "holysite",
+                ctx, !ctx.HasCivilization, LocalizationKeys.SIDEBAR_DISABLED_NEED_CIVILIZATION),
+            Item(SidebarNavId.CivilizationMilestones,
+                LocalizationKeys.UI_CIVILIZATION_TAB_MILESTONES, "achievement",
+                ctx, !ctx.HasCivilization, LocalizationKeys.SIDEBAR_DISABLED_NEED_CIVILIZATION)
+        };
+
+        var collapsed = ctx.CollapsedGroups != null
+                        && ctx.CollapsedGroups.TryGetValue(GroupCivilizationKey, out var c) && c;
+        return new SidebarGroupViewModel(GroupCivilizationKey,
+            LocalizationService.Instance.Get(LocalizationKeys.SIDEBAR_GROUP_CIVILIZATION), collapsed, items);
+    }
+
+    private static SidebarGroupViewModel BuildPersonalGroup(Context ctx)
+    {
+        var items = new List<SidebarItemViewModel>(1)
+        {
+            // Blessings is always reachable; the per-deity gating happens inside
+            // the content pane via DeitySelectorRenderer.
+            Item(SidebarNavId.Blessings,
+                LocalizationKeys.UI_TAB_BLESSINGS, "meditation",
+                ctx, isDisabled: false, disabledKey: null)
+        };
+
+        var collapsed = ctx.CollapsedGroups != null
+                        && ctx.CollapsedGroups.TryGetValue(GroupPersonalKey, out var c) && c;
+        return new SidebarGroupViewModel(GroupPersonalKey,
+            LocalizationService.Instance.Get(LocalizationKeys.SIDEBAR_GROUP_PERSONAL), collapsed, items);
+    }
+
+    private static SidebarItemViewModel Item(SidebarNavId id, string labelKey, string iconName,
+        Context ctx, bool isDisabled, string? disabledKey, int badge = 0)
+    {
+        return new SidebarItemViewModel(
+            id,
+            LocalizationService.Instance.Get(labelKey),
+            iconName,
+            badge,
+            IsActive: ctx.CurrentNav == id,
+            IsDisabled: isDisabled,
+            DisabledTooltipKey: isDisabled ? disabledKey : null);
+    }
+}

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.UI.Layout;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Services;
+using ImGuiNET;
+
+namespace DivineAscension.GUI.UI.Renderers.Sidebar;
+
+/// <summary>
+///     Draws the sidebar nav. Pure renderer — accepts a view model and a
+///     <see cref="UiRect" />, returns the events the layout coordinator should apply.
+///     No state mutation, no manager touching.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class SidebarRenderer
+{
+    private const float ToggleStripHeight = 28f;
+    private const float GroupHeaderHeight = 22f;
+    private const float ItemHeight = 28f;
+    private const float ItemIndent = 12f;
+    private const float CollapsedStripIconSize = 24f;
+
+    public static IReadOnlyList<SidebarEvent> Draw(UiRect rect, SidebarViewModel vm)
+    {
+        var events = new List<SidebarEvent>();
+        if (rect.W <= 0f || rect.H <= 0f) return events;
+
+        // Anchor a child window to the passed rect so widget cursor coords align.
+        ImGui.SetCursorScreenPos(new Vector2(rect.X, rect.Y));
+        ImGui.PushStyleColor(ImGuiCol.ChildBg, ColorPalette.TableBackground);
+        ImGui.BeginChild("##da-sidebar", new Vector2(rect.W, rect.H), false,
+            ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
+
+        DrawHideToggle(vm, events);
+
+        if (vm.IsCollapsed)
+        {
+            DrawCollapsedStrip(vm, events);
+        }
+        else
+        {
+            DrawGroups(vm, events);
+        }
+
+        ImGui.EndChild();
+        ImGui.PopStyleColor();
+        return events;
+    }
+
+    private static void DrawHideToggle(SidebarViewModel vm, List<SidebarEvent> events)
+    {
+        var label = vm.IsCollapsed ? ">>" : "<<";
+        if (ImGui.Button($"{label}##da-sidebar-toggle", new Vector2(-1f, ToggleStripHeight)))
+        {
+            events.Add(new SidebarEvent.SidebarToggled());
+        }
+    }
+
+    private static void DrawGroups(SidebarViewModel vm, List<SidebarEvent> events)
+    {
+        foreach (var group in vm.Groups)
+        {
+            DrawGroupHeader(group, events);
+            if (group.IsCollapsed) continue;
+
+            foreach (var item in group.Items)
+            {
+                DrawItem(item, events);
+            }
+        }
+    }
+
+    private static void DrawGroupHeader(SidebarGroupViewModel group, List<SidebarEvent> events)
+    {
+        var chevron = group.IsCollapsed ? "+" : "-";
+        ImGui.PushStyleColor(ImGuiCol.Text, ColorPalette.Gold);
+        if (ImGui.Selectable($"{chevron} {group.Label}##da-sidebar-grp-{group.Key}", false,
+                ImGuiSelectableFlags.None, new Vector2(0, GroupHeaderHeight)))
+        {
+            events.Add(new SidebarEvent.GroupToggled(group.Key));
+        }
+        ImGui.PopStyleColor();
+    }
+
+    private static void DrawItem(SidebarItemViewModel item, List<SidebarEvent> events)
+    {
+        // Indent everything inside a group.
+        ImGui.Indent(ItemIndent);
+
+        var label = item.Badge > 0
+            ? $"{item.Label}  ({item.Badge})"
+            : item.Label;
+
+        if (item.IsDisabled)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ColorPalette.Grey);
+            ImGui.Selectable($"{label}##da-sidebar-item-{item.Id}", false,
+                ImGuiSelectableFlags.Disabled, new Vector2(0, ItemHeight));
+            ImGui.PopStyleColor();
+
+            if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)
+                && !string.IsNullOrEmpty(item.DisabledTooltipKey))
+            {
+                ImGui.BeginTooltip();
+                ImGui.TextUnformatted(LocalizationService.Instance.Get(item.DisabledTooltipKey!));
+                ImGui.EndTooltip();
+            }
+        }
+        else
+        {
+            if (item.IsActive)
+            {
+                ImGui.PushStyleColor(ImGuiCol.Header, ColorPalette.Darken(ColorPalette.Gold, 0.6f));
+            }
+
+            if (ImGui.Selectable($"{label}##da-sidebar-item-{item.Id}", item.IsActive,
+                    ImGuiSelectableFlags.None, new Vector2(0, ItemHeight)))
+            {
+                events.Add(new SidebarEvent.ItemClicked(item.Id));
+            }
+
+            if (item.IsActive)
+            {
+                ImGui.PopStyleColor();
+            }
+        }
+
+        ImGui.Unindent(ItemIndent);
+    }
+
+    private static void DrawCollapsedStrip(SidebarViewModel vm, List<SidebarEvent> events)
+    {
+        // 40px strip: one square per enabled item, icon-only with tooltip on hover.
+        foreach (var group in vm.Groups)
+        {
+            foreach (var item in group.Items)
+            {
+                var size = new Vector2(CollapsedStripIconSize, CollapsedStripIconSize);
+                if (ImGui.Selectable($"##da-strip-{item.Id}", item.IsActive,
+                        item.IsDisabled
+                            ? ImGuiSelectableFlags.Disabled
+                            : ImGuiSelectableFlags.None,
+                        size))
+                {
+                    if (!item.IsDisabled) events.Add(new SidebarEvent.ItemClicked(item.Id));
+                }
+
+                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                {
+                    ImGui.BeginTooltip();
+                    ImGui.TextUnformatted(item.Label);
+                    if (item.IsDisabled && !string.IsNullOrEmpty(item.DisabledTooltipKey))
+                    {
+                        ImGui.Separator();
+                        ImGui.TextUnformatted(LocalizationService.Instance.Get(item.DisabledTooltipKey!));
+                    }
+                    ImGui.EndTooltip();
+                }
+            }
+        }
+    }
+}

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarViewModel.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarViewModel.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using DivineAscension.GUI.State;
+
+namespace DivineAscension.GUI.UI.Renderers.Sidebar;
+
+/// <summary>
+///     Top-level view model handed to <c>SidebarRenderer</c>. Built by
+///     <c>SidebarNavMapper</c> from <c>GuiDialogManager</c> + <c>SidebarState</c>.
+/// </summary>
+public sealed record SidebarViewModel(
+    bool IsCollapsed,
+    SidebarNavId CurrentNav,
+    IReadOnlyList<SidebarGroupViewModel> Groups
+);
+
+/// <summary>
+///     One collapsible group inside the sidebar (e.g. "Religion", "Civilization").
+///     <paramref name="Key" /> is the persisted identifier used by <c>SidebarState.CollapsedGroups</c>.
+/// </summary>
+public sealed record SidebarGroupViewModel(
+    string Key,
+    string Label,
+    bool IsCollapsed,
+    IReadOnlyList<SidebarItemViewModel> Items
+);
+
+/// <summary>
+///     One nav row. Renders as label + icon + optional badge. When
+///     <see cref="IsDisabled" /> is true, the row is dimmed and shows
+///     <see cref="DisabledTooltipKey" /> on hover; clicks are swallowed.
+/// </summary>
+public sealed record SidebarItemViewModel(
+    SidebarNavId Id,
+    string Label,
+    string IconName,
+    int Badge,
+    bool IsActive,
+    bool IsDisabled,
+    string? DisabledTooltipKey
+);
+
+/// <summary>
+///     Events emitted by <c>SidebarRenderer</c> for the layout coordinator to apply.
+/// </summary>
+public abstract record SidebarEvent
+{
+    /// <summary>User clicked an enabled item — switch nav.</summary>
+    public sealed record ItemClicked(SidebarNavId Id) : SidebarEvent;
+
+    /// <summary>User clicked a group header chevron — toggle collapse on that key.</summary>
+    public sealed record GroupToggled(string Key) : SidebarEvent;
+
+    /// <summary>User clicked the hide-sidebar button — toggle collapsed strip mode.</summary>
+    public sealed record SidebarToggled : SidebarEvent;
+}


### PR DESCRIPTION
## Summary

Phase 3a of the GuiDialog UI refactor (epic #258, issue #265). Lands the **non-visible** half of Phase 3 — every new file the sidebar + right rail need, plus the nav mapper, localization keys, and tests. `MainLayoutCoordinator` continues forwarding verbatim, so the dialog still looks identical. Phase 3b flips the layout.

### New files

- `GUI/UI/Renderers/Sidebar/SidebarViewModel.cs` — `SidebarViewModel`, `SidebarGroupViewModel`, `SidebarItemViewModel`, `SidebarEvent` union
- `GUI/UI/Renderers/Sidebar/SidebarNavMapper.cs` — pure mapping from a primitive `Context` snapshot into a `SidebarViewModel`; `Apply(SidebarNavId, ...)` translates clicks into legacy `CurrentMainTab` + `CurrentSubTab` writes
- `GUI/UI/Renderers/Sidebar/SidebarRenderer.cs` — draws nav (group headers + chevron, items with badge/active/disabled+tooltip, 40px collapsed strip, hide-sidebar toggle). Anchored to a `UiRect`. `[ExcludeFromCodeCoverage]`.
- `GUI/UI/Renderers/RightRail/RightRailViewModel.cs` — religion + civ status + notifications dataset (mirrors `ReligionHeaderViewModel` plus `NotificationHistoryEntry` list)
- `GUI/UI/Renderers/RightRail/RightRailRenderer.cs` — vertical 340px column: religion block, civ block, scrollable notification feed. Phase 3b wires it in. `[ExcludeFromCodeCoverage]`.

### Modified

- `Constants/LocalizationKeys.cs` — `SIDEBAR_GROUP_*` (Religion/Civilization/Personal) + `SIDEBAR_DISABLED_*` (NEED_RELIGION/NEED_CIVILIZATION/NEED_INVITE/FOUNDER_ONLY/ALREADY_IN_RELIGION/ALREADY_IN_CIVILIZATION).
- `GUI/Managers/CivilizationStateManager.cs` — new `public InviteState InviteState => State.InviteState` accessor, mirroring the existing `DiplomacyState` pattern. The mapper reads invite counts without touching the manager's private `State`.

### Tests

`DivineAscension.Tests/GUI/UI/Sidebar/SidebarNavMapperTests.cs` — 14 tests covering: no-religion/no-civ disabled tooltips, founder-only Roles gating, already-in-religion/civ guards, all-enabled when both joined, Blessings always reachable, badge counts pass through, `CurrentNav` marks the active item, collapsed-group state flows through, and `Apply(...)` correctly mutates `CurrentMainTab` + `CurrentSubTab` for Blessings/ReligionRoles/CivilizationMilestones nav.

## Test plan

- [x] `dotnet build DivineAscension.sln -c Debug` — clean
- [x] `dotnet test` — 2169 passing (was 2155; +14 new), 0 failures
- [x] Manual: launch the mod, `Shift+G` — UI **identical** to current state. Phase intentionally invisible.

Closes #265.