### PR TITLE
feat(ui): edge bookmark fast-jump ribbons (#290)

### DIFF
--- a/DivineAscension.Tests/GUI/UI/EdgeBookmarks/EdgeBookmarkMapperTests.cs
+++ b/DivineAscension.Tests/GUI/UI/EdgeBookmarks/EdgeBookmarkMapperTests.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.GUI.State;
+using DivineAscension.GUI.UI.Renderers.EdgeBookmarks;
+
+namespace DivineAscension.Tests.GUI.UI.EdgeBookmarks;
+
+[ExcludeFromCodeCoverage]
+public class EdgeBookmarkMapperTests
+{
+    private static EdgeBookmarkViewModel FindByStamp(EdgeBookmarkRibbonStack stack, string stamp)
+    {
+        return stack.Bookmarks.First(b => b.Stamp == stamp);
+    }
+
+    [Fact]
+    public void BuildViewModel_ReturnsFourBookmarksInRBCQOrder()
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(false, false, SidebarNavId.ReligionBrowse));
+
+        Assert.Equal(4, stack.Bookmarks.Count);
+        Assert.Equal("R", stack.Bookmarks[0].Stamp);
+        Assert.Equal("B", stack.Bookmarks[1].Stamp);
+        Assert.Equal("C", stack.Bookmarks[2].Stamp);
+        Assert.Equal("?", stack.Bookmarks[3].Stamp);
+    }
+
+    [Fact]
+    public void ReligionBookmark_TargetsBrowse_WhenPlayerHasNoReligion()
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(false, false, SidebarNavId.Blessings));
+        Assert.Equal(SidebarNavId.ReligionBrowse, FindByStamp(stack, "R").Target);
+    }
+
+    [Fact]
+    public void ReligionBookmark_TargetsInfo_WhenPlayerHasReligion()
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(true, false, SidebarNavId.Blessings));
+        Assert.Equal(SidebarNavId.ReligionInfo, FindByStamp(stack, "R").Target);
+    }
+
+    [Fact]
+    public void CivilizationBookmark_TargetsBrowse_WhenPlayerHasNoCivilization()
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(true, false, SidebarNavId.ReligionInfo));
+        Assert.Equal(SidebarNavId.CivilizationBrowse, FindByStamp(stack, "C").Target);
+    }
+
+    [Fact]
+    public void CivilizationBookmark_TargetsInfo_WhenPlayerHasCivilization()
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(true, true, SidebarNavId.ReligionInfo));
+        Assert.Equal(SidebarNavId.CivilizationInfo, FindByStamp(stack, "C").Target);
+    }
+
+    [Theory]
+    [InlineData(SidebarNavId.ReligionBrowse, "R")]
+    [InlineData(SidebarNavId.ReligionInfo, "R")]
+    [InlineData(SidebarNavId.ReligionActivity, "R")]
+    [InlineData(SidebarNavId.ReligionRoles, "R")]
+    [InlineData(SidebarNavId.ReligionInvites, "R")]
+    [InlineData(SidebarNavId.ReligionCreate, "R")]
+    [InlineData(SidebarNavId.Blessings, "B")]
+    [InlineData(SidebarNavId.CivilizationBrowse, "C")]
+    [InlineData(SidebarNavId.CivilizationInfo, "C")]
+    [InlineData(SidebarNavId.CivilizationInvites, "C")]
+    [InlineData(SidebarNavId.CivilizationCreate, "C")]
+    [InlineData(SidebarNavId.CivilizationDiplomacy, "C")]
+    [InlineData(SidebarNavId.CivilizationHolySites, "C")]
+    [InlineData(SidebarNavId.CivilizationMilestones, "C")]
+    public void ActiveBookmark_TracksCurrentNavSection(SidebarNavId nav, string activeStamp)
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(true, true, nav));
+
+        foreach (var bm in stack.Bookmarks)
+        {
+            Assert.Equal(bm.Stamp == activeStamp, bm.IsActive);
+        }
+    }
+
+    [Fact]
+    public void HelpBookmark_IsDisabled()
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(true, true, SidebarNavId.ReligionInfo));
+        var help = FindByStamp(stack, "?");
+        Assert.True(help.IsDisabled);
+        Assert.False(help.IsActive);
+    }
+
+    [Fact]
+    public void NonHelpBookmarks_AreEnabled()
+    {
+        var stack = EdgeBookmarkMapper.BuildViewModel(
+            new EdgeBookmarkMapper.Context(false, false, SidebarNavId.ReligionBrowse));
+        Assert.False(FindByStamp(stack, "R").IsDisabled);
+        Assert.False(FindByStamp(stack, "B").IsDisabled);
+        Assert.False(FindByStamp(stack, "C").IsDisabled);
+    }
+}

