### PR TITLE
Retire MainDialogTab / CurrentMainTab dual source of truth

### DIFF
--- a/DivineAscension.Tests/GUI/UI/Sidebar/SidebarNavMapperTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Sidebar/SidebarNavMapperTests.cs
@@ -193,41 +193,52 @@ public class SidebarNavMapperTests
     }
 
     [Fact]
-    public void Apply_BlessingsNav_SwitchesMainTabAndClearsSubTab()
+    public void Apply_BlessingsNav_SetsCurrentNav()
     {
-        var state = new GuiDialogState { CurrentMainTab = MainDialogTab.Religion };
-        var religion = new ReligionTabState();
-        var civ = new CivilizationTabState();
+        var state = new GuiDialogState();
 
-        SidebarNavMapper.Apply(SidebarNavId.Blessings, state, religion, civ);
+        SidebarNavMapper.Apply(SidebarNavId.Blessings, state);
 
-        Assert.Equal(MainDialogTab.Blessings, state.CurrentMainTab);
         Assert.Equal(SidebarNavId.Blessings, state.Sidebar.CurrentNav);
     }
 
     [Fact]
-    public void Apply_ReligionRoles_SetsMainTabAndSubTab()
+    public void Apply_ReligionRoles_SetsCurrentNav()
     {
         var state = new GuiDialogState();
-        var religion = new ReligionTabState();
-        var civ = new CivilizationTabState();
 
-        SidebarNavMapper.Apply(SidebarNavId.ReligionRoles, state, religion, civ);
+        SidebarNavMapper.Apply(SidebarNavId.ReligionRoles, state);
 
-        Assert.Equal(MainDialogTab.Religion, state.CurrentMainTab);
-        Assert.Equal(SubTab.Roles, religion.CurrentSubTab);
+        Assert.Equal(SidebarNavId.ReligionRoles, state.Sidebar.CurrentNav);
     }
 
     [Fact]
-    public void Apply_CivilizationMilestones_SetsMainTabAndSubTab()
+    public void Apply_CivilizationMilestones_SetsCurrentNav()
     {
         var state = new GuiDialogState();
-        var religion = new ReligionTabState();
-        var civ = new CivilizationTabState();
 
-        SidebarNavMapper.Apply(SidebarNavId.CivilizationMilestones, state, religion, civ);
+        SidebarNavMapper.Apply(SidebarNavId.CivilizationMilestones, state);
 
-        Assert.Equal(MainDialogTab.Civilization, state.CurrentMainTab);
-        Assert.Equal(CivilizationSubTab.Milestones, civ.CurrentSubTab);
+        Assert.Equal(SidebarNavId.CivilizationMilestones, state.Sidebar.CurrentNav);
+    }
+
+    [Fact]
+    public void ToReligionSubTab_MapsReligionNavs()
+    {
+        Assert.Equal(SubTab.Browse, SidebarNavMapper.ToReligionSubTab(SidebarNavId.ReligionBrowse));
+        Assert.Equal(SubTab.Info, SidebarNavMapper.ToReligionSubTab(SidebarNavId.ReligionInfo));
+        Assert.Equal(SubTab.Roles, SidebarNavMapper.ToReligionSubTab(SidebarNavId.ReligionRoles));
+        Assert.Null(SidebarNavMapper.ToReligionSubTab(SidebarNavId.Blessings));
+        Assert.Null(SidebarNavMapper.ToReligionSubTab(SidebarNavId.CivilizationInfo));
+    }
+
+    [Fact]
+    public void ToCivilizationSubTab_MapsCivilizationNavs()
+    {
+        Assert.Equal(CivilizationSubTab.Browse, SidebarNavMapper.ToCivilizationSubTab(SidebarNavId.CivilizationBrowse));
+        Assert.Equal(CivilizationSubTab.Milestones, SidebarNavMapper.ToCivilizationSubTab(SidebarNavId.CivilizationMilestones));
+        Assert.Equal(CivilizationSubTab.HolySites, SidebarNavMapper.ToCivilizationSubTab(SidebarNavId.CivilizationHolySites));
+        Assert.Null(SidebarNavMapper.ToCivilizationSubTab(SidebarNavId.Blessings));
+        Assert.Null(SidebarNavMapper.ToCivilizationSubTab(SidebarNavId.ReligionInfo));
     }
 }

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -316,7 +316,7 @@ public partial class GuiDialog : ModSystem
         if (viewBlessingsClicked)
         {
             // Set the tab BEFORE opening the dialog to ensure it opens on the correct tab
-            _state.CurrentMainTab = MainDialogTab.Blessings;
+            _state.Sidebar.CurrentNav = SidebarNavId.Blessings;
 
             _manager.NotificationManager.OnViewBlessingsClicked(
                 () =>
@@ -326,7 +326,7 @@ public partial class GuiDialog : ModSystem
                 () =>
                 {
                     // Tab already set above, but this ensures it's set if dialog was already open
-                    _state.CurrentMainTab = MainDialogTab.Blessings;
+                    _state.Sidebar.CurrentNav = SidebarNavId.Blessings;
                 }
             );
         }

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -219,7 +219,7 @@ public partial class GuiDialog
         else
         {
             // Default to Blessings tab when opening via hotkey
-            _state.CurrentMainTab = MainDialogTab.Blessings;
+            _state.Sidebar.CurrentNav = SidebarNavId.Blessings;
             Open();
         }
 

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -450,11 +450,11 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     /// <summary>
     ///     Main EDA orchestrator for Civilization tab: builds ViewModels, calls renderers, processes events
     /// </summary>
