### PR TITLE
refactor(ui): unify content-pane headers via PaneHeaderRenderer

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Blessing/Info/BlessingInfoSectionHeader.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/Info/BlessingInfoSectionHeader.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using DivineAscension.GUI.Models.Blessing.Info;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models;
 using ImGuiNET;
@@ -15,46 +16,26 @@ internal static class BlessingInfoSectionHeader
     {
         var drawList = ImGui.GetWindowDrawList();
 
-        // Title
-        var titleColor = selectedState.IsUnlocked ? ColorPalette.Gold : ColorPalette.White;
-        var titleColorU32 = ImGui.ColorConvertFloat4ToU32(titleColor);
-        drawList.AddText(ImGui.GetFont(), PageTitle, new Vector2(vm.X + padding, currentY), titleColorU32,
-            selectedState.Blessing.Name);
-        currentY += 28f;
-
-        // Status badge
-        var statusText = selectedState.VisualState switch
+        // Title + ornamental divider, with the unlock state as the rank tag.
+        var (statusText, statusColor) = selectedState.VisualState switch
         {
-            BlessingNodeVisualState.Unlocked => "[UNLOCKED]",
-            BlessingNodeVisualState.Unlockable => "[AVAILABLE]",
-            _ => "[LOCKED]"
+            BlessingNodeVisualState.Unlocked => ("UNLOCKED", ColorPalette.Gold),
+            BlessingNodeVisualState.Unlockable => ("AVAILABLE", ColorPalette.Green),
+            _ => ("LOCKED", ColorPalette.Red),
         };
 
-        var statusColor = selectedState.VisualState switch
-        {
-            BlessingNodeVisualState.Unlocked => ColorPalette.Gold,
-            BlessingNodeVisualState.Unlockable => ColorPalette.Green,
-            _ => ColorPalette.Red
-        };
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            selectedState.Blessing.Name,
+            vm.X + padding, currentY, vm.Width - padding * 2,
+            rankTag: statusText, rankColor: statusColor);
 
-        var statusColorU32 = ImGui.ColorConvertFloat4ToU32(statusColor);
-        drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(vm.X + padding, currentY), statusColorU32, statusText);
-        currentY += 20f;
-
-        // Category and kind
+        // Category and kind metadata, drawn below the divider as supplementary
+        // info (the status badge moved into the header's rank slot above).
         var metaText =
             $"{selectedState.Blessing.Category} | {selectedState.Blessing.Kind} Blessing | Tier {selectedState.Tier}";
         var metaColorU32 = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
         drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(vm.X + padding, currentY), metaColorU32, metaText);
         currentY += 20f;
-
-        // Separator line
-        var lineY = currentY;
-        var lineStart = new Vector2(vm.X + padding, lineY);
-        var lineEnd = new Vector2(vm.X + vm.Width - padding, lineY);
-        var lineColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey * 0.5f);
-        drawList.AddLine(lineStart, lineEnd, lineColor, 1f);
-        currentY += 8f;
 
         return currentY;
     }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationBrowseRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Models.Civilization.Table;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Inputs;
 using DivineAscension.GUI.UI.Renderers.Components;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -46,6 +47,12 @@ internal static class CivilizationBrowseRenderer
     {
         var events = new List<BrowseEvent>();
         var currentY = vm.Y + TopPadding;
+
+        // === PANE HEADER ===
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_TAB_BROWSE),
+            vm.X, currentY, vm.Width);
+
         var filterControlsY = currentY;  // Store filter controls Y position for dropdown menu
 
         // === FILTER CONTROLS ===

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Models.Civilization.Create;
 using DivineAscension.GUI.UI.Components;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Inputs;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -24,10 +25,10 @@ internal static class CivilizationCreateRenderer
         var events = new List<CreateEvent>();
         var currentY = vm.Y;
 