--- a/DivineAscension/GUI/Events/EdgeBookmarks/EdgeBookmarkEvent.cs
+++ b/DivineAscension/GUI/Events/EdgeBookmarks/EdgeBookmarkEvent.cs
@@ -1,0 +1,14 @@
+using DivineAscension.GUI.State;
+
+namespace DivineAscension.GUI.Events.EdgeBookmarks;
+
+/// <summary>
+///     Events emitted by <c>EdgeBookmarkRenderer</c>. The layout coordinator
+///     applies these against <c>SidebarState.CurrentNav</c> and the
+///     per-destination refresh path used by the sidebar.
+/// </summary>
+public abstract record EdgeBookmarkEvent
+{
+    /// <summary>User clicked a bookmark; jump to that section's default nav.</summary>
+    public sealed record Jump(SidebarNavId Target) : EdgeBookmarkEvent;
+}

--- a/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
+++ b/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using DivineAscension.GUI.Events.EdgeBookmarks;
 using DivineAscension.GUI.Events.RightRail;
 using DivineAscension.GUI.Models.Religion.Header;
 using DivineAscension.GUI.State;
+using DivineAscension.GUI.UI.Renderers.EdgeBookmarks;
 using DivineAscension.GUI.UI.Renderers.RightRail;
 using DivineAscension.GUI.UI.Renderers.Sidebar;
 using DivineAscension.GUI.UI.Utilities;
@@ -23,6 +25,8 @@ internal static class MainLayoutCoordinator
     private const float SidebarWidth = 240f;
     private const float SidebarCollapsedWidth = 40f;
     private const float RailWidth = 340f;
+    private const float BookmarkColumnWidth = 28f;
+    private const float BookmarkGap = 4f;
     private const float Gap = 8f;
     private const float TopChromeHeight = 32f;
 
@@ -64,7 +68,10 @@ internal static class MainLayoutCoordinator
         var body = inner.Cut(TopChromeHeight, 0f);
         var sidebarW = state.Sidebar.IsCollapsed ? SidebarCollapsedWidth : SidebarWidth;
         var (sidebar, afterSidebar) = body.SplitLeft(sidebarW, Gap);
-        var (content, rail) = afterSidebar.SplitRight(RailWidth, Gap);
+        // Bookmark column hugs the far right edge of the spread; the rail sits
+        // immediately to its left, content fills the remainder.
+        var (afterBookmarks, bookmarks) = afterSidebar.SplitRight(BookmarkColumnWidth, BookmarkGap);
+        var (content, rail) = afterBookmarks.SplitRight(RailWidth, Gap);
 
         // --- Sidebar ---
         var sidebarCtx = SidebarNavMapper.ContextFromManager(manager, state.Sidebar);
@@ -76,6 +83,15 @@ internal static class MainLayoutCoordinator
         var railVm = BuildRailViewModel(manager, state, rail);
         var railEvents = RightRailRenderer.Draw(rail, railVm);
         ApplyRailEvents(railEvents, manager, state);
+
+        // --- Edge bookmarks ---
+        var bookmarkCtx = new EdgeBookmarkMapper.Context(
+            manager.HasReligion(),
+            manager.HasCivilization(),
+            state.Sidebar.CurrentNav);
+        var bookmarkStack = EdgeBookmarkMapper.BuildViewModel(bookmarkCtx);
+        var bookmarkEvents = EdgeBookmarkRenderer.Draw(bookmarks, bookmarkStack);
+        ApplyBookmarkEvents(bookmarkEvents, manager, state);
 
         // --- Content dispatch (driven by Sidebar.CurrentNav).
         DispatchContent(manager, state, content, windowWidth, windowHeight, deltaTime);