-    internal void DrawCivilizationTab(float x, float y, float width, float height)
+    internal void DrawCivilizationTab(CivilizationSubTab activeSubTab, float x, float y, float width, float height)
     {
-        // Build tab ViewModel from state
+        // Build tab ViewModel from sidebar-driven sub-tab
         var tabVm = new CivilizationTabViewModel(
-            State.CurrentSubTab,
+            activeSubTab,
             State.LastActionError,
             State.BrowseState.ErrorMsg,
             State.InfoState.ErrorMsg,
@@ -467,38 +467,6 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
             width,
             height);
 
-        // AUTO-CORRECTION: Ensure active tab is valid for current religion/civilization state
-        var isCurrentTabValid = State.CurrentSubTab switch
-        {
-            CivilizationSubTab.Browse => true, // Always visible
-            CivilizationSubTab.Info => tabVm.ShowInfoTab,
-            CivilizationSubTab.Invites => tabVm.ShowInvitesTab,
-            CivilizationSubTab.Create => tabVm.ShowCreateTab,
-            CivilizationSubTab.Diplomacy => tabVm.ShowDiplomacyTab,
-            CivilizationSubTab.HolySites => tabVm.ShowHolySitesTab,
-            CivilizationSubTab.Milestones => tabVm.ShowMilestonesTab,
-            _ => false
-        };
-
-        if (!isCurrentTabValid)
-        {
-            _coreClientApi.Logger.Debug(
-                $"[DivineAscension] Auto-switching from {State.CurrentSubTab} to Browse (tab now hidden for HasReligion={UserHasReligion}, HasCivilization={HasCivilization()})");
-            State.CurrentSubTab = CivilizationSubTab.Browse;
-
-            // Rebuild ViewModel with corrected tab
-            tabVm = new CivilizationTabViewModel(
-                State.CurrentSubTab,
-                State.LastActionError,
-                State.BrowseState.ErrorMsg,
-                State.InfoState.ErrorMsg,
-                State.InviteState.ErrorMsg,
-                !string.IsNullOrEmpty(State.DetailState.ViewingCivilizationId),
-                UserHasReligion,
-                HasCivilization(),
-                x, y, width, height);
-        }
-
         var drawList = ImGui.GetWindowDrawList();
         var tabResult = CivilizationTabRenderer.Draw(tabVm, drawList);
 
@@ -509,7 +477,7 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
         var contentY = y + tabResult.RendererHeight;
         var contentHeight = height - tabResult.RendererHeight;
 
-        switch (State.CurrentSubTab)
+        switch (activeSubTab)
         {
             case CivilizationSubTab.Browse:
                 DrawCivilizationBrowse(x, contentY, width, contentHeight);

--- a/DivineAscension/GUI/Managers/ReligionStateManager.cs
+++ b/DivineAscension/GUI/Managers/ReligionStateManager.cs
@@ -644,43 +644,17 @@ public class ReligionStateManager : IReligionStateManager
     /// Draws the Religion tab header + error banner via pure renderer and routes to active sub-tab.
     /// This is the EDA orchestration point: builds the tab ViewModel, calls renderer, handles events, then draws sub-tab.
     /// </summary>
-    public void DrawReligionTab(float x, float y, float width, float height)
+    public void DrawReligionTab(SubTab activeSubTab, float x, float y, float width, float height)
     {
-        // Build view model from state
+        // Build view model from sidebar-driven sub-tab
         var tabVm = new ReligionTabViewModel(
-            currentSubTab: State.CurrentSubTab,
+            currentSubTab: activeSubTab,
             errorState: State.ErrorState,
             hasReligion: HasReligion(),
             x: x,
             y: y,
             width: width,
             height: height);
-
-        // AUTO-CORRECTION: Ensure active tab is valid for current religion state
-        var isCurrentTabValid = State.CurrentSubTab switch
-        {
-            SubTab.Browse => true, // Always visible
-            SubTab.Info => tabVm.ShowInfoTab,
-            SubTab.Activity => tabVm.ShowActivityTab,
-            SubTab.Roles => tabVm.ShowRolesTab,
-            SubTab.Invites => tabVm.ShowInvitesTab,
-            SubTab.Create => tabVm.ShowCreateTab,
-            _ => false
-        };
-
-        if (!isCurrentTabValid)
-        {
-            _coreClientApi.Logger.Debug(
-                $"[DivineAscension] Auto-switching from {State.CurrentSubTab} to Browse (tab now hidden for HasReligion={HasReligion()})");
-            State.CurrentSubTab = SubTab.Browse;
-
-            // Rebuild ViewModel with corrected tab
-            tabVm = new ReligionTabViewModel(
-                currentSubTab: State.CurrentSubTab,
-                errorState: State.ErrorState,
-                hasReligion: HasReligion(),
-                x: x, y: y, width: width, height: height);
-        }
 
         var drawList = ImGui.GetWindowDrawList();
         var tabResult = ReligionTabRenderer.Draw(tabVm, drawList, _coreClientApi);
@@ -779,7 +753,7 @@ public class ReligionStateManager : IReligionStateManager
         var contentY = y + tabResult.RenderedHeight;
         var contentHeight = height - tabResult.RenderedHeight;
 
-        switch (State.CurrentSubTab)
+        switch (activeSubTab)
         {
             case SubTab.Browse:
                 DrawReligionBrowse(x, contentY, width, contentHeight);

--- a/DivineAscension/GUI/State/GuiDialogState.cs
+++ b/DivineAscension/GUI/State/GuiDialogState.cs
@@ -6,11 +6,6 @@ namespace DivineAscension.GUI.State;
 public class GuiDialogState
 {
     /// <summary>
-    ///     Index of the main tab in BlessingDialog (0=Blessings, 1=Religion, 2=Civilization)
-    /// </summary>
-    public MainDialogTab CurrentMainTab { get; set; }
-
-    /// <summary>
     ///     Whether the dialog is currently open
     /// </summary>
     public bool IsOpen { get; set; }
@@ -74,7 +69,6 @@ public class GuiDialogState
         IsOpen = false;
         IsReady = false;
         RequestClose = false;
-        CurrentMainTab = MainDialogTab.Religion;
         WindowPosX = 0f;
         WindowPosY = 0f;
         WindowWidth = 0f;
@@ -84,11 +78,4 @@ public class GuiDialogState
         Sidebar.Reset();
         RightRail.Reset();
     }
-}
-
-public enum MainDialogTab
-{
-    Religion = 0,
-    Blessings = 1,
-    Civilization = 2
 }

--- a/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
+++ b/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
@@ -13,8 +13,7 @@ namespace DivineAscension.GUI.UI.Layout;
 /// <summary>
 ///     Top-level dispatcher for the dialog body. Splits the window into three
 ///     rects — sidebar | content | rightRail — and feeds each to its renderer.
-///     The legacy <c>CurrentMainTab</c> / <c>CurrentSubTab</c> fields are kept
-///     in sync by <see cref="SidebarNavMapper.Apply" /> until Phase 4 retires them.
+///     Content dispatch reads <see cref="SidebarState.CurrentNav" /> directly.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal static class MainLayoutCoordinator
@@ -65,8 +64,7 @@ internal static class MainLayoutCoordinator
         var railVm = BuildRailViewModel(manager, rail);
         RightRailRenderer.Draw(rail, railVm);
 
-        // --- Content dispatch (still driven by the legacy CurrentMainTab,
-        //     which SidebarNavMapper.Apply keeps in sync with CurrentNav).
+        // --- Content dispatch (driven by Sidebar.CurrentNav).
         DispatchContent(manager, state, content, windowWidth, windowHeight, deltaTime);
     }
 
@@ -78,19 +76,8 @@ internal static class MainLayoutCoordinator
             switch (ev)
             {
                 case SidebarEvent.ItemClicked itemClicked:
-                    var previousMainTab = state.CurrentMainTab;
-                    SidebarNavMapper.Apply(itemClicked.Id, state,
-                        manager.ReligionStateManager.State,
-                        manager.CivilizationManager.State);
-                    if (state.CurrentMainTab != previousMainTab)
-                    {
-                        // Mirror the old top-tab click-load: kicks off the
-                        // server requests so the new content has data to draw.
-                        RefreshTabData(state.CurrentMainTab, manager);
-                    }
-                    // Mirror the old SubTabEvent.TabChanged handlers in each
-                    // manager — every nav click re-fires the per-destination
-                    // data request and clears the matching context error.
+                    SidebarNavMapper.Apply(itemClicked.Id, state);
+                    // Per-destination data request + matching context-error clear.
                     RefreshSidebarDestinationData(itemClicked.Id, manager);
                     break;
                 case SidebarEvent.GroupToggled group:
@@ -101,29 +88,6 @@ internal static class MainLayoutCoordinator
                     state.Sidebar.IsCollapsed = !state.Sidebar.IsCollapsed;
                     break;
             }
-        }
-    }
-
-    private static void RefreshTabData(MainDialogTab tab, GuiDialogManager manager)
-    {
-        switch (tab)
-        {
-            case MainDialogTab.Religion:
-                manager.ReligionStateManager.State.BrowseState.IsBrowseLoading = true;
-                manager.ReligionStateManager.RequestReligionList(
-                    manager.ReligionStateManager.State.BrowseState.DeityFilter);
-                if (manager.HasReligion())
-                    manager.ReligionStateManager.State.InfoState.Loading = true;
-                else
-                    manager.ReligionStateManager.State.InvitesState.Loading = true;
-                manager.ReligionStateManager.RequestPlayerReligionInfo();
-                break;
-            case MainDialogTab.Civilization:
-                manager.CivilizationManager.RequestCivilizationList(
-                    manager.CivTabState.BrowseState.DeityFilter);
-                manager.CivilizationManager.RequestCivilizationInfo();
-                manager.ReligionStateManager.RequestPlayerReligionInfo();
-                break;
         }
     }
 
