### PR TITLE
feat(ui): fake diplomacy provider for dev rendering

### DIFF
--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -755,8 +755,6 @@ public static class LocalizationKeys
     public const string UI_DIPLOMACY_PROPOSAL_OFFER_PEACE = "divineascension:ui.diplomacy.proposal.offer_peace";
     public const string UI_DIPLOMACY_ACCEPT_VERB = "divineascension:ui.diplomacy.accept_verb";
     public const string UI_DIPLOMACY_REFUSE_VERB = "divineascension:ui.diplomacy.refuse_verb";
-    public const string UI_DIPLOMACY_TURN_PAGE_HINT = "divineascension:ui.diplomacy.turn_page_hint";
-    public const string UI_DIPLOMACY_TURN_PAGE_LABEL = "divineascension:ui.diplomacy.turn_page_label";
 
     // Propose Accord chapter (#330) — sibling page lifted from the Accords
     // chapter's old inline form.

--- a/DivineAscension/GUI/GuiDialogManager.cs
+++ b/DivineAscension/GUI/GuiDialogManager.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DivineAscension.GUI.Interfaces;
 using DivineAscension.GUI.Managers;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.UI.Adapters.Civilizations;
+using DivineAscension.GUI.UI.Adapters.Diplomacy;
 using DivineAscension.GUI.UI.Adapters.ReligionInvites;
 using DivineAscension.GUI.UI.Adapters.ReligionMembers;
 using DivineAscension.GUI.UI.Adapters.Religions;
@@ -52,6 +54,34 @@ public class GuiDialogManager : IBlessingDialogManager
         CivilizationManager.CivilizationProvider!.ConfigureDevSeed(25, 20251217);
         CivilizationManager.UseCivilizationDetailProvider(new FakeCivilizationDetailProvider(fakeCivProvider));
         CivilizationManager.RefreshCivilizationsFromProvider();
+
+        // Dev membership: park the player as founder of the first fake realm
+        // so HasCivilization() == true and the Accords / Propose chapters can
+        // render. Without this the diplomacy pages stop at the no-civilization
+        // empty state.
+        var devCiv = fakeCivProvider.GetCivilizations().FirstOrDefault();
+        if (devCiv != null)
+        {
+            CivilizationManager.UpdateCivilizationState(new CivilizationInfoResponsePacket.CivilizationDetails
+            {
+                CivId = devCiv.civId,
+                Name = devCiv.name,
+                FounderUID = devCiv.founderUID,
+                FounderReligionUID = devCiv.founderReligionUID,
+                Icon = devCiv.icon,
+                Description = devCiv.description,
+                IsFounder = true,
+                Rank = 3,
+                MemberReligions = new List<CivilizationInfoResponsePacket.MemberReligion>(),
+                PendingInvites = new List<CivilizationInfoResponsePacket.PendingInvite>(),
+            });
+        }
+
+        // Seeded diplomacy so Accords + Propose render without a server.
+        var fakeDiplomacyProvider = new FakeDiplomacyProvider();
+        fakeDiplomacyProvider.ConfigureDevSeed(20260522);
+        CivilizationManager.UseDiplomacyProvider(fakeDiplomacyProvider);
+        CivilizationManager.RequestDiplomacyInfo();
 #endif
     }
 

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -17,6 +17,7 @@ using DivineAscension.GUI.Models.Civilization.Tab;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.State.Civilization;
 using DivineAscension.GUI.UI.Adapters.Civilizations;
+using DivineAscension.GUI.UI.Adapters.Diplomacy;
 using DivineAscension.GUI.UI.Renderers.Civilization;
 using DivineAscension.GUI.UI.Renderers.HolySites;
 using DivineAscension.GUI.UI.Utilities;
@@ -44,6 +45,9 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
 
     // UI-only detail adapter (fake or real). Null when not used.
     internal ICivilizationDetailProvider? CivilizationDetailProvider { get; set; }
+
+    // UI-only diplomacy adapter (fake in dev). Null in release.
+    internal IDiplomacyProvider? DiplomacyProvider { get; private set; }
 
     public CivilizationTabState State { get; } = new();
 
@@ -105,6 +109,16 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     internal void UseCivilizationDetailProvider(ICivilizationDetailProvider provider)
     {
         CivilizationDetailProvider = provider;
+    }
+
+    /// <summary>
+    ///     Configure a UI-only diplomacy provider (fake in dev). When set,
+    ///     <see cref="RequestDiplomacyInfo" /> populates DiplomacyState from
+    ///     the provider instead of dispatching a packet to the server.
+    /// </summary>
+    internal void UseDiplomacyProvider(IDiplomacyProvider provider)
+    {
+        DiplomacyProvider = provider;
     }
 
     /// <summary>
