### PR TITLE
fix(ui): redraw Conquest swords + Wild antlers, default to domain ink

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Utilities/DomainGlyphRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/DomainGlyphRenderer.cs
@@ -20,7 +20,10 @@ internal static class DomainGlyphRenderer
     public static void Draw(ImDrawListPtr drawList, DeityDomain domain,
         Vector2 min, Vector2 max, Vector4? colorOverride = null)
     {
-        var color = ImGui.ColorConvertFloat4ToU32(colorOverride ?? ColorPalette.LightText);
+        // Default to the domain's manuscript-ink hue (palette §3) so the glyph
+        // reads on parchment. Callers can override for dark surfaces.
+        var color = ImGui.ColorConvertFloat4ToU32(
+            colorOverride ?? DomainHelper.GetDeityColor(domain));
         var w = max.X - min.X;
         var h = max.Y - min.Y;
         if (w <= 2f || h <= 2f) return;
@@ -73,30 +76,92 @@ internal static class DomainGlyphRenderer
 
     private static void DrawLeaf(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
     {
-        var halfW = s * 0.25f;
-        var halfH = s * 0.40f;
-        var top = new Vector2(cx, cy - halfH);
-        var right = new Vector2(cx + halfW, cy);
-        var bottom = new Vector2(cx, cy + halfH);
-        var left = new Vector2(cx - halfW, cy);
-        drawList.AddQuadFilled(top, right, bottom, left, color);
-        // Midrib.
-        drawList.AddLine(top, bottom, ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown), 1.5f);
+        // Antlers — heraldic stag mark. Symmetric pair rising from a small
+        // skull plate at the base, each antler a curved beam with two
+        // outward-up tines. More legible at 32px than the old leaf, which
+        // read as just a diamond when domain-tinted.
+        var beam = MathF.Max(2f, s * 0.07f);
+        var tine = MathF.Max(1.5f, s * 0.055f);
+        var baseY = cy + s * 0.30f;
+
+        // Skull plate.
+        drawList.AddTriangleFilled(
+            new Vector2(cx - s * 0.06f, baseY + s * 0.03f),
+            new Vector2(cx + s * 0.06f, baseY + s * 0.03f),
+            new Vector2(cx, baseY - s * 0.06f),
+            color);
+
+        for (var side = -1; side <= 1; side += 2)
+        {
+            var p0 = new Vector2(cx, baseY - s * 0.04f);
+            var p1 = new Vector2(cx + side * s * 0.10f, cy + s * 0.10f);
+            var p2 = new Vector2(cx + side * s * 0.20f, cy - s * 0.08f);
+            var p3 = new Vector2(cx + side * s * 0.28f, cy - s * 0.34f);
+
+            drawList.AddLine(p0, p1, color, beam);
+            drawList.AddLine(p1, p2, color, beam);
+            drawList.AddLine(p2, p3, color, beam);
+
+            // Inner-facing tines branching off the beam — each tine angles
+            // up and slightly outward so the rack reads as a fan.
+            var tine1 = new Vector2(cx + side * s * 0.30f, cy + s * 0.00f);
+            var tine2 = new Vector2(cx + side * s * 0.42f, cy - s * 0.22f);
+            drawList.AddLine(p1, tine1, color, tine);
+            drawList.AddLine(p2, tine2, color, tine);
+        }
     }
 
     private static void DrawCrossedSwords(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
     {
-        var arm = s * 0.40f;
-        var thick = MathF.Max(2f, s * 0.06f);
-        // Two diagonal lines forming an X.
-        drawList.AddLine(new Vector2(cx - arm, cy - arm), new Vector2(cx + arm, cy + arm), color, thick);
-        drawList.AddLine(new Vector2(cx - arm, cy + arm), new Vector2(cx + arm, cy - arm), color, thick);
-        // Hilts as little perpendicular ticks near the bottom of each blade.
-        var tick = s * 0.10f;
-        drawList.AddLine(new Vector2(cx - arm - tick * 0.5f, cy + arm - tick * 0.5f),
-            new Vector2(cx - arm + tick * 0.5f, cy + arm + tick * 0.5f), color, thick * 0.6f);
-        drawList.AddLine(new Vector2(cx + arm - tick * 0.5f, cy + arm + tick * 0.5f),
-            new Vector2(cx + arm + tick * 0.5f, cy + arm - tick * 0.5f), color, thick * 0.6f);
+        // Heraldic crossed-swords: both blades point upward, hilts down. Each
+        // blade is a filled tapered triangle from a wide base near the guard
+        // to a sharp tip, with a perpendicular crossguard and a circular
+        // pommel at the grip's end. Two swords drawn along the SW→NE and
+        // SE→NW diagonals so the tips reach the upper corners.
+        const float invSqrt2 = 0.70710677f;
+        // Tip = arm out along sword axis; HiltEnd = arm out the opposite way.
+        var arm = s * 0.42f;
+        var bladeHalf = MathF.Max(1.5f, s * 0.045f);
+        var guardArm = s * 0.10f;
+        var guardThick = MathF.Max(1.5f, s * 0.035f);
+        var pommelR = MathF.Max(2f, s * 0.06f);
+        // Where the blade ends and the grip begins along the sword axis.
+        var bladeBaseFromCenter = -arm * 0.35f;
+
+        // Sword A — tip top-left, hilt bottom-right.
+        DrawOneSword(drawList, cx, cy, -invSqrt2, -invSqrt2,
+            arm, bladeHalf, bladeBaseFromCenter, guardArm, guardThick, pommelR, color);
+        // Sword B — tip top-right, hilt bottom-left.
+        DrawOneSword(drawList, cx, cy, invSqrt2, -invSqrt2,
+            arm, bladeHalf, bladeBaseFromCenter, guardArm, guardThick, pommelR, color);
+    }
+
+    private static void DrawOneSword(
+        ImDrawListPtr drawList, float cx, float cy,
+        float dx, float dy,
+        float arm, float bladeHalf, float bladeBaseAlong,
+        float guardArm, float guardThick, float pommelR, uint color)
+    {
+        // Axis vector (toward tip) and perpendicular vector.
+        var px = -dy;
+        var py = dx;
+
+        var tip = new Vector2(cx + dx * arm, cy + dy * arm);
+        var baseX = cx + dx * bladeBaseAlong;
+        var baseY = cy + dy * bladeBaseAlong;
+        var baseLeft = new Vector2(baseX + px * bladeHalf, baseY + py * bladeHalf);
+        var baseRight = new Vector2(baseX - px * bladeHalf, baseY - py * bladeHalf);
+        drawList.AddTriangleFilled(baseLeft, baseRight, tip, color);
+
+        // Crossguard — short perpendicular bar straddling the guard line.
+        var guardA = new Vector2(baseX + px * guardArm, baseY + py * guardArm);
+        var guardB = new Vector2(baseX - px * guardArm, baseY - py * guardArm);
+        drawList.AddLine(guardA, guardB, color, guardThick);
+
+        // Grip + pommel at the hilt end (opposite the tip).
+        var hiltEnd = new Vector2(cx - dx * arm * 0.65f, cy - dy * arm * 0.65f);
+        drawList.AddLine(new Vector2(baseX, baseY), hiltEnd, color, guardThick * 0.85f);
+        drawList.AddCircleFilled(hiltEnd, pommelR, color);
     }
 
     private static void DrawWheat(ImDrawListPtr drawList, float cx, float cy, float s, uint color)


### PR DESCRIPTION
## Summary
- **Conquest** — crossed swords were two line strokes, read as a plain X. Each sword is now a filled tapered triangle from a wide base near the guard to a sharp tip, with a perpendicular crossguard and a circular pommel at the hilt end. Both blades point up (SW→NE and SE→NW diagonals), hilts crossed at center-bottom.
- **Wild** — midrib leaf collapsed into a diamond at 32px once domain-tinted. Redrawn as a heraldic stag rack: symmetric curved beams rising from a small skull plate with two outward tines per side.
- `DomainGlyphRenderer.Draw` now defaults the glyph color to `DomainHelper.GetDeityColor(domain)` (palette §3) instead of `LightText` cream. The cream default disappeared on parchment; the domain ink reads correctly. Callers can still pass `colorOverride` for dark surfaces.

## Test plan
- [x] Open the right rail / chapter strip on a Conquest order — glyph reads as crossed swords in dried-blood red (`#8E2E1F`).
- [x] Same for Wild — antlers in olive (`#5C6E2A`).
- [x] Other domains (Craft hammer, Harvest wheat, Stone mountain) still render, now tinted with their domain inks.