### PR TITLE
refactor(ui): unify color, font, and spacing constants across content pages

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingActionsRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingActionsRenderer.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.GUI.Events.Blessing;
 using DivineAscension.GUI.Models.Blessing.Actions;
+using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -23,14 +24,10 @@ internal static class BlessingActionsRenderer
 
     private const float CornerRadius = 4f;
 
-    // Color constants
-    private static readonly Vector4 ColorButtonNormal = new(0.24f, 0.18f, 0.13f, 1.0f); // #3d2e20
-    private static readonly Vector4 ColorButtonHover = new(0.35f, 0.26f, 0.19f, 1.0f); // Lighter brown
+    // Color constants — button-specific colors only.
+    // Shared semantic colors come from ColorPalette (Gold, White, DisabledGray, DarkBrown, LightBrown).
     private static readonly Vector4 ColorButtonActive = new(0.478f, 0.776f, 0.184f, 1.0f); // #7ac62f lime
     private static readonly Vector4 ColorButtonDisabled = new(0.2f, 0.15f, 0.11f, 0.6f); // Dark, semi-transparent
-    private static readonly Vector4 ColorTextNormal = new(0.9f, 0.9f, 0.9f, 1.0f);
-    private static readonly Vector4 ColorTextDisabled = new(0.5f, 0.5f, 0.5f, 1.0f);
-    private static readonly Vector4 ColorGold = new(0.996f, 0.682f, 0.204f, 1.0f); // #feae34
 
     /// <summary>
     ///     Draw action buttons using EDA style. Emits events based on user interaction.
@@ -70,7 +67,7 @@ internal static class BlessingActionsRenderer
 
             var isEnabled = canUnlock && canAfford;
             var buttonColor = isEnabled ? ColorButtonActive : ColorButtonDisabled;
-            var textColor = isEnabled ? ColorTextNormal : ColorTextDisabled;
+            var textColor = isEnabled ? ColorPalette.White : ColorPalette.DisabledGray;
 
             var clicked = DrawButton(buttonText, unlockButtonX, viewModel.Y, ButtonWidth, ButtonHeight,
                 buttonColor, textColor, isEnabled);
@@ -130,7 +127,7 @@ internal static class BlessingActionsRenderer
         else if (isHovering)
         {
             // Hover state
-            currentColor = ColorButtonHover;
+            currentColor = ColorPalette.LightBrown;
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
         }
         else
@@ -144,7 +141,7 @@ internal static class BlessingActionsRenderer
         drawList.AddRectFilled(buttonStart, buttonEnd, bgColor, CornerRadius);
 
         // Draw border (gold for active buttons)
-        var borderColor = enabled ? ColorGold : new Vector4(0.4f, 0.3f, 0.2f, 1.0f);
+        var borderColor = enabled ? ColorPalette.Gold : new Vector4(0.4f, 0.3f, 0.2f, 1.0f);
         var borderColorU32 = ImGui.ColorConvertFloat4ToU32(borderColor);
         drawList.AddRect(buttonStart, buttonEnd, borderColorU32, CornerRadius, ImDrawFlags.None, 2f);
 

--- a/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
@@ -6,6 +6,7 @@ using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models.Enum;
 using DivineAscension.Systems;
 using ImGuiNET;
+using static DivineAscension.GUI.UI.Utilities.FontSizes;
 
 namespace DivineAscension.GUI.UI.Renderers.Blessing;
 
@@ -44,21 +45,21 @@ internal static class CrossDeitySummaryRenderer
 
             var label = $"{DomainShort(s.Domain)} {RankRequirements.GetFavorRankName(s.FavorRank)}";
             var labelSize = ImGui.CalcTextSize(label);
