### PR TITLE
refactor(ui): pane titles use sidebar tab labels

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
@@ -26,7 +26,7 @@ internal static class CivilizationCreateRenderer
         var currentY = vm.Y;
 
         currentY = PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_CREATE_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_TAB_CREATE),
             vm.X, currentY, vm.Width);
         currentY += 12f;
 

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
@@ -94,7 +94,7 @@ internal static class CivilizationHolySitesRenderer
 
         // Title + ornamental divider; return the height the helper consumed.
         var contentStartY = PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_HOLYSITES_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_TAB_HOLYSITES),
             viewModel.X, y, viewModel.Width);
         return contentStartY - y;
     }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -57,7 +57,8 @@ internal static class CivilizationInfoRenderer
         var rankName = RankRequirements.GetCivilizationRankName(vm.Rank);
         currentY = PaneHeaderRenderer.Draw(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_TAB_INFO),
-            vm.X, currentY, vm.Width, iconTextureId, rankName);
+            vm.X, currentY, vm.Width, iconTextureId, rankName,
+            rightTitle: vm.CivName);
 
         // Founded · · · · · 2026-03-14
         ChromeRenderer.DrawLeader(drawList,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -55,7 +55,8 @@ internal static class CivilizationInfoRenderer
 
         var iconTextureId = CivilizationIconLoader.GetIconTextureId(vm.Icon);
         var rankName = RankRequirements.GetCivilizationRankName(vm.Rank);
-        currentY = PaneHeaderRenderer.Draw(drawList, vm.CivName,
+        currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_TAB_INFO),
             vm.X, currentY, vm.Width, iconTextureId, rankName);
 
         // Founded · · · · · 2026-03-14

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInvitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInvitesRenderer.cs
@@ -27,7 +27,7 @@ internal static class CivilizationInvitesRenderer
         var currentY = vm.Y;
 
         currentY = PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INVITES_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_TAB_INVITES),
             vm.X, currentY, vm.Width);
 
         // Help text explaining where to send invites

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
@@ -109,7 +109,7 @@ internal static class CivilizationMilestoneRenderer
         // so the caller's accumulator advances by exactly that much.
         var headerStartY = y;
         var contentStartY = PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_MILESTONES_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_TAB_MILESTONES),
             viewModel.X, y, viewModel.Width);
         return contentStartY - headerStartY;
     }

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
@@ -34,7 +34,8 @@ internal static class ReligionInfoHeaderRenderer
     {
         var deityDomain = DomainHelper.ParseDeityType(viewModel.Deity);
         var iconTextureId = DeityIconLoader.GetDeityTextureId(deityDomain);
-        var currentY = PaneHeaderRenderer.Draw(drawList, viewModel.ReligionName,
+        var currentY = PaneHeaderRenderer.Draw(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_TAB_INFO),
             x, y, width, iconTextureId, viewModel.PrestigeRank);
 
         // Deity · · · · · Hroth (Wild) — leader row, matching the rest.

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
@@ -36,7 +36,8 @@ internal static class ReligionInfoHeaderRenderer
         var iconTextureId = DeityIconLoader.GetDeityTextureId(deityDomain);
         var currentY = PaneHeaderRenderer.Draw(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_TAB_INFO),
-            x, y, width, iconTextureId, viewModel.PrestigeRank);
+            x, y, width, iconTextureId, viewModel.PrestigeRank,
+            rightTitle: viewModel.ReligionName);
 
         // Deity · · · · · Hroth (Wild) — leader row, matching the rest.
         // Edit affordance for founders moves to its own row underneath when

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionActivityRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionActivityRenderer.cs
@@ -96,7 +96,7 @@ internal static class ReligionActivityRenderer
 
         // Title + ornamental divider
         return PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ACTIVITY_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_TAB_ACTIVITY),
             viewModel.X, headerY, viewModel.Width);
     }
 

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
@@ -43,7 +43,7 @@ internal static class ReligionCreateRenderer
 
         // === HEADER ===
         currentY = PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_CREATE_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_TAB_CREATE),
             formX, currentY, formWidth);
         currentY += padding;
 

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionInvitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionInvitesRenderer.cs
@@ -34,7 +34,7 @@ internal static class ReligionInvitesRenderer
 
         // === HEADER ===
         currentY = PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INVITES_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_TAB_INVITES),
             viewModel.X, currentY, viewModel.Width);
 
         // === HELP TEXT ===

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionRolesBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionRolesBrowseRenderer.cs
@@ -97,7 +97,7 @@ internal static class ReligionRolesBrowseRenderer
 
         // Header
         currentY = PaneHeaderRenderer.Draw(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_TITLE),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_TAB_ROLES),
             x, currentY, width - ScrollbarWidth);
 
         // Create Role button (if player can manage roles)

--- a/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
@@ -30,7 +30,8 @@ internal static class PaneHeaderRenderer
         float x, float y, float width,
         IntPtr iconTextureId = default,
         string? rankTag = null,
-        Vector4? rankColor = null)
+        Vector4? rankColor = null,
+        string? rightTitle = null)
     {
         var hasIcon = iconTextureId != IntPtr.Zero;
         var titleX = hasIcon ? x + IconSize + 12f : x;
@@ -56,6 +57,17 @@ internal static class PaneHeaderRenderer
             drawList.AddText(ImGui.GetFont(), FontSizes.SubsectionLabel,
                 new Vector2(titleX + nameWidthScaled + 8f, y + 6f),
                 ImGui.ColorConvertFloat4ToU32(rankColor ?? ColorPalette.Gold), rankText);
+        }
+
+        if (!string.IsNullOrEmpty(rightTitle))
+        {
+            // Right-aligned entity name at the same baseline as the title.
+            var rightScale = FontSizes.PageTitle / FontSizes.SubsectionLabel;
+            var rightWidth = ImGui.CalcTextSize(rightTitle).X * rightScale;
+            var rightX = x + width - rightWidth;
+            drawList.AddText(ImGui.GetFont(), FontSizes.PageTitle,
+                new Vector2(rightX, y + 4f),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), rightTitle);
         }
 
         var dividerY = y + RowHeight;


### PR DESCRIPTION
## Summary
- Pane headers now use the sidebar's tab localization keys, so the index entry and the page header stay in sync after localization changes.
- Religion and Civilization info panes drop the entity-name title (still shown in body content).
- Covers: religion (browse already aligned, info, activity, roles, invites, create) and civilization (info, create, invites, holysites, milestones).

## Test plan
- [ ] Open dialog (Shift+G), click each sidebar entry, confirm pane header matches the sidebar label.