-        TextRenderer.DrawLabel(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_CREATE_TITLE), vm.X, currentY, SectionHeader,
-            ColorPalette.White);
-        currentY += 32f;
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_CREATE_TITLE),
+            vm.X, currentY, vm.Width);
+        currentY += 12f;
 
         // Requirements
         TextRenderer.DrawLabel(drawList,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationEditRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationEditRenderer.cs
@@ -6,6 +6,7 @@ using DivineAscension.GUI.Events.Civilization;
 using DivineAscension.GUI.Models.Civilization.Edit;
 using DivineAscension.GUI.UI.Components;
 using DivineAscension.GUI.UI.Components.Buttons;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -44,7 +45,7 @@ internal static class CivilizationEditRenderer
 
         // Section heights match the currentY increments below:
         //   20 top pad
-        // + 40 title row
+        // + PaneHeaderRenderer.TotalHeight title row (icon-less header + ornamental divider)
         // + 30 civ-name row
         // + 25 'Current Icon:' label
         // + previewHeight + 20 gap
@@ -52,7 +53,7 @@ internal static class CivilizationEditRenderer
         // + pickerHeight + 20 gap
         // + 60 button strip
         // + 20 bottom pad
-        var dialogHeight = 20f + 40f + 30f + 25f + previewHeightEstimate + 20f
+        var dialogHeight = 20f + PaneHeaderRenderer.TotalHeight + 30f + 25f + previewHeightEstimate + 20f
                            + 25f + pickerHeightEstimate + 20f + 60f + 20f;
         // Clamp to the available overlay so dialogs never escape the dialog.
         dialogHeight = System.MathF.Min(dialogHeight, System.MathF.Max(300f, vm.Height - 40f));
@@ -75,9 +76,9 @@ internal static class CivilizationEditRenderer
         var contentWidth = dialogWidth - 40f;
 
         // Title
-        TextRenderer.DrawLabel(drawList, LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_EDIT_TITLE),
-            contentX, currentY, 18f, ColorPalette.White);
-        currentY += 40f;
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_EDIT_TITLE),
+            contentX, currentY, contentWidth);
 
         // Civilization name
         TextRenderer.DrawLabel(drawList,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.Constants;
 using DivineAscension.GUI.Events.Civilization;
 using DivineAscension.GUI.Models.Civilization.HolySites;
 using DivineAscension.GUI.UI.Components.Buttons;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Network.HolySite;
 using DivineAscension.Services;
@@ -81,26 +82,21 @@ internal static class CivilizationHolySitesRenderer
         float y,
         List<HolySitesEvent> events)
     {
-        // Title
-        var titleText = LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_HOLYSITES_TITLE);
-        drawList.AddText(ImGui.GetFont(), SectionHeader,
-            new Vector2(viewModel.X + 20f, y),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.White),
-            titleText);
-
-        // Refresh button (right-aligned)
-        var buttonX = viewModel.X + viewModel.Width - RefreshButtonWidth - 20f;
-        var buttonY = y - 5f;
-
+        // Refresh button (drawn on the same row as the title, right-aligned)
+        var buttonX = viewModel.X + viewModel.Width - RefreshButtonWidth;
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_HOLYSITES_REFRESH),
-                buttonX, buttonY, RefreshButtonWidth, RefreshButtonHeight,
+                buttonX, y + 3f, RefreshButtonWidth, RefreshButtonHeight,
                 false, !viewModel.IsLoading))
         {
             events.Add(new HolySitesEvent.RefreshClicked());
         }
 
-        return HeaderHeight;
+        // Title + ornamental divider; return the height the helper consumed.
+        var contentStartY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_HOLYSITES_TITLE),
+            viewModel.X, y, viewModel.Width);
+        return contentStartY - y;
     }
 
     private static void DrawLoadingState(

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -53,35 +53,10 @@ internal static class CivilizationInfoRenderer
             return new CivilizationInfoRendererResult(events, vm.Height);
         }
 
-        // Header with icon
-        const float iconSize = 32f;
         var iconTextureId = CivilizationIconLoader.GetIconTextureId(vm.Icon);