@@ -221,6 +237,19 @@ internal static class MainLayoutCoordinator
                 case RightRailEvent.SetUnreadOnly toggle:
                     state.RightRail.ShowUnreadOnly = toggle.Enabled;
                     break;
+            }
+        }
+    }
+
+    private static void ApplyBookmarkEvents(IReadOnlyList<EdgeBookmarkEvent> events,
+        GuiDialogManager manager, GuiDialogState state)
+    {
+        foreach (var ev in events)
+        {
+            if (ev is EdgeBookmarkEvent.Jump jump)
+            {
+                SidebarNavMapper.Apply(jump.Target, state);
+                RefreshSidebarDestinationData(jump.Target, manager);
             }
         }
     }

--- a/DivineAscension/GUI/UI/Renderers/EdgeBookmarks/EdgeBookmarkMapper.cs
+++ b/DivineAscension/GUI/UI/Renderers/EdgeBookmarks/EdgeBookmarkMapper.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using DivineAscension.GUI.State;
+using DivineAscension.GUI.UI.Utilities;
+
+namespace DivineAscension.GUI.UI.Renderers.EdgeBookmarks;
+
+/// <summary>
+///     Build the right-edge bookmark stack from manager flags + the current
+///     nav. One ribbon per main section: Religion (R), Blessings (B),
+///     Civilization (C), Help (?). Each ribbon's default jump target adapts
+///     to membership: if the player has no religion, R jumps to Browse; same
+///     for Civilization.
+/// </summary>
+public static class EdgeBookmarkMapper
+{
+    public readonly record struct Context(
+        bool HasReligion,
+        bool HasCivilization,
+        SidebarNavId CurrentNav);
+
+    public static EdgeBookmarkRibbonStack BuildViewModel(Context ctx)
+    {
+        var bookmarks = new List<EdgeBookmarkViewModel>(4)
+        {
+            new(
+                Stamp: "R",
+                Tooltip: "Religion",
+                RibbonColor: DomainHelper.GetDomainColor("Craft"),
+                Target: ctx.HasReligion ? SidebarNavId.ReligionInfo : SidebarNavId.ReligionBrowse,
+                IsActive: IsReligionNav(ctx.CurrentNav),
+                IsDisabled: false),
+            new(
+                Stamp: "B",
+                Tooltip: "Blessings",
+                RibbonColor: DomainHelper.GetDomainColor("Harvest"),
+                Target: SidebarNavId.Blessings,
+                IsActive: ctx.CurrentNav == SidebarNavId.Blessings,
+                IsDisabled: false),
+            new(
+                Stamp: "C",
+                Tooltip: "Civilization",
+                RibbonColor: DomainHelper.GetDomainColor("Stone"),
+                Target: ctx.HasCivilization ? SidebarNavId.CivilizationInfo : SidebarNavId.CivilizationBrowse,
+                IsActive: IsCivilizationNav(ctx.CurrentNav),
+                IsDisabled: false),
+            new(
+                Stamp: "?",
+                Tooltip: "Help (coming soon)",
+                RibbonColor: ColorPalette.Grey,
+                Target: ctx.CurrentNav,
+                IsActive: false,
+                IsDisabled: true)
+        };
+        return new EdgeBookmarkRibbonStack(bookmarks);
+    }
+
+    private static bool IsReligionNav(SidebarNavId nav) => nav is
+        SidebarNavId.ReligionBrowse or
+        SidebarNavId.ReligionInfo or
+        SidebarNavId.ReligionActivity or
+        SidebarNavId.ReligionRoles or
+        SidebarNavId.ReligionInvites or
+        SidebarNavId.ReligionCreate;
+
+    private static bool IsCivilizationNav(SidebarNavId nav) => nav is
+        SidebarNavId.CivilizationBrowse or
+        SidebarNavId.CivilizationInfo or
+        SidebarNavId.CivilizationInvites or
+        SidebarNavId.CivilizationCreate or
+        SidebarNavId.CivilizationDiplomacy or
+        SidebarNavId.CivilizationHolySites or
+        SidebarNavId.CivilizationMilestones;
+}