-            drawList.AddText(ImGui.GetFont(), 12f,
+            drawList.AddText(ImGui.GetFont(), Micro,
                 new Vector2(colX + (colWidth - labelSize.X) / 2f, colTop),
                 s.IsPatron ? gold : textColor,
                 label);
 
             var counts = $"P {s.UnlockedPlayer}/{s.TotalPlayer}  R {s.UnlockedReligion}/{s.TotalReligion}";
             var countsSize = ImGui.CalcTextSize(counts);
-            drawList.AddText(ImGui.GetFont(), 12f,
+            drawList.AddText(ImGui.GetFont(), Micro,
                 new Vector2(colX + (colWidth - countsSize.X) / 2f, colTop + 16f),
                 textColor,
                 counts);
 
             if (s.IsPatron)
             {
-                drawList.AddText(ImGui.GetFont(), 12f,
+                drawList.AddText(ImGui.GetFont(), Micro,
                     new Vector2(colX + 2f, colTop), gold, "*");
             }
         }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models.Enum;
 using ImGuiNET;
+using static DivineAscension.GUI.UI.Utilities.FontSizes;
 
 namespace DivineAscension.GUI.UI.Renderers.Blessing;
 
@@ -74,7 +75,7 @@ internal static class DeitySelectorRenderer
                 var patronBorder = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
                 drawList.AddRect(min, max, patronBorder, 4f, ImDrawFlags.None, PatronBorderThickness);
                 var star = "*";
-                drawList.AddText(ImGui.GetFont(), 14f,
+                drawList.AddText(ImGui.GetFont(), Secondary,
                     new Vector2(max.X - 12f, min.Y + 2f),
                     patronBorder, star);
             }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/Info/BlessingInfoSectionRequirements.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/Info/BlessingInfoSectionRequirements.cs
@@ -25,9 +25,9 @@ internal static class BlessingInfoSectionRequirements
 
         currentY += 8f;
         var reqTitleColorU32 = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(vm.X + padding, currentY), reqTitleColorU32,
+        drawList.AddText(ImGui.GetFont(), TableHeader, new Vector2(vm.X + padding, currentY), reqTitleColorU32,
             LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_REQUIREMENTS));
-        currentY += 18f;
+        currentY += 22f;
 
         // Check if we have space for requirements
         if (currentY < vm.Y + vm.Height - 40f)

--- a/DivineAscension/GUI/UI/Renderers/Blessing/Info/BlessingInfoTextUtils.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/Info/BlessingInfoTextUtils.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.Extensions;
+using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -25,7 +26,7 @@ internal static class BlessingInfoTextUtils
             if (testSize.X > maxWidth && !string.IsNullOrEmpty(currentLine))
             {
                 drawList.AddText(ImGui.GetFont(), fontSize, new Vector2(x, currentY), color, currentLine);
-                currentY += fontSize + 4f;
+                currentY += fontSize + FontSizes.LinePadding;
                 currentLine = word;
             }
             else

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
@@ -46,7 +46,7 @@ internal static class CivilizationDetailRenderer
                 vm.X, currentY, 160f, 32f, directoryPath: "GUI", iconName: "back"))
             events.Add(new DetailEvent.BackToBrowseClicked());
 
-        currentY += 44f;
+        currentY += Spacing.BackButtonRow;
 
         // Civilization header with rank
         TextRenderer.DrawLabel(drawList, vm.CivName, vm.X, currentY, PageTitle, ColorPalette.White);
@@ -55,7 +55,7 @@ internal static class CivilizationDetailRenderer
         var rankText = $"[{rankName}]";
         drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(vm.X + civNameWidth + 12f, currentY + 3f),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), rankText);
-        currentY += 32f;
+        currentY += Spacing.Block;
 
         // Info grid
         var leftCol = vm.X;
@@ -75,7 +75,7 @@ internal static class CivilizationDetailRenderer
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(rightCol + 80f, currentY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White), $"{vm.MemberCount}/4");
 