-
-        if (iconTextureId != IntPtr.Zero)
-        {
-            // Draw icon
-            var iconMin = new Vector2(vm.X, currentY);
-            var iconMax = new Vector2(vm.X + iconSize, currentY + iconSize);
-            var tintColorU32 = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f));
-            drawList.AddImage(iconTextureId, iconMin, iconMax, Vector2.Zero, Vector2.One, tintColorU32);
-
-            // Draw icon border
-            var iconBorderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f);
-            drawList.AddRect(iconMin, iconMax, iconBorderColor, 4f, ImDrawFlags.None, 1f);
-        }
-
-        // Draw civilization name next to icon with rank
-        TextRenderer.DrawLabel(drawList, vm.CivName, vm.X + iconSize + 12f, currentY + 4f, SectionHeader, ColorPalette.White);
-        var civNameWidth = ImGui.CalcTextSize(vm.CivName).X * (SectionHeader / SubsectionLabel); // Approximate scaled width
         var rankName = RankRequirements.GetCivilizationRankName(vm.Rank);
-        var rankText = $"[{rankName}]";
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(vm.X + iconSize + 12f + civNameWidth + 8f, currentY + 6f),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), rankText);
-        currentY += Math.Max(iconSize + 4f, 32f);
-
-        // Ornamental divider under the civilization header.
-        ChromeRenderer.DrawDivider(drawList, vm.X, currentY, vm.Width);
-        currentY += 20f;
+        currentY = PaneHeaderRenderer.Draw(drawList, vm.CivName,
+            vm.X, currentY, vm.Width, iconTextureId, rankName);
 
         // Founded · · · · · 2026-03-14
         ChromeRenderer.DrawLeader(drawList,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInvitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInvitesRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Events.Civilization;
 using DivineAscension.GUI.Models.Civilization.Invites;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Lists;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Network.Civilization;
 using DivineAscension.Services;
@@ -25,10 +26,9 @@ internal static class CivilizationInvitesRenderer
         var events = new List<InvitesEvent>();
         var currentY = vm.Y;
 
-        TextRenderer.DrawLabel(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INVITES_TITLE), vm.X, currentY, SectionHeader,
-            ColorPalette.White);
-        currentY += 26f;
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INVITES_TITLE),
+            vm.X, currentY, vm.Width);
 
         // Help text explaining where to send invites
         TextRenderer.DrawInfoText(drawList,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
@@ -8,6 +8,7 @@ using DivineAscension.GUI.Events.Civilization;
 using DivineAscension.GUI.Models.Civilization.Milestones;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Lists;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Network;
 using DivineAscension.Services;
@@ -94,26 +95,23 @@ internal static class CivilizationMilestoneRenderer
         float y,
         List<MilestoneEvent> events)
     {
-        // Title
-        var titleText = LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_MILESTONES_TITLE);
-        drawList.AddText(ImGui.GetFont(), SectionHeader,
-            new Vector2(viewModel.X + 20f, y),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.White),
-            titleText);
-
-        // Refresh button (right-aligned)
-        var buttonX = viewModel.X + viewModel.Width - RefreshButtonWidth - 20f;
-        var buttonY = y - 5f;
-
+        // Refresh button (drawn on the same row as the title, right-aligned)
+        var buttonX = viewModel.X + viewModel.Width - RefreshButtonWidth;
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_MILESTONES_REFRESH),
-                buttonX, buttonY, RefreshButtonWidth, RefreshButtonHeight,
+                buttonX, y + 3f, RefreshButtonWidth, RefreshButtonHeight,
                 false, !viewModel.IsLoading))
         {
             events.Add(new MilestoneEvent.RefreshClicked());
         }
 