--- a/DivineAscension/GUI/UI/Renderers/EdgeBookmarks/EdgeBookmarkRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/EdgeBookmarks/EdgeBookmarkRenderer.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.Events.EdgeBookmarks;
+using DivineAscension.GUI.UI.Layout;
+using DivineAscension.GUI.UI.Renderers.Utilities;
+using DivineAscension.GUI.UI.Utilities;
+using ImGuiNET;
+
+namespace DivineAscension.GUI.UI.Renderers.EdgeBookmarks;
+
+/// <summary>
+///     Paints colored ribbons protruding from the right page edge of the
+///     codex. Each ribbon is a fast-jump shortcut to one main section.
+///     Pure renderer — accepts the view model and a <see cref="UiRect"/>,
+///     returns click events for the layout coordinator.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class EdgeBookmarkRenderer
+{
+    private const float RibbonHeight = 44f;
+    private const float RibbonSpacing = 10f;
+    private const float TopOffset = 12f;
+    private const float NotchDepth = 8f;
+    private const float ActiveExtrude = 4f;
+
+    public static IReadOnlyList<EdgeBookmarkEvent> Draw(UiRect rect, EdgeBookmarkRibbonStack stack)
+    {
+        var events = new List<EdgeBookmarkEvent>();
+        if (rect.W <= 0f || rect.H <= 0f || stack.Bookmarks.Count == 0) return events;
+
+        var drawList = ImGui.GetWindowDrawList();
+        var y = rect.Y + TopOffset;
+
+        for (var i = 0; i < stack.Bookmarks.Count; i++)
+        {
+            var bm = stack.Bookmarks[i];
+
+            // Active bookmark extrudes slightly further out so it reads as
+            // "the page currently flipped to". Disabled bookmarks render at
+            // a muted alpha and skip click handling.
+            var extrude = bm.IsActive ? ActiveExtrude : 0f;
+            var x0 = rect.X - extrude;
+            var x1 = rect.Right;
+            var y0 = y;
+            var y1 = y + RibbonHeight;
+
+            // Click target spans the ribbon body.
+            ImGui.SetCursorScreenPos(new Vector2(x0, y0));
+            var clicked = ImGui.InvisibleButton(
+                $"##da-bookmark-{i}",
+                new Vector2(x1 - x0, RibbonHeight));
+            var hovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled);
+
+            if (clicked && !bm.IsDisabled)
+            {
+                events.Add(new EdgeBookmarkEvent.Jump(bm.Target));
+            }
+            if (hovered && !bm.IsDisabled)
+            {
+                ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
+            }
+
+            DrawRibbon(drawList, x0, y0, x1, y1, bm, hovered);
+
+            y += RibbonHeight + RibbonSpacing;
+            if (y > rect.Bottom) break;
+
+            if (hovered)
+            {
+                using var _ = ChromeRenderer.BeginStyledTooltip();
+                ImGui.TextUnformatted(bm.Tooltip);
+            }
+        }
+
+        return events;
+    }
+
+    /// <summary>
+    ///     Cloth-ribbon shape: rectangle body, V-notch cut into the right edge
+    ///     so it reads as fabric hanging from the page. Color from the deity
+    ///     domain palette; muted alpha when disabled or non-active; gold trim
+    ///     for the active ribbon.
+    /// </summary>
+    private static void DrawRibbon(ImDrawListPtr drawList, float x0, float y0, float x1, float y1,
+        EdgeBookmarkViewModel bm, bool hovered)
+    {
+        var baseColor = bm.IsDisabled
+            ? ColorPalette.WithAlpha(bm.RibbonColor, 0.25f)
+            : (hovered ? ColorPalette.Lighten(bm.RibbonColor, 1.15f) : bm.RibbonColor);
+        var shadowColor = ColorPalette.Darken(baseColor, 0.55f);
+        var fill = ImGui.ColorConvertFloat4ToU32(baseColor);
+        var shadow = ImGui.ColorConvertFloat4ToU32(shadowColor);
+
+        var midY = (y0 + y1) * 0.5f;
+        var notchX = x1 - NotchDepth;
+
+        // Main ribbon body — pentagon with notched right edge.
+        var body = new[]
+        {
+            new Vector2(x0, y0),
+            new Vector2(notchX, y0),
+            new Vector2(x1, midY),
+            new Vector2(notchX, y1),
+            new Vector2(x0, y1)
+        };
+        drawList.AddConvexPolyFilled(ref body[0], 5, fill);
+
+        // Shadow stripe along the bottom edge to suggest cloth thickness.
+        var shadowPoly = new[]
+        {
+            new Vector2(x0, y1 - 3f),
+            new Vector2(notchX, y1 - 3f),
+            new Vector2(x1, midY + 1.5f),
+            new Vector2(notchX, y1),
+            new Vector2(x0, y1)
+        };
+        drawList.AddConvexPolyFilled(ref shadowPoly[0], 5, shadow);
+
+        // Active ribbon picks up a gold outline.
+        if (bm.IsActive)
+        {
+            var trim = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
+            var outline = new[]
+            {
+                new Vector2(x0, y0),
+                new Vector2(notchX, y0),
+                new Vector2(x1, midY),
+                new Vector2(notchX, y1),
+                new Vector2(x0, y1),
+                new Vector2(x0, y0)
+            };
+            drawList.AddPolyline(ref outline[0], outline.Length, trim, ImDrawFlags.None, 1.5f);
+        }
+
+        // Stamp letter centered on the ribbon body. Cream-white on colored
+        // ribbons, grey on the disabled '?' ribbon.
+        var textColor = ImGui.ColorConvertFloat4ToU32(bm.IsDisabled
+            ? ColorPalette.Grey
+            : ColorPalette.White);
+        var stampSize = ImGui.CalcTextSize(bm.Stamp);
+        var bodyCenter = (x0 + notchX) * 0.5f;
+        drawList.AddText(
+            new Vector2(bodyCenter - stampSize.X * 0.5f, midY - stampSize.Y * 0.5f),
+            textColor,
+            bm.Stamp);
+    }
+}