@@ -307,6 +321,23 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
 
         State.DiplomacyState.IsLoading = true;
         State.DiplomacyState.ErrorMessage = null;
+
+        // Adapter short-circuit: dev fake provider populates state in-process
+        // so the Accords / Propose pages render seeded data without a server.
+        if (DiplomacyProvider != null)
+        {
+            var roster = State.BrowseState.AllCivilizations
+                .Where(c => c.CivId != CurrentCivilizationId)
+                .Select(c => (c.CivId, c.Name))
+                .ToList();
+            var packet = DiplomacyProvider.GetDiplomacyInfo(CurrentCivilizationId, roster);
+            State.DiplomacyState.ActiveRelationships = packet.Relationships;
+            State.DiplomacyState.IncomingProposals = packet.IncomingProposals;
+            State.DiplomacyState.OutgoingProposals = packet.OutgoingProposals;
+            State.DiplomacyState.IsLoading = false;
+            State.DiplomacyState.LastRefresh = DateTime.UtcNow;
+            return;
+        }
 
         _uiService.RequestDiplomacyInfo(CurrentCivilizationId);
         _coreClientApi.Logger.Debug(

--- a/DivineAscension/GUI/UI/Adapters/Diplomacy/FakeDiplomacyProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/Diplomacy/FakeDiplomacyProvider.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.Models.Enum;
+using DivineAscension.Network.Diplomacy;
+
+namespace DivineAscension.GUI.UI.Adapters.Diplomacy;
+
+/// <summary>
+///     Dev-only diplomacy provider. Picks a deterministic subset of the
+///     supplied other realms and assigns them roles (alliance / NAP / war /
+///     incoming proposal / outgoing proposal) so the ledger Accords chapter
+///     and Propose page have something to render without a running server.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class FakeDiplomacyProvider : IDiplomacyProvider
+{
+    private int _seed = 20260522;
+
+    public void ConfigureDevSeed(int seed)
+    {
+        _seed = seed;
+    }
+
+    public DiplomacyInfoResponsePacket GetDiplomacyInfo(
+        string currentCivId,
+        IReadOnlyList<(string CivId, string Name)> otherRealms)
+    {
+        var rnd = new Random(_seed);
+        var now = DateTime.UtcNow;
+
+        // Shuffle a copy of the roster so each call grabs the same realms for
+        // each slot, but the slots themselves rotate when the dev tweaks the
+        // seed.
+        var roster = otherRealms.ToList();
+        for (var i = roster.Count - 1; i > 0; i--)
+        {
+            var j = rnd.Next(i + 1);
+            (roster[i], roster[j]) = (roster[j], roster[i]);
+        }
+
+        var relationships = new List<DiplomacyInfoResponsePacket.RelationshipInfo>();
+        var incoming = new List<DiplomacyInfoResponsePacket.ProposalInfo>();
+        var outgoing = new List<DiplomacyInfoResponsePacket.ProposalInfo>();
+
+        // Slots are picked by index so the layout reads predictably:
+        //  0: alliance (no scheduled break)
+        //  1: alliance with a scheduled break in 14 hours
+        //  2: NAP, permanent
+        //  3: NAP, expiring soon, two grievances
+        //  4: war
+        //  5: incoming proposal — alliance offer
+        //  6: incoming proposal — NAP offer
+        //  7: outgoing proposal — alliance offer
+        TryAddRelationship(roster, 0, rel => relationships.Add(MakeRelationship(rel,
+            DiplomaticStatus.Alliance,
+            established: now.AddDays(-90),
+            expires: now.AddDays(275),
+            violations: 0,
+            breakScheduled: null)));
+
+        TryAddRelationship(roster, 1, rel => relationships.Add(MakeRelationship(rel,
+            DiplomaticStatus.Alliance,
+            established: now.AddDays(-160),
+            expires: null,
+            violations: 1,
+            breakScheduled: now.AddHours(14))));
+
+        TryAddRelationship(roster, 2, rel => relationships.Add(MakeRelationship(rel,
+            DiplomaticStatus.NonAggressionPact,
+            established: now.AddDays(-200),
+            expires: null,
+            violations: 0,
+            breakScheduled: null)));
+
+        TryAddRelationship(roster, 3, rel => relationships.Add(MakeRelationship(rel,
+            DiplomaticStatus.NonAggressionPact,
+            established: now.AddDays(-40),
+            expires: now.AddDays(2),
+            violations: 2,
+            breakScheduled: null)));
+
+        TryAddRelationship(roster, 4, rel => relationships.Add(MakeRelationship(rel,
+            DiplomaticStatus.War,
+            established: now.AddDays(-7),
+            expires: null,
+            violations: 0,
+            breakScheduled: null)));
+
+        TryAddRelationship(roster, 5, rel => incoming.Add(MakeProposal(rel,
+            DiplomaticStatus.Alliance,
+            sent: now.AddHours(-6),
+            expires: now.AddHours(66))));
+
+        TryAddRelationship(roster, 6, rel => incoming.Add(MakeProposal(rel,
+            DiplomaticStatus.NonAggressionPact,
+            sent: now.AddHours(-1),
+            expires: now.AddMinutes(35))));
+
+        TryAddRelationship(roster, 7, rel => outgoing.Add(MakeProposal(rel,
+            DiplomaticStatus.Alliance,
+            sent: now.AddHours(-12),
+            expires: now.AddHours(60))));
+
+        return new DiplomacyInfoResponsePacket
+        {
+            CivId = currentCivId,
+            Relationships = relationships,
+            IncomingProposals = incoming,
+            OutgoingProposals = outgoing,
+        };
+    }
+
+    private static void TryAddRelationship(
+        List<(string CivId, string Name)> roster,
+        int index,
+        Action<(string CivId, string Name)> add)
+    {
+        if (index < roster.Count) add(roster[index]);
+    }
+
+    private static DiplomacyInfoResponsePacket.RelationshipInfo MakeRelationship(
+        (string CivId, string Name) other,
+        DiplomaticStatus status,
+        DateTime established,
+        DateTime? expires,
+        int violations,
+        DateTime? breakScheduled)
+    {
+        return new DiplomacyInfoResponsePacket.RelationshipInfo
+        {
+            RelationshipId = Guid.NewGuid().ToString("N"),
+            OtherCivId = other.CivId,
+            OtherCivName = other.Name,
+            Status = status,
+            EstablishedDate = established,
+            ExpiresDate = expires,
+            ViolationCount = violations,
+            BreakScheduledDate = breakScheduled,
+        };
+    }
+
+    private static DiplomacyInfoResponsePacket.ProposalInfo MakeProposal(
+        (string CivId, string Name) other,
+        DiplomaticStatus proposed,
+        DateTime sent,
+        DateTime expires)
+    {
+        return new DiplomacyInfoResponsePacket.ProposalInfo
+        {
+            ProposalId = Guid.NewGuid().ToString("N"),
+            OtherCivId = other.CivId,
+            OtherCivName = other.Name,
+            ProposedStatus = proposed,
+            SentDate = sent,
+            ExpiresDate = expires,
+            Duration = proposed == DiplomaticStatus.NonAggressionPact ? 3 : null,
+        };
+    }
+}

--- a/DivineAscension/GUI/UI/Adapters/Diplomacy/IDiplomacyProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/Diplomacy/IDiplomacyProvider.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DivineAscension.Network.Diplomacy;
+
+namespace DivineAscension.GUI.UI.Adapters.Diplomacy;
+
+/// <summary>
+///     UI-only data source for diplomatic relationships and pending proposals.
+///     Lets the Accords + Propose pages render seeded data in DEBUG without
+///     a server round-trip. Mirrors the
+///     <see cref="DivineAscension.GUI.UI.Adapters.Civilizations.ICivilizationProvider" />
+///     pattern.
+/// </summary>
+internal interface IDiplomacyProvider
+{
+    /// <summary>
+    ///     Synthesise diplomatic state for <paramref name="currentCivId" /> against
+    ///     the supplied roster of other realms (typically the fake civ list).
+    /// </summary>
+    DiplomacyInfoResponsePacket GetDiplomacyInfo(
+        string currentCivId,
+        IReadOnlyList<(string CivId, string Name)> otherRealms);
+
+    void ConfigureDevSeed(int seed);
+}

--- a/DivineAscension/GUI/UI/Renderers/Civilization/DiplomacyTabRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/DiplomacyTabRenderer.cs
@@ -60,10 +60,6 @@ internal static class DiplomacyTabRenderer
     private const float ProposalRowHeight = 28f;
     private const float ProposalRowSpacing = 4f;
 
-    // Footer geometry.
-    private const float TurnPageGap = 8f;
-    private const float TurnPageChevronSize = 10f;
-
     public static DiplomacyTabRendererResult Draw(
         DiplomacyTabViewModel vm,
         ImDrawListPtr drawList)
@@ -136,10 +132,6 @@ internal static class DiplomacyTabRenderer
         currentY = DrawOrnateDivider(drawList, x, currentY, contentWidth);
 
         currentY = DrawPendingSection(drawList, vm, x, currentY, contentWidth, events);
-
-        currentY = DrawOrnateDivider(drawList, x, currentY, contentWidth);
-
-        DrawTurnPageFooter(drawList, x, currentY, contentWidth);
 
         drawList.PopClipRect();
 
@@ -384,29 +376,6 @@ internal static class DiplomacyTabRenderer
         return y + ProposalRowHeight;
     }
 