-        return HeaderHeight;
+        // Title + ornamental divider; return the height the helper consumed
+        // so the caller's accumulator advances by exactly that much.
+        var headerStartY = y;
+        var contentStartY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_MILESTONES_TITLE),
+            viewModel.X, y, viewModel.Width);
+        return contentStartY - headerStartY;
     }
 
     private static void DrawLoadingState(

--- a/DivineAscension/GUI/UI/Renderers/HolySites/HolySiteBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/HolySites/HolySiteBrowseRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Models.HolySite.Browse;
 using DivineAscension.GUI.Models.HolySite.Table;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Renderers.Components;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -24,7 +25,6 @@ internal static class HolySiteBrowseRenderer
     private const float TopPadding = 8f;
     private const float RefreshButtonWidth = 100f;
     private const float RefreshButtonHeight = 30f;
-    private const float ComponentSpacing = 40f;
 
     /// <summary>
     ///     Pure renderer: builds visuals from the view model and emits UI events. No state or side effects.
@@ -35,11 +35,9 @@ internal static class HolySiteBrowseRenderer
     {
         var events = new List<BrowseEvent>();
         var currentY = viewModel.Y + TopPadding;
-        var controlsY = currentY;
 
         // === HEADER CONTROLS ===
-        DrawHeaderControls(viewModel, controlsY, drawList, events);
-        currentY += ComponentSpacing;
+        currentY = DrawHeaderControls(viewModel, currentY, drawList, events);
 
         // === HOLY SITES TABLE ===
         var tableHeight = viewModel.Height - (currentY - viewModel.Y);
@@ -89,25 +87,26 @@ internal static class HolySiteBrowseRenderer
     /// <summary>
     ///     Draw header with title and refresh button
     /// </summary>
-    private static void DrawHeaderControls(
+    private static float DrawHeaderControls(
         HolySiteBrowseViewModel vm,
         float y,
         ImDrawListPtr drawList,
         List<BrowseEvent> events)
     {
-        // Title
-        var titleText = LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_BROWSE_TITLE);
-        TextRenderer.DrawLabel(drawList, titleText, vm.X, y);
-
-        // Refresh button (right-aligned)
+        // Refresh button (drawn on the same row as the title, right-aligned)
         var refreshButtonX = vm.X + vm.Width - RefreshButtonWidth;
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_BROWSE_REFRESH),
-                refreshButtonX, y - 6f, RefreshButtonWidth, RefreshButtonHeight,
+                refreshButtonX, y + 3f, RefreshButtonWidth, RefreshButtonHeight,
                 false, !vm.IsLoading))
         {
             events.Add(new BrowseEvent.RefreshClicked());
         }
+
+        // Title + ornamental divider
+        return PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_BROWSE_TITLE),
+            vm.X, y, vm.Width);
     }
 
     /// <summary>

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
@@ -32,44 +32,10 @@ internal static class ReligionInfoHeaderRenderer
         float width,
         List<InfoEvent> events)
     {
-        var currentY = y;
-
-        // === RELIGION HEADER ===
-        // Mirror the CivilizationInfo layout: deity icon at left, religion
-        // name (white, SectionHeader) next to it, then a gold bracket tag
-        // showing the prestige rank tier.
-        const float iconSize = 32f;
         var deityDomain = DomainHelper.ParseDeityType(viewModel.Deity);
         var iconTextureId = DeityIconLoader.GetDeityTextureId(deityDomain);
-        if (iconTextureId != IntPtr.Zero)
-        {
-            var iconMin = new Vector2(x, currentY);
-            var iconMax = new Vector2(x + iconSize, currentY + iconSize);
-            var tint = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f));
-            drawList.AddImage(iconTextureId, iconMin, iconMax, Vector2.Zero, Vector2.One, tint);
-
-            var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f);
-            drawList.AddRect(iconMin, iconMax, borderColor, 4f, ImDrawFlags.None, 1f);
-        }
-
-        TextRenderer.DrawLabel(drawList, viewModel.ReligionName,
-            x + iconSize + 12f, currentY + 4f, PageTitle, ColorPalette.White);
-
-        // Approximate the scaled name width and place the bracket tag after it.
-        var nameWidthScaled = ImGui.CalcTextSize(viewModel.ReligionName).X
-                              * (PageTitle / SubsectionLabel);
-        if (!string.IsNullOrEmpty(viewModel.PrestigeRank))
-        {
-            var rankText = $"[{viewModel.PrestigeRank}]";
-            drawList.AddText(ImGui.GetFont(), SubsectionLabel,
-                new Vector2(x + iconSize + 12f + nameWidthScaled + 8f, currentY + 6f),
-                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), rankText);
-        }
-        currentY += Math.Max(iconSize + 4f, 32f);
-
-        // Ornamental divider under the header.
-        ChromeRenderer.DrawDivider(drawList, x, currentY, width);
-        currentY += 20f;
+        var currentY = PaneHeaderRenderer.Draw(drawList, viewModel.ReligionName,
+            x, y, width, iconTextureId, viewModel.PrestigeRank);
 
         // Deity · · · · · Hroth (Wild) — leader row, matching the rest.
         // Edit affordance for founders moves to its own row underneath when

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionActivityRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionActivityRenderer.cs
@@ -10,6 +10,7 @@ using DivineAscension.GUI.Events.Religion;
 using DivineAscension.GUI.Models.Religion.Activity;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Lists;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Network;
 using DivineAscension.Services;