@@ -230,28 +194,33 @@ internal static class MainLayoutCoordinator
     {
         if (content.W <= 0f || content.H <= 0f) return;
 
-        switch (state.CurrentMainTab)
+        var nav = state.Sidebar.CurrentNav;
+        if (SidebarNavMapper.ToReligionSubTab(nav) is { } religionSub)
         {
-            case MainDialogTab.Religion:
-                manager.ReligionStateManager.DrawReligionTab(content.X, content.Y, content.W, content.H);
-                break;
-            case MainDialogTab.Blessings:
-                manager.BlessingStateManager.DrawBlessingsTab(
-                    content.X, content.Y, content.W, content.H,
-                    windowWidth, windowHeight, deltaTime,
-                    manager.ReligionStateManager.CurrentFavor,
-                    manager.ReligionStateManager.CurrentPrestige,
-                    manager.ReligionStateManager.CurrentReligionDomain,
-                    manager.ReligionStateManager.FavorRanksByDeity,
-                    manager.ReligionStateManager.TotalFavorEarnedByDeity,
-                    manager.ReligionStateManager.DiscipleThreshold,
-                    manager.ReligionStateManager.ZealotThreshold,
-                    manager.ReligionStateManager.ChampionThreshold,
-                    manager.ReligionStateManager.AvatarThreshold);
-                break;
-            case MainDialogTab.Civilization:
-                manager.CivilizationManager.DrawCivilizationTab(content.X, content.Y, content.W, content.H);
-                break;
+            manager.ReligionStateManager.DrawReligionTab(religionSub, content.X, content.Y, content.W, content.H);
+            return;
+        }
+
+        if (SidebarNavMapper.ToCivilizationSubTab(nav) is { } civSub)
+        {
+            manager.CivilizationManager.DrawCivilizationTab(civSub, content.X, content.Y, content.W, content.H);
+            return;
+        }
+
+        if (nav == SidebarNavId.Blessings)
+        {
+            manager.BlessingStateManager.DrawBlessingsTab(
+                content.X, content.Y, content.W, content.H,
+                windowWidth, windowHeight, deltaTime,
+                manager.ReligionStateManager.CurrentFavor,
+                manager.ReligionStateManager.CurrentPrestige,
+                manager.ReligionStateManager.CurrentReligionDomain,
+                manager.ReligionStateManager.FavorRanksByDeity,
+                manager.ReligionStateManager.TotalFavorEarnedByDeity,
+                manager.ReligionStateManager.DiscipleThreshold,
+                manager.ReligionStateManager.ZealotThreshold,
+                manager.ReligionStateManager.ChampionThreshold,
+                manager.ReligionStateManager.AvatarThreshold);
         }
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarNavMapper.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarNavMapper.cs
@@ -9,9 +9,7 @@ namespace DivineAscension.GUI.UI.Renderers.Sidebar;
 /// <summary>
 ///     Pure mapping from manager-derived flags + counts into a
 ///     <see cref="SidebarViewModel" />, plus an <see cref="Apply" /> helper
-///     that translates clicks into the legacy
-///     <c>CurrentMainTab</c> / <c>CurrentSubTab</c> writes the existing
-///     state managers still consume until Phase 4 retires those fields.
+///     that commits a sidebar click to <see cref="SidebarState.CurrentNav" />.
 /// </summary>
 public static class SidebarNavMapper
 {
@@ -54,73 +52,45 @@ public static class SidebarNavMapper
     }
 
     /// <summary>
-    ///     Project the active <see cref="SidebarNavId" /> back onto the legacy
-    ///     <c>MainDialogTab</c> + sub-tab fields so the existing state managers
-    ///     keep rendering until Phase 4 cuts them.
+    ///     Commit a sidebar click. <see cref="SidebarState.CurrentNav" /> is the
+    ///     single source of truth for the active destination; rendering reads it
+    ///     directly via <see cref="ToReligionSubTab" /> / <see cref="ToCivilizationSubTab" />.
     /// </summary>
-    public static void Apply(SidebarNavId nav, GuiDialogState state, ReligionTabState religion,
-        CivilizationTabState civilization)
+    public static void Apply(SidebarNavId nav, GuiDialogState state)
     {
         state.Sidebar.CurrentNav = nav;
-        switch (nav)
-        {
-            case SidebarNavId.ReligionBrowse:
-                state.CurrentMainTab = MainDialogTab.Religion;
-                religion.CurrentSubTab = SubTab.Browse;
-                break;
-            case SidebarNavId.ReligionInfo:
-                state.CurrentMainTab = MainDialogTab.Religion;
-                religion.CurrentSubTab = SubTab.Info;
-                break;
-            case SidebarNavId.ReligionActivity:
-                state.CurrentMainTab = MainDialogTab.Religion;
-                religion.CurrentSubTab = SubTab.Activity;
-                break;
-            case SidebarNavId.ReligionRoles:
-                state.CurrentMainTab = MainDialogTab.Religion;
-                religion.CurrentSubTab = SubTab.Roles;
-                break;
-            case SidebarNavId.ReligionInvites:
-                state.CurrentMainTab = MainDialogTab.Religion;
-                religion.CurrentSubTab = SubTab.Invites;
-                break;
-            case SidebarNavId.ReligionCreate:
-                state.CurrentMainTab = MainDialogTab.Religion;
-                religion.CurrentSubTab = SubTab.Create;
-                break;
-            case SidebarNavId.Blessings:
-                state.CurrentMainTab = MainDialogTab.Blessings;
-                break;
-            case SidebarNavId.CivilizationBrowse:
-                state.CurrentMainTab = MainDialogTab.Civilization;
-                civilization.CurrentSubTab = CivilizationSubTab.Browse;
-                break;
-            case SidebarNavId.CivilizationInfo:
-                state.CurrentMainTab = MainDialogTab.Civilization;
-                civilization.CurrentSubTab = CivilizationSubTab.Info;
-                break;
-            case SidebarNavId.CivilizationInvites:
-                state.CurrentMainTab = MainDialogTab.Civilization;
-                civilization.CurrentSubTab = CivilizationSubTab.Invites;
-                break;
-            case SidebarNavId.CivilizationCreate:
-                state.CurrentMainTab = MainDialogTab.Civilization;
-                civilization.CurrentSubTab = CivilizationSubTab.Create;
-                break;
-            case SidebarNavId.CivilizationDiplomacy:
-                state.CurrentMainTab = MainDialogTab.Civilization;
-                civilization.CurrentSubTab = CivilizationSubTab.Diplomacy;
-                break;
-            case SidebarNavId.CivilizationHolySites:
-                state.CurrentMainTab = MainDialogTab.Civilization;
-                civilization.CurrentSubTab = CivilizationSubTab.HolySites;
-                break;
-            case SidebarNavId.CivilizationMilestones:
-                state.CurrentMainTab = MainDialogTab.Civilization;
-                civilization.CurrentSubTab = CivilizationSubTab.Milestones;
-                break;
-        }
     }
+
+    /// <summary>
+    ///     Map a Religion-area nav id to its <see cref="SubTab" />. Returns
+    ///     <c>null</c> for non-Religion ids.
+    /// </summary>
+    public static SubTab? ToReligionSubTab(SidebarNavId nav) => nav switch
+    {
+        SidebarNavId.ReligionBrowse => SubTab.Browse,
+        SidebarNavId.ReligionInfo => SubTab.Info,
+        SidebarNavId.ReligionActivity => SubTab.Activity,
+        SidebarNavId.ReligionRoles => SubTab.Roles,
+        SidebarNavId.ReligionInvites => SubTab.Invites,
+        SidebarNavId.ReligionCreate => SubTab.Create,
+        _ => null
+    };
+
+    /// <summary>
+    ///     Map a Civilization-area nav id to its <see cref="CivilizationSubTab" />.
+    ///     Returns <c>null</c> for non-Civilization ids.
+    /// </summary>
+    public static CivilizationSubTab? ToCivilizationSubTab(SidebarNavId nav) => nav switch
+    {
+        SidebarNavId.CivilizationBrowse => CivilizationSubTab.Browse,
+        SidebarNavId.CivilizationInfo => CivilizationSubTab.Info,
+        SidebarNavId.CivilizationInvites => CivilizationSubTab.Invites,
+        SidebarNavId.CivilizationCreate => CivilizationSubTab.Create,
+        SidebarNavId.CivilizationDiplomacy => CivilizationSubTab.Diplomacy,
+        SidebarNavId.CivilizationHolySites => CivilizationSubTab.HolySites,
+        SidebarNavId.CivilizationMilestones => CivilizationSubTab.Milestones,
+        _ => null
+    };
 
     /// <summary>
     ///     Convenience adapter — production builds the context off the live


### PR DESCRIPTION
## Summary
- `Sidebar.CurrentNav` is now the single source for content dispatch in `MainLayoutCoordinator`; `MainDialogTab` enum and `GuiDialogState.CurrentMainTab` deleted.
- `SidebarNavMapper.Apply` shrunk to a single `CurrentNav` write; new helpers `ToReligionSubTab` / `ToCivilizationSubTab` feed per-area draws.
- `DrawReligionTab` / `DrawCivilizationTab` now take the nav-derived sub-tab. Auto-correction blocks that mutated the now-passive `State.CurrentSubTab` were removed (sidebar visibility gates cover them).

Closes #274.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` (2171 pass)
- [x] `git grep CurrentMainTab` / `MainDialogTab` — code clean (only historical planning docs remain)
- [x] Manual: open dialog, click every sidebar item, confirm correct content renders