-        currentY += 24f;
+        currentY += Spacing.Section;
 
         // Civilization founder (player name)
         TextRenderer.DrawLabel(drawList,
@@ -84,7 +84,7 @@ internal static class CivilizationDetailRenderer
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(leftCol + 120f, currentY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), vm.FounderName);
 
-        currentY += 24f;
+        currentY += Spacing.Section;
 
         // Founding religion
         TextRenderer.DrawLabel(drawList,
@@ -93,16 +93,16 @@ internal static class CivilizationDetailRenderer
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(leftCol + 120f, currentY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), vm.FounderReligionName);
 
-        currentY += 32f;
+        currentY += Spacing.Block;
 
         // Description section (if present)
         if (!string.IsNullOrEmpty(vm.Description))
         {
-            currentY += 8f;
+            currentY += Spacing.Tight;
             TextRenderer.DrawLabel(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_DESCRIPTION),
-                vm.X, currentY, SubsectionLabel, ColorPalette.Grey);
-            currentY += 22f;
+                vm.X, currentY, TableHeader, ColorPalette.Grey);
+            currentY += Spacing.HeaderToContent;
 
             TextRenderer.DrawInfoText(drawList, vm.Description, vm.X, currentY, vm.Width * 0.9f);
             currentY += 60f;
@@ -111,13 +111,13 @@ internal static class CivilizationDetailRenderer
         // Divider line
         drawList.AddLine(new Vector2(vm.X, currentY), new Vector2(vm.X + vm.Width, currentY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey * 0.5f), 1f);
-        currentY += 16f;
+        currentY += Spacing.Comfortable;
 
         // Member religions section
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_MEMBER_RELIGIONS),
             vm.X, currentY, TableHeader, ColorPalette.White);
-        currentY += 28f;
+        currentY += Spacing.HeaderToContent;
 
         // Member list (scrollable)
         var listHeight = vm.Height - (currentY - vm.Y) - 80f;
@@ -131,7 +131,7 @@ internal static class CivilizationDetailRenderer
             listHeight,
             membersList,
             60f,
-            8f,
+            Spacing.ListItemGap,
             vm.MemberScrollY,
             (member, cx, cy, cw, ch) => DrawMemberRow(member, cx, cy, cw, ch, drawList, vm.FounderReligionName),
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_NO_MEMBERS)
@@ -189,7 +189,7 @@ internal static class CivilizationDetailRenderer
         }
 
         // Religion name
-        TextRenderer.DrawLabel(drawList, member.ReligionName, x + 40f, y + 8f, 15f);
+        TextRenderer.DrawLabel(drawList, member.ReligionName, x + 40f, y + 8f, Body);
 
         // Sub info - includes deity, member count, and religion founder name
         var subText = LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_MEMBER_CARD_INFO,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
@@ -322,7 +322,7 @@ internal static class CivilizationHolySitesRenderer
         var currentY = y + SiteItemPadding;
 
         // Site name (larger font)
-        drawList.AddText(ImGui.GetFont(), TableHeader - 1f,
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel,
             new Vector2(currentX, currentY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White),
             site.SiteName);
@@ -334,7 +334,7 @@ internal static class CivilizationHolySitesRenderer
             .Replace("{0}", site.Tier.ToString());
         drawList.AddText(ImGui.GetFont(), Secondary,
             new Vector2(currentX, currentY),
-            ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 0.84f, 0f, 1f)), // Gold color
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold),
             tierText);
 
         // Volume

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
@@ -165,7 +165,7 @@ internal static class CivilizationMilestoneRenderer
         );
 
         drawList.AddText(ImGui.GetFont(), SubsectionLabel, textPos,
-            ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 0.3f, 0.3f, 1f)), text);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.ErrorRed), text);
     }
 
     private static float DrawRankSection(
@@ -191,7 +191,7 @@ internal static class CivilizationMilestoneRenderer
         var rankText = LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_MILESTONES_RANK)
             .Replace("{0}", rankName);
         var rankY = startY + (RankSectionHeight - ImGui.CalcTextSize(rankText).Y) / 2f;