@@ -55,15 +56,14 @@ internal static class ReligionActivityRenderer
         }
 
         // Header with refresh button
-        var headerHeight = DrawHeader(viewModel, drawList, out var refreshClicked);
+        var contentY = DrawHeader(viewModel, drawList, out var refreshClicked);
         if (refreshClicked)
         {
             events.Add(new ActivityEvent.RefreshRequested());
         }
 
         // Activity feed with scrolling
-        var contentY = viewModel.Y + headerHeight + 20f;
-        var contentHeight = viewModel.Height - headerHeight - 20f;
+        var contentHeight = viewModel.Y + viewModel.Height - contentY;
 
         DrawActivityFeed(viewModel, contentY, contentHeight, events);
 
@@ -76,23 +76,17 @@ internal static class ReligionActivityRenderer
         refreshClicked = false;
         var headerY = viewModel.Y + 10f;
 
-        // Title
-        var titleText = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ACTIVITY_TITLE);
-        drawList.AddText(ImGui.GetFont(), SectionHeader,
-            new Vector2(viewModel.X + 20f, headerY),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), titleText);
-
-        // Refresh button
-        var buttonWidth = 100f;
-        var buttonHeight = 30f;
-        var buttonX = viewModel.X + viewModel.Width - buttonWidth - 20f;
+        // Refresh button (drawn on the same row as the title, right-aligned)
+        const float buttonWidth = 100f;
+        const float buttonHeight = 30f;
+        var buttonX = viewModel.X + viewModel.Width - buttonWidth;
         var refreshText = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ACTIVITY_REFRESH);
 
         if (ButtonRenderer.DrawButton(
                 drawList,
                 refreshText,
                 buttonX,
-                headerY,
+                headerY + 3f,
                 buttonWidth,
                 buttonHeight,
                 isPrimary: false))
@@ -100,7 +94,10 @@ internal static class ReligionActivityRenderer
             refreshClicked = true;
         }
 
-        return 50f; // Header height
+        // Title + ornamental divider
+        return PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ACTIVITY_TITLE),
+            viewModel.X, headerY, viewModel.Width);
     }
 
     private static void DrawActivityFeed(ReligionActivityViewModel viewModel,

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionBrowseRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Models.Religion.Table;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Inputs;
 using DivineAscension.GUI.UI.Renderers.Components;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -40,6 +41,12 @@ internal static class ReligionBrowseRenderer
     {
         var events = new List<BrowseEvent>();
         var currentY = viewModel.Y + TopPadding;
+
+        // === PANE HEADER ===
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_TAB_BROWSE),
+            viewModel.X, currentY, viewModel.Width);
+
         var filterControlsY = currentY;
 
         // === FILTER CONTROLS ===

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
@@ -42,12 +42,10 @@ internal static class ReligionCreateRenderer
         const float padding = 20f;
 
         // === HEADER ===
