### PR TITLE
Flatten right rail to match sidebar (#283)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/RightRail/RightRailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/RightRail/RightRailRenderer.cs
@@ -17,8 +17,9 @@ namespace DivineAscension.GUI.UI.Renderers.RightRail;
 /// <summary>
 ///     Vertical 340 px column: religion + civilization status (via
 ///     <see cref="ReligionHeaderRenderer" />), then a scrollable notification
-///     feed styled as a stack of letters. Owns the outer panel chrome and
-///     delegates status content to the header renderer.
+///     feed styled as a stack of letters. Paints a flat panel fill that
+///     matches the sidebar's <c>TableBackground</c> so both columns read as
+///     a single spread rather than two framed widgets.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal static class RightRailRenderer
@@ -34,13 +35,13 @@ internal static class RightRailRenderer
 
         var drawList = ImGui.GetWindowDrawList();
 
-        // Outer panel chrome.
-        var bg = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
-        var border = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.5f);
-        var topLeft = new Vector2(rect.X, rect.Y);
-        var botRight = new Vector2(rect.Right, rect.Bottom);
-        drawList.AddRectFilled(topLeft, botRight, bg, 4f);
-        drawList.AddRect(topLeft, botRight, border, 4f, ImDrawFlags.None, 2f);
+        // Flat fill matching the sidebar's TableBackground. No border, no
+        // rounding — keeps both columns reading as one spread.
+        var bg = ImGui.ColorConvertFloat4ToU32(ColorPalette.TableBackground);
+        drawList.AddRectFilled(
+            new Vector2(rect.X, rect.Y),
+            new Vector2(rect.Right, rect.Bottom),
+            bg);
 
         // Status block (deity + civ identity).
         var headerVm = WithBounds(vm.Header, rect.X + Padding, rect.Y + Padding,


### PR DESCRIPTION
Closes #283. Part of epic #273 (Tier 1 — codex chrome, no new assets).

## Summary
The right rail painted its own dark-brown panel with a gold border and rounded corners; the sidebar used a flat `TableBackground` fill with no border. The asymmetry read as a panel beside a page.

Picked the flat treatment for both: dropped the right rail's border + rounding and switched its fill to `TableBackground`. Sidebar untouched.

## Why flat, not bordered both
- The codex destination sketch in #273 wraps the whole dialog in a single outer frame with internal gutters — not two free-standing widgets.
- The right rail's future is uncertain (#290 may fold it into edge bookmarks). Ornate framing now would be wasted polish.
- Tier 2 will apply a parchment overlay only to the content pane (#286); uniform dark-leather rails set up that contrast.

## Follow-up
Once #290 settles the right rail's shape, a thin gold vertical gutter between the content pane and the rail will probably want to come back to honour the `║` divider in the sketch. Out of scope here.

## Test plan
- [x] Open `Shift+G`; verify the right rail has no border and shares the sidebar's dark fill.
- [x] Status block (deity + civ identity) still renders correctly inside the rail.
- [x] Notification feed scrolls, unread highlight + hover lift still visible.
- [x] Filter checkbox + clear button align cleanly against the right edge.