-        drawList.AddText(ImGui.GetFont(), 24f,
+        drawList.AddText(ImGui.GetFont(), PageTitle,
             new Vector2(x + 20f, rankY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold),
             rankText);
@@ -281,7 +281,7 @@ internal static class CivilizationMilestoneRenderer
     {
         var label = LocalizationService.Instance.Get(labelKey);
         var color = isActive
-            ? ImGui.ColorConvertFloat4ToU32(new Vector4(0.3f, 0.9f, 0.3f, 1f)) // Green when active
+            ? ImGui.ColorConvertFloat4ToU32(ColorPalette.SuccessGreen)
             : ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
 
         drawList.AddText(ImGui.GetFont(), Body,
@@ -414,7 +414,7 @@ internal static class CivilizationMilestoneRenderer
 
         // Border
         var borderColor = milestone.IsCompleted
-            ? ImGui.ColorConvertFloat4ToU32(new Vector4(0.3f, 0.7f, 0.3f, 1f))
+            ? ImGui.ColorConvertFloat4ToU32(ColorPalette.Darken(ColorPalette.SuccessGreen, 0.78f))
             : ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.BorderColor, 0.5f));
         drawList.AddRect(itemRect, itemRectEnd, borderColor, 3f, ImDrawFlags.None, 1f);
 
@@ -424,9 +424,9 @@ internal static class CivilizationMilestoneRenderer
 
         // Milestone name
         var nameColor = milestone.IsCompleted
-            ? ImGui.ColorConvertFloat4ToU32(new Vector4(0.5f, 1f, 0.5f, 1f))
+            ? ImGui.ColorConvertFloat4ToU32(ColorPalette.Lighten(ColorPalette.SuccessGreen, 1.4f))
             : ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
-        drawList.AddText(ImGui.GetFont(), TableHeader - 1f,
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel,
             new Vector2(currentX, currentY),
             nameColor,
             milestone.MilestoneName);
@@ -438,7 +438,7 @@ internal static class CivilizationMilestoneRenderer
         var statusSize = ImGui.CalcTextSize(statusText);
         var statusX = x + width - statusSize.X - padding;
         var statusColor = milestone.IsCompleted
-            ? ImGui.ColorConvertFloat4ToU32(new Vector4(0.3f, 0.9f, 0.3f, 1f))
+            ? ImGui.ColorConvertFloat4ToU32(ColorPalette.SuccessGreen)
             : ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
         drawList.AddText(ImGui.GetFont(), Secondary,
             new Vector2(statusX, currentY),

--- a/DivineAscension/GUI/UI/Renderers/Civilization/MilestoneTooltipRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/MilestoneTooltipRenderer.cs
@@ -53,7 +53,7 @@ internal static class MilestoneTooltipRenderer
     {
         var lines = new List<TooltipLine>();
         var goldColor = ColorPalette.Gold;
-        var greenColor = new Vector4(0.3f, 0.9f, 0.3f, 1f);
+        var greenColor = ColorPalette.SuccessGreen;
         var contentWidth = TOOLTIP_MAX_WIDTH - TOOLTIP_PADDING * 2;
 
         // Title in gold

--- a/DivineAscension/GUI/UI/Renderers/HolySites/HolySiteDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/HolySites/HolySiteDetailRenderer.cs
@@ -81,7 +81,7 @@ internal static class HolySiteDetailRenderer
             events.Add(new DetailEvent.MarkClicked());
         }
 
-        currentY += 44f;
+        currentY += Spacing.BackButtonRow;
 
         // Draw background panel
         var backgroundY = currentY;
@@ -316,7 +316,7 @@ internal static class HolySiteDetailRenderer
 
         // Checkbox background (green if complete, dark gray if not)
         var bgColor = step.IsComplete
-            ? ImGui.ColorConvertFloat4ToU32(new Vector4(0.2f, 0.8f, 0.2f, 0.9f))
+            ? ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Green, 0.9f))
             : ImGui.ColorConvertFloat4ToU32(new Vector4(0.2f, 0.2f, 0.2f, 0.8f));
 
         drawList.AddRectFilled(
@@ -328,7 +328,7 @@ internal static class HolySiteDetailRenderer
         drawList.AddRect(
             new Vector2(x, y),
             new Vector2(x + checkboxSize, y + checkboxSize),
-            ImGui.ColorConvertFloat4ToU32(new Vector4(0.4f, 0.4f, 0.4f, 1f)),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.MutedText),
             3f, ImDrawFlags.None, 1.5f);
 
         // Checkmark (if complete)