-    private static void DrawTurnPageFooter(
-        ImDrawListPtr drawList, float x, float y, float width)
-    {
-        var hint = LocalizationService.Instance.Get(LocalizationKeys.UI_DIPLOMACY_TURN_PAGE_HINT);
-        var label = LocalizationService.Instance.Get(LocalizationKeys.UI_DIPLOMACY_TURN_PAGE_LABEL);
-
-        drawList.AddText(ImGui.GetFont(), Body, new Vector2(x, y),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), hint);
-
-        var labelSize = ImGui.CalcTextSize(label);
-        var chevronCx = x + width - TurnPageChevronSize / 2f;
-        var labelX = chevronCx - TurnPageChevronSize / 2f - TurnPageGap - labelSize.X;
-        var textY = y;
-        drawList.AddText(ImGui.GetFont(), Body, new Vector2(labelX, textY),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), label);
-        ChromeRenderer.DrawChevron(drawList,
-            chevronCx,
-            textY + labelSize.Y / 2f,
-            TurnPageChevronSize,
-            ChromeRenderer.ChevronDirection.Right,
-            ColorPalette.Gold);
-    }
-
     private static float DrawOrnateDivider(ImDrawListPtr drawList, float x, float y, float width)
     {
         var dividerY = y + DividerYPadding;
@@ -560,10 +529,6 @@ internal static class DiplomacyTabRenderer
             h += vm.IncomingProposals.Count * (ProposalRowHeight + ProposalRowSpacing) + EntryBottomSpacing
                  - ProposalRowSpacing;
 
-        h += OrnateDividerHeight;
-
-        // Footer.
-        h += EntryLineHeight + 6f;
         return h;
     }
 

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -479,8 +479,6 @@
   "divineascension:ui.diplomacy.proposal.offer_peace": "{0} offer peace.",
   "divineascension:ui.diplomacy.accept_verb": "Accept",
   "divineascension:ui.diplomacy.refuse_verb": "Refuse",