-        var headerText = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_CREATE_TITLE);
-        var headerSize = ImGui.CalcTextSize(headerText);
-        var headerPos = new Vector2(formX, currentY);
-        var headerColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        drawList.AddText(ImGui.GetFont(), PageTitle, headerPos, headerColor, headerText);
-        currentY += headerSize.Y + padding;
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_CREATE_TITLE),
+            formX, currentY, formWidth);
+        currentY += padding;
 
         // === FORM FIELDS ===
         const float fieldWidth = formWidth;

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionInvitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionInvitesRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Events.Religion;
 using DivineAscension.GUI.Models.Religion.Invites;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Lists;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -32,14 +33,9 @@ internal static class ReligionInvitesRenderer
         var currentY = viewModel.Y;
 
         // === HEADER ===
-        TextRenderer.DrawLabel(
-            drawList,
+        currentY = PaneHeaderRenderer.Draw(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INVITES_TITLE),
-            viewModel.X,
-            currentY,
-            18f,
-            ColorPalette.White);
-        currentY += 26f;
+            viewModel.X, currentY, viewModel.Width);
 
         // === HELP TEXT ===
         TextRenderer.DrawInfoText(

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionRoleDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionRoleDetailRenderer.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.Models.Religion.Roles;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Inputs;
 using DivineAscension.GUI.UI.Components.Overlays;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models;
 using DivineAscension.Services;
@@ -45,10 +46,9 @@ internal static class ReligionRoleDetailRenderer
         currentY += 42f;
 
         // Title
-        TextRenderer.DrawLabel(drawList,
+        currentY = PaneHeaderRenderer.Draw(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLE_DETAIL_TITLE, viewModel.ViewingRoleName),
-            x, currentY, SectionHeader, ColorPalette.Gold);
-        currentY += 30f;
+            x, currentY, width);
 
         // Get members with this role
         var membersWithRole = viewModel.GetMembersWithRole();
@@ -117,7 +117,7 @@ internal static class ReligionRoleDetailRenderer
             var memberUID = openDropdownMemberUID;
             var dropdownX = x + width - dropdownWidth;
             var memberIndex = membersWithRole.IndexOf(memberUID);
-            var dropdownY = y + 42f + 30f + memberIndex * 32f;
+            var dropdownY = y + 42f + PaneHeaderRenderer.TotalHeight + memberIndex * 32f;
             var memberRoleUID = viewModel.MemberRoles.GetValueOrDefault(memberUID);
             var currentRoleIndex = memberRoleUID != null
                 ? assignableRoles.ToList().FindIndex(r => r.RoleUID == memberRoleUID)

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionRolesBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionRolesBrowseRenderer.cs
@@ -9,6 +9,7 @@ using DivineAscension.GUI.Events.Religion;
 using DivineAscension.GUI.Models.Religion.Roles;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Overlays;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models;
 using DivineAscension.Services;
@@ -95,10 +96,9 @@ internal static class ReligionRolesBrowseRenderer
         currentY = y - scrollY;
 
         // Header
-        TextRenderer.DrawLabel(drawList,
+        currentY = PaneHeaderRenderer.Draw(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_TITLE),
-            x, currentY, TableHeader, ColorPalette.Gold);
-        currentY += 30f;
+            x, currentY, width - ScrollbarWidth);
 
         // Create Role button (if player can manage roles)
         if (viewModel.CanManageRoles())