@@ -359,7 +359,7 @@ internal static class HolySiteDetailRenderer
             var contributorsText = "  Contributors: " + string.Join(", ",
                 step.TopContributors.Take(3).Select(c => $"{c.PlayerName} ({c.Quantity})"));
             drawList.AddText(ImGui.GetFont(), Small, new Vector2(textX, y),
-                ImGui.ColorConvertFloat4ToU32(new Vector4(0.6f, 0.6f, 0.6f, 1f)),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.DisabledGray),
                 contributorsText);
             y += 16f;
         }
@@ -392,13 +392,13 @@ internal static class HolySiteDetailRenderer
 
         // "Undiscovered Step" text
         var textX = x + iconSize + 10f;
-        var textColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.5f, 0.5f, 0.5f, 1f)); // Gray
+        var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DisabledGray);
         drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(textX, y), textColor, "??? Undiscovered Step");
         y += 20f;
 
         // Hint text
         var hintText = "  Offer sacred items to discover this step";
-        var hintColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.4f, 0.4f, 0.4f, 1f));
+        var hintColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.MutedText);
         drawList.AddText(ImGui.GetFont(), Small, new Vector2(textX, y), hintColor, hintText);
         y += 16f;
     }

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
@@ -53,11 +53,11 @@ internal static class ReligionInfoHeaderRenderer
         }
 
         TextRenderer.DrawLabel(drawList, viewModel.ReligionName,
-            x + iconSize + 12f, currentY + 4f, SectionHeader, ColorPalette.White);
+            x + iconSize + 12f, currentY + 4f, PageTitle, ColorPalette.White);
 
         // Approximate the scaled name width and place the bracket tag after it.
         var nameWidthScaled = ImGui.CalcTextSize(viewModel.ReligionName).X
-                              * (SectionHeader / SubsectionLabel);
+                              * (PageTitle / SubsectionLabel);
         if (!string.IsNullOrEmpty(viewModel.PrestigeRank))
         {
             var rankText = $"[{viewModel.PrestigeRank}]";

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionDetailRenderer.cs
@@ -58,7 +58,7 @@ internal static class ReligionDetailRenderer
                 events.Add(new DetailEvent.JoinClicked(vm.ReligionUID));
         }
 
-        currentY += 44f;
+        currentY += Spacing.BackButtonRow;
 
         // Draw background panel per CSS spec (#241B14, 4px border radius)
         var backgroundY = currentY;
@@ -107,7 +107,7 @@ internal static class ReligionDetailRenderer
         var prestigeCenter = vm.X + prestigeColumnLeft + (columnWidth / 2f);
         var publicCenter = vm.X + publicColumnLeft + (columnWidth / 2f);
         // Column headers - centered using exact text measurements
-        var headerColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.239f, 0.180f, 0.125f, 1f)); // #3D2E20
+        var headerColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
 
         // Name header (centered in 270px column at 291px)
         var nameHeader = LocalizationService.Instance.Get(LocalizationKeys.UI_TABLE_NAME);
@@ -132,7 +132,7 @@ internal static class ReligionDetailRenderer
         drawList.AddText(font, TableHeader, new Vector2(publicCenter - publicHeaderWidth / 2f, currentY), headerColor,
             publicHeader);
 