--- a/DivineAscension/GUI/UI/Renderers/EdgeBookmarks/EdgeBookmarkViewModel.cs
+++ b/DivineAscension/GUI/UI/Renderers/EdgeBookmarks/EdgeBookmarkViewModel.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Numerics;
+using DivineAscension.GUI.State;
+
+namespace DivineAscension.GUI.UI.Renderers.EdgeBookmarks;
+
+/// <summary>
+///     One ribbon hanging from the right edge of the codex spread. A click
+///     jumps to <see cref="Target"/>. <see cref="IsActive"/> marks the bookmark
+///     whose section currently owns <c>SidebarState.CurrentNav</c>;
+///     <see cref="IsDisabled"/> covers sections that don't exist yet (e.g. Help).
+/// </summary>
+public readonly record struct EdgeBookmarkViewModel(
+    string Stamp,
+    string Tooltip,
+    Vector4 RibbonColor,
+    SidebarNavId Target,
+    bool IsActive,
+    bool IsDisabled);
+
+/// <summary>
+///     Ordered set of bookmarks (top → bottom). Built by
+///     <c>EdgeBookmarkMapper.BuildViewModel</c>.
+/// </summary>
+public readonly record struct EdgeBookmarkRibbonStack(IReadOnlyList<EdgeBookmarkViewModel> Bookmarks);


### PR DESCRIPTION
Closes #290.

## Summary

- New `EdgeBookmarkRenderer` paints cloth-ribbon shortcuts hanging off the right edge of the codex spread.
- Four ribbons — Religion (R), Blessings (B), Civilization (C), Help (?).
- Click jumps to the section's default sub-nav (Browse when player isn't a member, otherwise Info).
- Active section's ribbon picks up a gold trim and extrudes slightly so it reads as the current page.
- Disabled Help ribbon until a help section lands.

## Layout decision

Right rail kept. Bookmarks slot into a 28px column to the rail's right (sidebar | content | rail | bookmarks). Folding identity into the title ribbon and dropping the rail entirely is a larger restructure — notification feed needs a new home — and is left as a follow-up if/when desired.

## Test plan

- [x] `dotnet test` — 2186 passed
- [x] New `EdgeBookmarkMapperTests` covers target adaptation by membership, active-section tracking across all nav ids, and Help-disabled invariant
- [ ] Manual: open Shift+G dialog, verify ribbons paint, clicking each jumps + refreshes section data, active ribbon highlights as nav changes