-  "divineascension:ui.diplomacy.turn_page_hint": "To propose a new accord, turn to the next page.",
-  "divineascension:ui.diplomacy.turn_page_label": "Turn page",
   "divineascension:ui.propose_accord.chapter.title": "Propose an Accord",
   "divineascension:ui.propose_accord.intro": "Send word to another Realm. Mark its name and the manner of the pact you would set between you.",
   "divineascension:ui.propose_accord.no_civilization": "Your religion must stand within a Realm to send word to another.",


### PR DESCRIPTION
## Summary
- Add `IDiplomacyProvider` + `FakeDiplomacyProvider` mirroring the existing civilization adapter pattern.
- `RequestDiplomacyInfo` short-circuits to the provider when registered, so Accords (#329) and Propose (#330) render seeded data in DEBUG without a server.
- DEBUG block in `GuiDialogManager` parks the player as founder of the first fake realm and calls `RequestDiplomacyInfo` to populate the chapters on dialog open.

Seed covers every renderer branch: two alliances (one with a scheduled break), two NAPs (one expiring soon with two grievances), a war, two incoming proposals, one outgoing.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug`
- [x] `dotnet test` (2169 passed)
- [x] In-game (DEBUG): open Shift+G, navigate to Accords — see seeded standing accords sorted Alliance → NAP → War with grievance + countdown lines
- [x] In-game (DEBUG): Propose page — recipient dropdown excludes the seeded partners; war manner targets non-war realms