-        currentY += 32f;
+        currentY += Spacing.Block;
 
         // Deity icon — centered inside the icon column, sized to fit.
         var iconSize = MathF.Min(85f, iconColumnWidth - 16f);
@@ -144,7 +144,7 @@ internal static class ReligionDetailRenderer
             var deityTextureId = DeityIconLoader.GetDeityTextureId(deityType);
             if (deityTextureId != IntPtr.Zero)
             {
-                var borderColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.239f, 0.180f, 0.125f, 1f)); // #3D2E20
+                var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
                 // Draw border (2px)
                 drawList.AddRect(
                     new Vector2(iconX - 1f, iconY - 1f),
@@ -161,7 +161,7 @@ internal static class ReligionDetailRenderer
         }
 
         // Religion name - in Name column (centered in 270px column at 291px)
-        var nameColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.996f, 0.682f, 0.204f, 1f)); // #FEAE34
+        var nameColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
         var nameApproxWidth = vm.ReligionName.Length * 6.5f;
 
         // Name vertically aligned with icon center
@@ -171,7 +171,7 @@ internal static class ReligionDetailRenderer
             nameColor, vm.ReligionName);
 
         // Values centered in their columns (vertically centered with icon)
-        var valueColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.573f, 0.502f, 0.416f, 1f)); // #92806A
+        var valueColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
         var deityValueY = iconY + (iconSize - 16f) / 2f;
 
         // Deity name with full title (multi-line if needed)
@@ -220,19 +220,18 @@ internal static class ReligionDetailRenderer
             new Vector2(publicCenter - publicApproxWidth / 2f, deityValueY),
             valueColor, publicText);
 
-        currentY = iconY + iconSize + 32f;
+        currentY = iconY + iconSize + Spacing.Block;
     }
 
     private static void DrawDescriptionSection(ReligionDetailViewModel vm, ImDrawListPtr drawList, ref float currentY)
     {
         var font = ImGui.GetFont();
-        var headerColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.239f, 0.180f, 0.125f, 1f)); // #3D2E20
-        var valueColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.573f, 0.502f, 0.416f, 1f)); // #92806A
+        var headerColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
+        var valueColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
 
         // Description spans the full content width, with horizontal padding.
-        const float horizontalPadding = 16f;
-        var descLeft = vm.X + horizontalPadding;
-        var descWidth = MathF.Max(vm.Width - horizontalPadding * 2f, 100f);
+        var descLeft = vm.X + Spacing.ContentPadding;
+        var descWidth = MathF.Max(vm.Width - Spacing.ContentPadding * 2f, 100f);
         var descCenter = vm.X + vm.Width / 2f;
 
         // Header centered above the description block.
@@ -241,11 +240,9 @@ internal static class ReligionDetailRenderer
         drawList.AddText(font, TableHeader, new Vector2(descCenter - descHeaderWidth / 2f, currentY), headerColor,
             descHeader);
 
-        currentY += 28f;
+        currentY += Spacing.HeaderToContent;
 
-        var lineHeight = 20f;
-
-        ImGui.PushFont(ImGui.GetFont());
+        var lineHeight = Body + LinePadding;
         var descLines = WrapText(vm.Description, descWidth, font, Body);
 
         foreach (var line in descLines)
@@ -258,8 +255,7 @@ internal static class ReligionDetailRenderer
             currentY += lineHeight;
         }
 
-        ImGui.PopFont();
-        currentY += 16f; // Extra spacing after description
+        currentY += Spacing.Comfortable; // Extra spacing after description
     }
 
     private static List<string> WrapText(string text, float maxWidth, ImFontPtr font, float fontSize)