@@ -473,7 +473,7 @@ internal static class ReligionRolesBrowseRenderer
 
     private static float ComputeContentHeight(ReligionRolesBrowseViewModel viewModel)
     {
-        var height = 80f; // Header + padding
+        var height = PaneHeaderRenderer.TotalHeight + 8f; // Header + padding
 
         if (viewModel.CanManageRoles()) height += 42f; // Create button
 

--- a/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.UI.Utilities;
+using ImGuiNET;
+
+namespace DivineAscension.GUI.UI.Renderers.Utilities;
+
+/// <summary>
+///     Shared header renderer for sidebar destinations and modal/overlay forms.
+///     Every pane-level title goes through this so font, color, icon framing,
+///     rank-tag placement, and the ornamental divider stay consistent across
+///     Religion, Civilization, Blessing, and HolySites content.
+///     Pass <paramref name="iconTextureId" /> when the pane represents the
+///     player's own entity (identity panes). Pass <paramref name="rankTag" />
+///     when the entity has a rank/status to display in brackets after the
+///     title. Both are optional.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class PaneHeaderRenderer
+{
+    public const float IconSize = 32f;
+    public const float RowHeight = 36f; // Math.Max(IconSize + 4f, 32f)
+    public const float DividerBelowSpacing = 20f;
+    public const float TotalHeight = RowHeight + DividerBelowSpacing;
+
+    public static float Draw(
+        ImDrawListPtr drawList,
+        string title,
+        float x, float y, float width,
+        IntPtr iconTextureId = default,
+        string? rankTag = null,
+        Vector4? rankColor = null)
+    {
+        var hasIcon = iconTextureId != IntPtr.Zero;
+        var titleX = hasIcon ? x + IconSize + 12f : x;
+
+        if (hasIcon)
+        {
+            var iconMin = new Vector2(x, y);
+            var iconMax = new Vector2(x + IconSize, y + IconSize);
+            var tint = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f));
+            drawList.AddImage(iconTextureId, iconMin, iconMax, Vector2.Zero, Vector2.One, tint);
+            var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f);
+            drawList.AddRect(iconMin, iconMax, borderColor, 4f, ImDrawFlags.None, 1f);
+        }
+
+        TextRenderer.DrawLabel(drawList, title, titleX, y + 4f, FontSizes.PageTitle, ColorPalette.White);
+
+        if (!string.IsNullOrEmpty(rankTag))
+        {
+            // CalcTextSize reports at the loaded font's base size (SubsectionLabel-equivalent);
+            // scale to match what we actually rendered the title at.
+            var nameWidthScaled = ImGui.CalcTextSize(title).X * (FontSizes.PageTitle / FontSizes.SubsectionLabel);
+            var rankText = $"[{rankTag}]";
+            drawList.AddText(ImGui.GetFont(), FontSizes.SubsectionLabel,
+                new Vector2(titleX + nameWidthScaled + 8f, y + 6f),
+                ImGui.ColorConvertFloat4ToU32(rankColor ?? ColorPalette.Gold), rankText);
+        }
+
+        var dividerY = y + RowHeight;
+        ChromeRenderer.DrawDivider(drawList, x, dividerY, width);
+        return dividerY + DividerBelowSpacing;
+    }
+}


### PR DESCRIPTION
Every sidebar destination and modal/overlay form now routes its top-of-pane
title through a shared PaneHeaderRenderer so font, color, icon framing,
rank-tag placement, and the ornamental divider stay consistent across
Religion, Civilization, Blessing, and HolySites content.

- PaneHeaderRenderer.Draw paints icon (optional), PageTitle 20f White
  title, optional [Rank] tag in SubsectionLabel Gold, and the
  ChromeRenderer ornamental divider; returns the next content Y.
- Identity panes (Religion/Civilization Info) drop their bespoke
  header+divider block in favour of one helper call.
- Activity, Milestones, HolySites panes keep their right-aligned refresh
  button alongside the unified title row.
- Invites, Roles, Role Detail, HolySite Browse, Create/Edit forms drop
  their assorted SectionHeader/TableHeader/hardcoded-18f title variants.
- Religion/Civilization Browse panes gain an explicit pane header (they
  previously jumped straight into filter controls).
- BlessingInfoSectionHeader collapses its title+status-badge+separator
  into the helper, with the unlock state surfaced as the rank tag
  (gold/green/red) and category/kind metadata kept below the divider.

https://claude.ai/code/session_01CGCEJDpoJP9v9GzJyHDZcR