@@ -294,17 +290,17 @@ internal static class ReligionDetailRenderer
     private static void DrawMembersSection(ReligionDetailViewModel vm, ImDrawListPtr drawList, ref float currentY,
         List<DetailEvent> events)
     {
-        var headerColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.239f, 0.180f, 0.125f, 1f)); // #3D2E20
+        var headerColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
         var font = ImGui.GetFont();
 
         // Members header
         var headerText = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_DETAIL_MEMBERS, vm.MemberCount);
-        drawList.AddText(font, TableHeader, new Vector2(vm.X + 16, currentY), headerColor, headerText);
+        drawList.AddText(font, TableHeader, new Vector2(vm.X + Spacing.ContentPadding, currentY), headerColor, headerText);
 
-        currentY += 28f;
+        currentY += Spacing.HeaderToContent;
 
         // Member list (scrollable)
-        var listHeight = vm.Height - (currentY - vm.Y) - 16f;
+        var listHeight = vm.Height - (currentY - vm.Y) - Spacing.Comfortable;
         var members = vm.Members?.ToList() ?? new List<ReligionDetailResponsePacket.MemberInfo>();
 
         var newScrollY = ScrollableList.Draw<ReligionDetailResponsePacket.MemberInfo>(
@@ -315,7 +311,7 @@ internal static class ReligionDetailRenderer
             listHeight,
             members,
             36f, // Item height
-            8f, // Item spacing
+            Spacing.ListItemGap,
             vm.MemberScrollY,
             (member, cx, cy, cw, ch) => DrawMemberRow(member, cx, cy, cw, ch, drawList),
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_DETAIL_NO_MEMBERS)
@@ -331,9 +327,9 @@ internal static class ReligionDetailRenderer
     private static void DrawMemberRow(ReligionDetailResponsePacket.MemberInfo member, float x, float y, float width,
         float height, ImDrawListPtr drawList)
     {
-        var bgColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.161f, 0.118f, 0.086f, 1f)); // #291E16
-        var borderColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.239f, 0.180f, 0.125f, 1f)); // #3D2E20
-        var textColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.573f, 0.502f, 0.416f, 1f)); // #92806A
+        var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Background);
+        var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
+        var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
 
         // Background
         drawList.AddRectFilled(

--- a/DivineAscension/GUI/UI/Utilities/ColorPalette.cs
+++ b/DivineAscension/GUI/UI/Utilities/ColorPalette.cs
@@ -30,6 +30,15 @@ internal static class ColorPalette
     public static readonly Vector4 Green = new(0.2f, 0.8f, 0.2f, 1.0f); // Success
     public static readonly Vector4 Yellow = new(0.8f, 0.8f, 0.2f, 1.0f); // Warning
 
+    // Brighter status variants used for badges, active indicators, completed states
+    public static readonly Vector4 SuccessGreen = new(0.3f, 0.9f, 0.3f, 1.0f);
+    public static readonly Vector4 ErrorRed = new(1.0f, 0.3f, 0.3f, 1.0f);
+
+    // Neutral text variants
+    public static readonly Vector4 LightText = new(0.8f, 0.8f, 0.8f, 1.0f); // Body copy on dark bg
+    public static readonly Vector4 DisabledGray = new(0.5f, 0.5f, 0.5f, 1.0f); // Disabled labels
+    public static readonly Vector4 MutedText = new(0.4f, 0.4f, 0.4f, 1.0f); // Hints, secondary captions
+
     // Opacity Variants
     public static readonly Vector4 BlackOverlay = new(0f, 0f, 0f, 0.8f); // Modal background
     public static readonly Vector4 BlackOverlayLight = new(0f, 0f, 0f, 0.7f); // Lighter overlay

--- a/DivineAscension/GUI/UI/Utilities/FontSizes.cs
+++ b/DivineAscension/GUI/UI/Utilities/FontSizes.cs
@@ -32,4 +32,11 @@ internal static class FontSizes
 
     /// <summary>Tier labels, very small text</summary>
     public const float Compact = 14f;
+
+    /// <summary>Densely packed summary text (cross-deity counts, micro badges)</summary>
+    public const float Micro = 12f;
+
+    // Spacing helpers
+    /// <summary>Pixels added between wrapped text lines (line-height = fontSize + LinePadding).</summary>
+    public const float LinePadding = 6f;
 }

--- a/DivineAscension/GUI/UI/Utilities/Spacing.cs
+++ b/DivineAscension/GUI/UI/Utilities/Spacing.cs
@@ -1,0 +1,28 @@
+namespace DivineAscension.GUI.UI.Utilities;
+
+/// <summary>
+///     Centralized spacing scale for content page renderers.
+///     Use these in preference to magic numbers so padding stays
+///     consistent across Religion / Civilization / Blessing / HolySites.
+/// </summary>
+internal static class Spacing
+{
+    // Horizontal padding inside a content panel (gap from the panel edge).
+    public const float ContentPadding = 16f;
+
+    // Gap between the back-button row and the panel content below it.
+    public const float BackButtonRow = 44f;
+
+    // Vertical rhythm — pick one of these for "blank space between things".
+    public const float Tight = 8f;
+    public const float Compact = 12f;
+    public const float Comfortable = 16f;
+    public const float Section = 24f;
+    public const float Block = 32f;
+
+    // Spacing between a section header label and the first content row underneath it.
+    public const float HeaderToContent = 28f;
+
+    // Gap between repeated rows in a vertical list (members, milestones, etc.).
+    public const float ListItemGap = 8f;
+}


### PR DESCRIPTION
Add semantic constants and replace hardcoded literals scattered through
the Religion, Civilization, Blessing, and HolySites content pages.

ColorPalette: add SuccessGreen, ErrorRed, LightText, DisabledGray,
MutedText so brighter status colors and neutral text variants stop
being redefined inline in renderers.

FontSizes: add Micro (12f) for densely packed summary text and
LinePadding (6f) so wrapped text rendering shares one line-height
formula instead of mixing +4f and hardcoded 20f.

Spacing: new scale (ContentPadding, BackButtonRow, Tight, Compact,
Comfortable, Section, Block, HeaderToContent, ListItemGap) used by
the detail renderers so panel padding stops drifting per file.

Renderer fixes:
- ReligionDetailRenderer: replace 7 hardcoded #3D2E20 browns with
  ColorPalette.DarkBrown, the inline gold with ColorPalette.Gold, the
  inline grey with ColorPalette.Grey, drop the no-op PushFont pair,
  derive description lineHeight from FontSizes.
- ReligionInfoHeaderRenderer: bump religion name from SectionHeader
  to PageTitle to match Civilization and Blessing entity titles.
- CivilizationMilestoneRenderer: collapse 3 separate green variants
  to SuccessGreen, use ErrorRed for error state, swap raw 24f for
  PageTitle and TableHeader-1f for SubsectionLabel.
- CivilizationHolySitesRenderer: remove TableHeader-1f offset and
  hardcoded gold color literal.
- CivilizationDetailRenderer: align description header gap with the
  Religion/Blessing 28f rhythm, use Body constant for member-row name.
- HolySiteDetailRenderer: replace muted gray literals with
  DisabledGray / MutedText, use Green palette entry for completion
  checkbox.
- BlessingActionsRenderer: drop duplicated ColorGold/ColorTextNormal/
  ColorTextDisabled/ColorButtonHover/ColorButtonNormal in favor of
  ColorPalette.
- BlessingInfoSectionRequirements: match BlessingInfoSectionStats by
  using TableHeader for the section title.
- BlessingInfoTextUtils: switch wrap spacing to FontSizes.LinePadding.
- CrossDeitySummaryRenderer / DeitySelectorRenderer: replace raw 12f
  and 14f font sizes with Micro and Secondary constants.
- MilestoneTooltipRenderer: reuse SuccessGreen.

https://claude.ai/code/session_01HGwNFTdWzicYbqJemFjDGa