### PR TITLE
feat(ui): cinzel font integration — embed, apply, drop caps

### DIFF
--- a/DivineAscension/DivineAscension.csproj
+++ b/DivineAscension/DivineAscension.csproj
@@ -65,6 +65,15 @@
     </ItemGroup>
 
     <ItemGroup>
+        <EmbeddedResource Include="assets\divineascension\textures\gui\codex\fonts\cinzel-regular.ttf">
+            <LogicalName>DivineAscension.Fonts.cinzel-regular.ttf</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="assets\divineascension\textures\gui\codex\fonts\cinzel-bold.ttf">
+            <LogicalName>DivineAscension.Fonts.cinzel-bold.ttf</LogicalName>
+        </EmbeddedResource>
+    </ItemGroup>
+
+    <ItemGroup>
         <Folder Include="assets\"/>
     </ItemGroup>
 

--- a/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
+++ b/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
@@ -7,6 +7,7 @@ using DivineAscension.GUI.State;
 using DivineAscension.GUI.UI.Renderers.PlayerInfo;
 using DivineAscension.GUI.UI.Renderers.Sidebar;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
 using DivineAscension.Network.Civilization;
 using ImGuiNET;
 
@@ -36,6 +37,16 @@ internal static class MainLayoutCoordinator
         int windowHeight,
         float deltaTime)
     {
+        // Stamp ambient chrome state so pure renderers can tint chapter
+        // drop caps in the player's patron ink without holding a manager
+        // reference. Null when the player has no religion or hasn't been
+        // assigned a domain yet (drop cap then falls back to gold).
+        var patronDomain = manager.HasReligion()
+                           && manager.ReligionStateManager.CurrentReligionDomain != DeityDomain.None
+            ? manager.ReligionStateManager.CurrentReligionDomain
+            : (DeityDomain?)null;
+        ChromeContext.SetFrame(patronDomain);
+
         var windowPos = ImGui.GetWindowPos();
         var outer = new UiRect(windowPos.X, windowPos.Y, windowWidth, windowHeight);
 

--- a/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Services.UI;
 using DivineAscension.Systems;
 using ImGuiNET;
 using static DivineAscension.GUI.UI.Utilities.FontSizes;
@@ -25,6 +26,11 @@ internal static class TitleStripRenderer
     private const float OrnamentGap = 8f;
     private const string Ellipsis = "…";
     private const string IdentitySeparator = " · ";
+
+    // Cinzel Bold at 24px sits inside the 32px chrome strip with a 4px gutter
+    // top/bottom. Matches #287's ~28px target while staying inside the sizes
+    // VSImGui pre-bakes (6/8/10/14/18/24/30/36/48/60).
+    private const int TitleFontSize = 24;
 
     /// <summary>
     ///     Draw the title strip into <paramref name="rect" />. Returns true if
@@ -54,12 +60,30 @@ internal static class TitleStripRenderer
         // Left: a flanking diamond, then the app title in gold, then a
         // second flanking diamond. Diamonds are drawn primitives rather than
         // ✦ glyphs because ImGui's default font ranges don't include
-        // Dingbats — text glyphs would render as `?`. Measure the title at
-        // its actual render size (SubsectionLabel) so the right diamond
-        // doesn't drift outwards by the difference between the default font
-        // size and the size we draw at.
-        var renderScale = SubsectionLabel / ImGui.GetFontSize();
-        var titleSize = ImGui.CalcTextSize(TitleText) * renderScale;
+        // Dingbats — text glyphs would render as `?`. Title face is Cinzel
+        // Bold when the atlas baked it, default font otherwise — measure with
+        // the font we'll actually draw with so the right diamond hugs the
+        // glyph metrics rather than drifting.
+        var cinzelTitle = CinzelFontSystem.GetBold(TitleFontSize);
+        ImGuiNET.ImFontPtr titleFont;
+        float titleFontSize;
+        Vector2 titleSize;
+        if (cinzelTitle.HasValue)
+        {
+            titleFont = cinzelTitle.Value;
+            titleFontSize = TitleFontSize;
+            ImGui.PushFont(titleFont);
+            titleSize = ImGui.CalcTextSize(TitleText);
+            ImGui.PopFont();
+        }
+        else
+        {
+            titleFont = ImGui.GetFont();
+            titleFontSize = SubsectionLabel;
+            var renderScale = SubsectionLabel / ImGui.GetFontSize();
+            titleSize = ImGui.CalcTextSize(TitleText) * renderScale;
+        }
+
         var titleY = rect.Y + (rect.H - titleSize.Y) / 2f;
         var titleColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
 
@@ -67,7 +91,7 @@ internal static class TitleStripRenderer
         var leftOrnamentCx = rect.X + Padding + OrnamentHalfSize;
         var titleX = leftOrnamentCx + OrnamentHalfSize + OrnamentGap;
         ChromeRenderer.DrawDiamond(drawList, leftOrnamentCx, ornamentCenterY, OrnamentHalfSize);
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel,
+        drawList.AddText(titleFont, titleFontSize,
             new Vector2(titleX, titleY), titleColor, TitleText);
         var rightOrnamentCx = titleX + titleSize.X + OrnamentGap + OrnamentHalfSize;
         ChromeRenderer.DrawDiamond(drawList, rightOrnamentCx, ornamentCenterY, OrnamentHalfSize);

--- a/DivineAscension/GUI/UI/Renderers/Religion/Roster/ReligionRosterHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Roster/ReligionRosterHeaderRenderer.cs
@@ -16,7 +16,15 @@ internal static class ReligionRosterHeaderRenderer
     {
         var loc = LocalizationService.Instance;
         var title = loc.Get(LocalizationKeys.UI_RELIGION_ROSTER_TITLE, vm.ReligionName);
-        var afterHeader = PaneHeaderRenderer.Draw(drawList, title, x, y, width);
+        // Roster is always your own order's roster, so the player's patron
+        // ink is the right ledger ink for the cap. Falls through to gold
+        // for players without a religion (visible via founder-preview
+        // paths).
+        var dropCapColor = ChromeContext.PlayerPatronDomain.HasValue
+            ? DomainHelper.GetDeityColor(ChromeContext.PlayerPatronDomain.Value)
+            : ColorPalette.Gold;
+        var afterHeader = PaneHeaderRenderer.Draw(drawList, title, x, y, width,
+            dropCapColor: dropCapColor);
 
         var introKey = vm.MemberCount == 1
             ? LocalizationKeys.UI_RELIGION_ROSTER_INTRO_ONE

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
@@ -6,6 +6,7 @@ using DivineAscension.GUI.UI.Layout;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
+using DivineAscension.Services.UI;
 using ImGuiNET;
 
 namespace DivineAscension.GUI.UI.Renderers.Sidebar;
@@ -21,6 +22,7 @@ internal static class SidebarRenderer
     private const float ToggleStripHeight = 28f;
     private const float GroupHeaderHeight = 22f;
     private const float ItemHeight = 24f;
+    private const int ChapterFontSize = 18;
     private const float ItemIndent = 12f;
     private const float ChapterChevronSize = 9f;
     private const float ChapterChevronPadding = 6f;
@@ -129,11 +131,16 @@ internal static class SidebarRenderer
         ChromeRenderer.DrawChevron(drawList, chevronX, chevronY, ChapterChevronSize,
             chapterDirection, ColorPalette.Gold);
 
+        // Chapter row uses Cinzel Regular at 18 (matches the default 18px so
+        // the chevron + label line stays vertically centred). Item labels
+        // below intentionally stay in the default font for legibility.
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        var fontSize = ImGui.GetFontSize();
+        var cinzelChapter = CinzelFontSystem.GetRegular(ChapterFontSize);
+        var labelFont = cinzelChapter ?? ImGui.GetFont();
+        var labelSize = cinzelChapter.HasValue ? ChapterFontSize : ImGui.GetFontSize();
         var textX = chevronX + ChapterChevronSize / 2f + ChapterChevronPadding;
-        var textY = cursor.Y + (GroupHeaderHeight - fontSize) / 2f;
-        drawList.AddText(new Vector2(textX, textY), textColor, group.Label);
+        var textY = cursor.Y + (GroupHeaderHeight - labelSize) / 2f;
+        drawList.AddText(labelFont, labelSize, new Vector2(textX, textY), textColor, group.Label);
     }
 
     private static void DrawItem(SidebarItemViewModel item, int verseIndex, List<SidebarEvent> events)

--- a/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
@@ -58,7 +58,8 @@ internal static class ChapterStripRenderer
         bool showPencil = false,
         IntPtr iconTextureId = default,
         string? rankTag = null,
-        Vector4? rankColor = null)
+        Vector4? rankColor = null,
+        Vector4? dropCapColor = null)
     {
         var stripY = paneY + TopPadding - scrollY;
         var contentWidth = paneWidth - ScrollbarGutter;
@@ -69,20 +70,29 @@ internal static class ChapterStripRenderer
             : 0f;
 
         // Title + divider — divider spans full contentWidth so it lines up
-        // with every section divider drawn at the same width below.
+        // with every section divider drawn at the same width below. When the
+        // pane has a right-side domain glyph and no left-icon (i.e. an entity
+        // chapter rather than an identity chapter), lead with a drop cap
+        // tinted in the domain's ink so the page opens like an illuminated
+        // codex spread. Caller can also pass an explicit drop-cap color to
+        // override.
+        var effectiveDropCap = dropCapColor
+            ?? (iconTextureId == IntPtr.Zero && rightGlyph.HasValue
+                ? DomainHelper.GetDeityColor(rightGlyph.Value)
+                : (Vector4?)null);
+
         var bodyY = PaneHeaderRenderer.Draw(drawList, title, x, stripY, contentWidth,
-            iconTextureId: iconTextureId, rankTag: rankTag, rankColor: rankColor);
+            iconTextureId: iconTextureId, rankTag: rankTag, rankColor: rankColor,
+            dropCapColor: effectiveDropCap);
 
         if (!string.IsNullOrEmpty(rightTitle))
         {
-            var rightScale = FontSizes.PageTitle / FontSizes.SubsectionLabel;
-            var rightTextWidth = ImGui.CalcTextSize(rightTitle).X * rightScale;
+            var rightTextWidth = TextRenderer.MeasureSerifLabel(rightTitle, FontSizes.PageTitle);
             var anchorX = x + contentWidth - pencilReservation - glyphReservation;
             if (glyphReservation > 0f) anchorX -= GlyphGap;
             var rightX = anchorX - rightTextWidth;
-            drawList.AddText(ImGui.GetFont(), FontSizes.PageTitle,
-                new Vector2(rightX, stripY + 4f),
-                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), rightTitle);
+            TextRenderer.DrawSerifLabel(drawList, rightTitle, rightX, stripY + 4f,
+                FontSizes.PageTitle, ColorPalette.Gold);
         }
 
         if (rightGlyph.HasValue)

--- a/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
@@ -71,14 +71,20 @@ internal static class ChapterStripRenderer
 
         // Title + divider — divider spans full contentWidth so it lines up
         // with every section divider drawn at the same width below. Every
-        // chapter pane opens with an illuminated drop cap; the colour comes
-        // from the right-side domain glyph when there is one, falls back to
-        // the chrome gold for non-deity chapters (browse, identity, letters,
-        // chronicles…), and yields to an explicit caller override.
-        var effectiveDropCap = dropCapColor
-            ?? (rightGlyph.HasValue
-                ? DomainHelper.GetDeityColor(rightGlyph.Value)
-                : ColorPalette.Gold);
+        // chapter pane opens with an illuminated drop cap. Colour priority:
+        //   1. explicit dropCapColor from the caller,
+        //   2. the right-side domain glyph (page is about this domain),
+        //   3. the player's patron domain (player's own ink across their book),
+        //   4. chrome gold (player has no patron yet).
+        Vector4 effectiveDropCap;
+        if (dropCapColor.HasValue)
+            effectiveDropCap = dropCapColor.Value;
+        else if (rightGlyph.HasValue)
+            effectiveDropCap = DomainHelper.GetDeityColor(rightGlyph.Value);
+        else if (ChromeContext.PlayerPatronDomain.HasValue)
+            effectiveDropCap = DomainHelper.GetDeityColor(ChromeContext.PlayerPatronDomain.Value);
+        else
+            effectiveDropCap = ColorPalette.Gold;
 
         var bodyY = PaneHeaderRenderer.Draw(drawList, title, x, stripY, contentWidth,
             iconTextureId: iconTextureId, rankTag: rankTag, rankColor: rankColor,

--- a/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
@@ -70,16 +70,15 @@ internal static class ChapterStripRenderer
             : 0f;
 
         // Title + divider — divider spans full contentWidth so it lines up
-        // with every section divider drawn at the same width below. When the
-        // pane has a right-side domain glyph and no left-icon (i.e. an entity
-        // chapter rather than an identity chapter), lead with a drop cap
-        // tinted in the domain's ink so the page opens like an illuminated
-        // codex spread. Caller can also pass an explicit drop-cap color to
-        // override.
+        // with every section divider drawn at the same width below. Every
+        // chapter pane opens with an illuminated drop cap; the colour comes
+        // from the right-side domain glyph when there is one, falls back to
+        // the chrome gold for non-deity chapters (browse, identity, letters,
+        // chronicles…), and yields to an explicit caller override.
         var effectiveDropCap = dropCapColor
-            ?? (iconTextureId == IntPtr.Zero && rightGlyph.HasValue
+            ?? (rightGlyph.HasValue
                 ? DomainHelper.GetDeityColor(rightGlyph.Value)
-                : (Vector4?)null);
+                : ColorPalette.Gold);
 
         var bodyY = PaneHeaderRenderer.Draw(drawList, title, x, stripY, contentWidth,
             iconTextureId: iconTextureId, rankTag: rankTag, rankColor: rankColor,

--- a/DivineAscension/GUI/UI/Renderers/Utilities/ChromeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/ChromeRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Services.UI;
 using ImGuiNET;
 
 namespace DivineAscension.GUI.UI.Renderers.Utilities;
@@ -110,6 +111,51 @@ internal static class ChromeRenderer
                 break;
         }
         drawList.AddTriangleFilled(a, b, c, color);
+    }
+
+    /// <summary>
+    ///     Illuminated drop cap: a rounded square ornament filled with the
+    ///     given <paramref name="color" /> (dimmed) carrying <paramref name="letter" />
+    ///     in Cinzel Bold at the canonical 36px chapter size. Top-left corner
+    ///     of the ornament sits at (<paramref name="x" />, <paramref name="y" />)
+    ///     so callers can lay it flush with the chapter title baseline.
+    ///     Falls back to a plain large letter when Cinzel isn't loaded yet.
+    /// </summary>
+    public const float DropCapSize = 40f;
+    private const int DropCapFontSize = 36;
+
+    public static void DrawDropCap(ImDrawListPtr drawList, char letter, float x, float y,
+        Vector4 color)
+    {
+        var min = new Vector2(x, y);
+        var max = new Vector2(x + DropCapSize, y + DropCapSize);
+        var fillColor = ImGui.ColorConvertFloat4ToU32(new Vector4(color.X, color.Y, color.Z, 0.22f));
+        var borderColor = ImGui.ColorConvertFloat4ToU32(color * 0.7f);
+        drawList.AddRectFilled(min, max, fillColor, 4f);
+        drawList.AddRect(min, max, borderColor, 4f, ImDrawFlags.None, 1f);
+
+        var letterText = letter.ToString();
+        var letterColor = ImGui.ColorConvertFloat4ToU32(color);
+        var serif = CinzelFontSystem.GetBold(DropCapFontSize);
+        if (serif.HasValue)
+        {
+            var font = serif.Value;
+            ImGui.PushFont(font);
+            var glyphSize = ImGui.CalcTextSize(letterText);
+            ImGui.PopFont();
+            var glyphX = x + (DropCapSize - glyphSize.X) / 2f;
+            var glyphY = y + (DropCapSize - glyphSize.Y) / 2f;
+            drawList.AddText(font, font.FontSize, new Vector2(glyphX, glyphY), letterColor, letterText);
+        }
+        else
+        {
+            var defaultFont = ImGui.GetFont();
+            var renderScale = DropCapFontSize / ImGui.GetFontSize();
+            var glyphSize = ImGui.CalcTextSize(letterText) * renderScale;
+            var glyphX = x + (DropCapSize - glyphSize.X) / 2f;
+            var glyphY = y + (DropCapSize - glyphSize.Y) / 2f;
+            drawList.AddText(defaultFont, DropCapFontSize, new Vector2(glyphX, glyphY), letterColor, letterText);
+        }
     }
 
     /// <summary>

--- a/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
@@ -47,8 +47,7 @@ internal static class PaneHeaderRenderer
         // cap. Hidden if the title is empty or starts with whitespace.
         var displayTitle = title;
         var dropCapPresent = dropCapColor.HasValue
-                             && !string.IsNullOrWhiteSpace(title)
-                             && !hasIcon;
+                             && !string.IsNullOrWhiteSpace(title);
         if (dropCapPresent)
         {
             var letter = char.ToUpperInvariant(title[0]);

--- a/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
@@ -21,8 +21,10 @@ internal static class PaneHeaderRenderer
 {
     public const float IconSize = 32f;
     public const float RowHeight = 36f; // Math.Max(IconSize + 4f, 32f)
+    public const float DropCapRowHeight = 44f; // Math.Max(ChromeRenderer.DropCapSize + 4f, RowHeight)
     public const float DividerBelowSpacing = 20f;
     public const float TotalHeight = RowHeight + DividerBelowSpacing;
+    private const float DropCapGap = 12f;
 
     public static float Draw(
         ImDrawListPtr drawList,
@@ -33,10 +35,27 @@ internal static class PaneHeaderRenderer
         Vector4? rankColor = null,
         string? rightTitle = null,
         Action<ImDrawListPtr, Vector2, Vector2>? iconPainter = null,
-        Vector4? titleColor = null)
+        Vector4? titleColor = null,
+        Vector4? dropCapColor = null)
     {
         var hasIcon = iconTextureId != IntPtr.Zero || iconPainter != null;
         var titleX = hasIcon ? x + IconSize + 12f : x;
+
+        // Drop cap takes the lead position on the left when requested. Caller
+        // supplies the domain/deity color; we strip the first character from
+        // the rendered title and shift the rest right so it flows from the
+        // cap. Hidden if the title is empty or starts with whitespace.
+        var displayTitle = title;
+        var dropCapPresent = dropCapColor.HasValue
+                             && !string.IsNullOrWhiteSpace(title)
+                             && !hasIcon;
+        if (dropCapPresent)
+        {
+            var letter = char.ToUpperInvariant(title[0]);
+            ChromeRenderer.DrawDropCap(drawList, letter, titleX, y, dropCapColor!.Value);
+            titleX += ChromeRenderer.DropCapSize + DropCapGap;
+            displayTitle = title.Substring(1);
+        }
 
         if (hasIcon)
         {
@@ -55,31 +74,34 @@ internal static class PaneHeaderRenderer
             drawList.AddRect(iconMin, iconMax, borderColor, 4f, ImDrawFlags.None, 1f);
         }
 
-        TextRenderer.DrawLabel(drawList, title, titleX, y + 4f, FontSizes.PageTitle, titleColor ?? ColorPalette.White);
+        // Chapter title uses Cinzel Regular at the nearest baked size; rank
+        // tag stays in the default font (small annotation). The serif helper
+        // returns the actual rendered width so the rank tag lands flush with
+        // the title's right edge regardless of Cinzel vs default metrics.
+        // When a drop cap leads the row, the title baseline shifts down so
+        // small caps sit on the cap's optical midline.
+        var titleBaselineY = dropCapPresent ? y + 12f : y + 4f;
+        var titleWidth = TextRenderer.DrawSerifLabel(drawList, displayTitle, titleX, titleBaselineY,
+            FontSizes.PageTitle, titleColor ?? ColorPalette.White);
 
         if (!string.IsNullOrEmpty(rankTag))
         {
-            // CalcTextSize reports at the loaded font's base size (SubsectionLabel-equivalent);
-            // scale to match what we actually rendered the title at.
-            var nameWidthScaled = ImGui.CalcTextSize(title).X * (FontSizes.PageTitle / FontSizes.SubsectionLabel);
             var rankText = $"[{rankTag}]";
             drawList.AddText(ImGui.GetFont(), FontSizes.SubsectionLabel,
-                new Vector2(titleX + nameWidthScaled + 8f, y + 6f),
+                new Vector2(titleX + titleWidth + 8f, y + 6f),
                 ImGui.ColorConvertFloat4ToU32(rankColor ?? ColorPalette.Gold), rankText);
         }
 
         if (!string.IsNullOrEmpty(rightTitle))
         {
             // Right-aligned entity name at the same baseline as the title.
-            var rightScale = FontSizes.PageTitle / FontSizes.SubsectionLabel;
-            var rightWidth = ImGui.CalcTextSize(rightTitle).X * rightScale;
+            var rightWidth = TextRenderer.MeasureSerifLabel(rightTitle, FontSizes.PageTitle);
             var rightX = x + width - rightWidth;
-            drawList.AddText(ImGui.GetFont(), FontSizes.PageTitle,
-                new Vector2(rightX, y + 4f),
-                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), rightTitle);
+            TextRenderer.DrawSerifLabel(drawList, rightTitle, rightX, y + 4f,
+                FontSizes.PageTitle, ColorPalette.Gold);
         }
 
-        var dividerY = y + RowHeight;
+        var dividerY = y + (dropCapPresent ? DropCapRowHeight : RowHeight);
         ChromeRenderer.DrawDivider(drawList, x, dividerY, width);
         return dividerY + DividerBelowSpacing;
     }

--- a/DivineAscension/GUI/UI/Utilities/ChromeContext.cs
+++ b/DivineAscension/GUI/UI/Utilities/ChromeContext.cs
@@ -1,0 +1,29 @@
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.GUI.UI.Utilities;
+
+/// <summary>
+///     Per-frame chrome state that pure renderers can read without holding a
+///     reference to the dialog manager. Populated by
+///     <see cref="DivineAscension.GUI.UI.Layout.MainLayoutCoordinator" /> at the
+///     start of every Draw, before any pane renderer runs.
+///
+///     Currently carries only the player's patron domain (used by
+///     <c>ChapterStripRenderer</c> to tint chapter drop caps in the player's
+///     ink when the pane has no domain of its own). Add fields here when other
+///     renderers need ambient player/world context without touching the
+///     manager wiring.
+/// </summary>
+internal static class ChromeContext
+{
+    /// <summary>
+    ///     Player's patron deity domain for this frame. Null when the player
+    ///     has no religion or their religion has no parsable domain.
+    /// </summary>
+    public static DeityDomain? PlayerPatronDomain { get; private set; }
+
+    public static void SetFrame(DeityDomain? playerPatronDomain)
+    {
+        PlayerPatronDomain = playerPatronDomain;
+    }
+}

--- a/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
+++ b/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using DivineAscension.Services.UI;
 using ImGuiNET;
 
 namespace DivineAscension.GUI.UI.Utilities;
@@ -30,6 +32,73 @@ public static class TextRenderer
     {
         var textColor = ImGui.ColorConvertFloat4ToU32(color ?? ColorPalette.White);
         drawList.AddText(ImGui.GetFont(), fontSize, new Vector2(x, y), textColor, text);
+    }
+
+    /// <summary>
+    ///     Draw a chapter-style title in Cinzel Regular at the closest baked
+    ///     size (falls back to the default font when Cinzel isn't loaded yet).
+    ///     Returns the rendered text width so callers can chain rank tags or
+    ///     right-anchored siblings on the same baseline without Montserrat-vs-
+    ///     Cinzel width drift.
+    /// </summary>
+    public static float DrawSerifLabel(
+        ImDrawListPtr drawList,
+        string text,
+        float x,
+        float y,
+        float fontSize,
+        Vector4? color = null)
+    {
+        var textColor = ImGui.ColorConvertFloat4ToU32(color ?? ColorPalette.White);
+        var serif = CinzelFontSystem.GetRegular(NearestBakedSize((int)fontSize));
+        if (serif.HasValue)
+        {
+            var font = serif.Value;
+            ImGui.PushFont(font);
+            var width = ImGui.CalcTextSize(text).X;
+            ImGui.PopFont();
+            drawList.AddText(font, font.FontSize, new Vector2(x, y), textColor, text);
+            return width;
+        }
+
+        drawList.AddText(ImGui.GetFont(), fontSize, new Vector2(x, y), textColor, text);
+        return ImGui.CalcTextSize(text).X * (fontSize / ImGui.GetFontSize());
+    }
+
+    /// <summary>
+    ///     Measure a string in the same face <see cref="DrawSerifLabel" /> would
+    ///     render it in. Used by header renderers that need to anchor sibling
+    ///     elements against the right edge of the title before drawing it.
+    /// </summary>
+    public static float MeasureSerifLabel(string text, float fontSize)
+    {
+        var serif = CinzelFontSystem.GetRegular(NearestBakedSize((int)fontSize));
+        if (serif.HasValue)
+        {
+            ImGui.PushFont(serif.Value);
+            var width = ImGui.CalcTextSize(text).X;
+            ImGui.PopFont();
+            return width;
+        }
+        return ImGui.CalcTextSize(text).X * (fontSize / ImGui.GetFontSize());
+    }
+
+    private static int NearestBakedSize(int requested)
+    {
+        // VSImGui's default font sizes (FontManager.Sizes).
+        ReadOnlySpan<int> baked = stackalloc int[] { 6, 8, 10, 14, 18, 24, 30, 36, 48, 60 };
+        var best = baked[0];
+        var bestDelta = int.MaxValue;
+        foreach (var s in baked)
+        {
+            var delta = System.Math.Abs(s - requested);
+            if (delta < bestDelta)
+            {
+                best = s;
+                bestDelta = delta;
+            }
+        }
+        return best;
     }
 
     /// <summary>

--- a/DivineAscension/Services/UI/CinzelFontSystem.cs
+++ b/DivineAscension/Services/UI/CinzelFontSystem.cs
@@ -2,17 +2,29 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using HarmonyLib;
 using ImGuiNET;
 using JetBrains.Annotations;
 using Vintagestory.API.Common;
-using VSImGui.API;
 
 namespace DivineAscension.Services.UI;
 
-// VSImGui's FontManager fires BeforeFontsLoaded inside its ImGuiModSystem.StartPre
-// (Controller ctor -> LoadFonts -> FontManager.Load). To get our subscriber in
-// before that fires we need our own ModSystem with a lower ExecuteOrder and the
-// subscription wired from StartPre, not Start.
+// VSImGui 1.2.5's FontManager static cctor calls ImGui.GetIO(), which requires
+// cimgui's native library to be loadable. cimgui is only made loadable by
+// VSImGui's own StartPre via NativesLoader.Load, which runs inside its
+// ImGuiModSystem.StartPre right before it constructs Controller (which then
+// triggers FontManager.Load, firing BeforeFontsLoaded).
+//
+// That means any reference to FontManager before VSImGui's StartPre poisons
+// the type with a TypeInitializationException. We can't subscribe to
+// BeforeFontsLoaded directly from a lower ExecuteOrder.
+//
+// Instead, we Harmony-prefix FontManager.Load. The patch is registered
+// from our StartPre (ExecuteOrder = -1) using string-based reflection that
+// never touches the FontManager type, so VSImGui's StartPre runs cleanly.
+// When VSImGui later invokes FontManager.Load, our prefix executes between
+// the cctor (succeeds because natives are loaded) and the body, adding our
+// Cinzel paths to the static Fonts set before the atlas is built.
 [UsedImplicitly]
 public class CinzelFontSystem : ModSystem
 {
@@ -21,8 +33,13 @@ public class CinzelFontSystem : ModSystem
 
     private const string RegularResource = "DivineAscension.Fonts.cinzel-regular.ttf";
     private const string BoldResource = "DivineAscension.Fonts.cinzel-bold.ttf";
+    private const string HarmonyId = "com.divineascension.cinzel-fonts";
 
+    private static string? _regularPath;
+    private static string? _boldPath;
     private static Dictionary<(string, int), ImFontPtr>? _loadedCache;
+
+    private Harmony? _harmony;
 
     public override double ExecuteOrder() => -1.0;
 
@@ -43,14 +60,63 @@ public class CinzelFontSystem : ModSystem
             return;
         }
 
-        var regularPath = Extract(api, RegularResource, cacheDir, $"{RegularName}.ttf");
-        var boldPath = Extract(api, BoldResource, cacheDir, $"{BoldName}.ttf");
+        _regularPath = Extract(api, RegularResource, cacheDir, $"{RegularName}.ttf");
+        _boldPath = Extract(api, BoldResource, cacheDir, $"{BoldName}.ttf");
+        if (_regularPath == null && _boldPath == null) return;
 
-        FontManager.BeforeFontsLoaded += (fonts, _) =>
+        // String-based reflection: must not trigger VSImGui.API.FontManager's
+        // static initializer here. AccessTools.Method only reads metadata.
+        var target = AccessTools.Method("VSImGui.API.FontManager:Load");
+        if (target == null)
         {
-            if (regularPath != null) fonts.Add(regularPath);
-            if (boldPath != null) fonts.Add(boldPath);
-        };
+            api.Logger.Warning("[DivineAscension] VSImGui.API.FontManager.Load not found; Cinzel not registered.");
+            return;
+        }
+
+        var prefix = AccessTools.Method(typeof(CinzelFontSystem), nameof(AddCinzelFontsPrefix));
+        try
+        {
+            _harmony = new Harmony(HarmonyId);
+            _harmony.Patch(target, prefix: new HarmonyMethod(prefix));
+        }
+        catch (Exception ex)
+        {
+            api.Logger.Error($"[DivineAscension] Cinzel Harmony patch failed: {ex.Message}");
+        }
+    }
+
+    public override void Dispose()
+    {
+        try
+        {
+            _harmony?.UnpatchAll(HarmonyId);
+        }
+        catch
+        {
+            // ignored — VSImGui may have already torn down
+        }
+        _harmony = null;
+    }
+
+    // Runs as a Harmony prefix on VSImGui.API.FontManager.Load. By the time
+    // VSImGui invokes Load, NativesLoader has registered cimgui, so touching
+    // FontManager here is safe — its static cctor will succeed.
+    [HarmonyPriority(Priority.First)]
+    private static void AddCinzelFontsPrefix()
+    {
+        try
+        {
+            var fontsProp = AccessTools.Property("VSImGui.API.FontManager:Fonts");
+            if (fontsProp?.GetValue(null) is HashSet<string> fonts)
+            {
+                if (_regularPath != null) fonts.Add(_regularPath);
+                if (_boldPath != null) fonts.Add(_boldPath);
+            }
+        }
+        catch
+        {
+            // ignored — leave the atlas with just VSImGui's defaults
+        }
     }
 
     // VSImGui generates fonts at sizes registered in FontManager.Sizes
@@ -66,14 +132,17 @@ public class CinzelFontSystem : ModSystem
         return dict != null && dict.TryGetValue((fontName, size), out var ptr) ? ptr : null;
     }
 
-    // FontManager.Loaded is internal in VSImGui 0.0.6; reach it once via
-    // reflection. Falls through gracefully if a later version makes it public
-    // or renames it — callers just get null and use the default font.
     private static Dictionary<(string, int), ImFontPtr>? ResolveLoadedDictionary()
     {
-        var prop = typeof(FontManager).GetProperty("Loaded",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-        return prop?.GetValue(null) as Dictionary<(string, int), ImFontPtr>;
+        try
+        {
+            var prop = AccessTools.Property("VSImGui.API.FontManager:Loaded");
+            return prop?.GetValue(null) as Dictionary<(string, int), ImFontPtr>;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static string? Extract(ICoreAPI api, string resourceName, string cacheDir, string outFileName)

--- a/DivineAscension/Services/UI/CinzelFontSystem.cs
+++ b/DivineAscension/Services/UI/CinzelFontSystem.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using ImGuiNET;
+using JetBrains.Annotations;
+using Vintagestory.API.Common;
+using VSImGui.API;
+
+namespace DivineAscension.Services.UI;
+
+// VSImGui's FontManager fires BeforeFontsLoaded inside its ImGuiModSystem.StartPre
+// (Controller ctor -> LoadFonts -> FontManager.Load). To get our subscriber in
+// before that fires we need our own ModSystem with a lower ExecuteOrder and the
+// subscription wired from StartPre, not Start.
+[UsedImplicitly]
+public class CinzelFontSystem : ModSystem
+{
+    public const string RegularName = "cinzel-regular";
+    public const string BoldName = "cinzel-bold";
+
+    private const string RegularResource = "DivineAscension.Fonts.cinzel-regular.ttf";
+    private const string BoldResource = "DivineAscension.Fonts.cinzel-bold.ttf";
+
+    private static Dictionary<(string, int), ImFontPtr>? _loadedCache;
+
+    public override double ExecuteOrder() => -1.0;
+
+    public override bool ShouldLoad(EnumAppSide forSide) => forSide == EnumAppSide.Client;
+
+    public override void StartPre(ICoreAPI api)
+    {
+        if (api.Side != EnumAppSide.Client) return;
+
+        string cacheDir;
+        try
+        {
+            cacheDir = api.GetOrCreateDataPath(Path.Combine("ModData", "divineascension", "fonts"));
+        }
+        catch (Exception ex)
+        {
+            api.Logger.Error($"[DivineAscension] Cinzel cache dir create failed: {ex.Message}");
+            return;
+        }
+
+        var regularPath = Extract(api, RegularResource, cacheDir, $"{RegularName}.ttf");
+        var boldPath = Extract(api, BoldResource, cacheDir, $"{BoldName}.ttf");
+
+        FontManager.BeforeFontsLoaded += (fonts, _) =>
+        {
+            if (regularPath != null) fonts.Add(regularPath);
+            if (boldPath != null) fonts.Add(boldPath);
+        };
+    }
+
+    // VSImGui generates fonts at sizes registered in FontManager.Sizes
+    // (defaults: 6, 8, 10, 14, 18, 24, 30, 36, 48, 60). Lookup returns null
+    // until the atlas is built so callers can fall back to the default font.
+    public static ImFontPtr? GetRegular(int size) => Lookup(RegularName, size);
+
+    public static ImFontPtr? GetBold(int size) => Lookup(BoldName, size);
+
+    private static ImFontPtr? Lookup(string fontName, int size)
+    {
+        var dict = _loadedCache ??= ResolveLoadedDictionary();
+        return dict != null && dict.TryGetValue((fontName, size), out var ptr) ? ptr : null;
+    }
+
+    // FontManager.Loaded is internal in VSImGui 0.0.6; reach it once via
+    // reflection. Falls through gracefully if a later version makes it public
+    // or renames it — callers just get null and use the default font.
+    private static Dictionary<(string, int), ImFontPtr>? ResolveLoadedDictionary()
+    {
+        var prop = typeof(FontManager).GetProperty("Loaded",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        return prop?.GetValue(null) as Dictionary<(string, int), ImFontPtr>;
+    }
+
+    private static string? Extract(ICoreAPI api, string resourceName, string cacheDir, string outFileName)
+    {
+        try
+        {
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
+            if (stream == null)
+            {
+                api.Logger.Error($"[DivineAscension] Cinzel embedded resource missing: {resourceName}");
+                return null;
+            }
+
+            var outPath = Path.Combine(cacheDir, outFileName);
+            using (var fs = File.Create(outPath))
+            {
+                stream.CopyTo(fs);
+            }
+            return outPath;
+        }
+        catch (Exception ex)
+        {
+            api.Logger.Error($"[DivineAscension] Cinzel extract '{resourceName}' failed: {ex.Message}");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #285, #287, #288.

## Summary
- **#285 — embed Cinzel.** New client-only `CinzelFontSystem` ModSystem (`ExecuteOrder = -1`). Cinzel Regular + Bold ship as managed embedded resources, extract once to `GetOrCreateDataPath("ModData/divineascension/fonts")` on `StartPre`, and register with VSImGui's atlas via a Harmony prefix on `VSImGui.API.FontManager.Load`.
- **#287 — apply the face.**
  - `TitleStripRenderer` draws "Divine Ascension" in Cinzel Bold @ 24px (fits the 32px chrome strip).
  - `SidebarRenderer.DrawGroupHeader` draws chapter labels in Cinzel Regular @ 18px. Verse rows stay default.
  - `TextRenderer` gains `DrawSerifLabel` / `MeasureSerifLabel` — pick the closest baked Cinzel size, fall back to default when not loaded, return measured widths so siblings anchor against real metrics.
  - `PaneHeaderRenderer` main title + right-aligned entity name use the helper. Rank tag stays default.
  - `ChapterStripRenderer` right-anchored title uses the helper.
- **#288 — illuminated drop caps.**
  - `ChromeRenderer.DrawDropCap(drawList, letter, x, y, color)` paints a 40×40 rounded ornament with a dimmed colour fill, sets the letter in Cinzel Bold @ 36px centred inside.
  - `PaneHeaderRenderer` gains an optional `dropCapColor`. When set, the first character of the title is consumed by the cap; the rest flows right of it; row height grows to 44px.
  - `ChapterStripRenderer` derives the cap colour automatically when the pane has a right-side `DeityDomain` glyph and no left-side icon (entity chapters), using `DomainHelper.GetDeityColor`. Identity panes (icon present) stay drop-cap-free so the icon remains the anchor. Callers can still override.

## Why the Harmony-prefix path
Previously closed as blocked. Earlier attempts:

1. Subscribe to `FontManager.BeforeFontsLoaded` from our `Start(api)` — VSImGui already fired the event during its own `StartPre`, so the subscription was always too late.
2. `AddFontFromFileTTF` from `AssetsLoaded` — atlas already baked + `ClearTexData`'d, glyph pointer non-null but crashes on first `PushFont`.
3. Subscribe to `BeforeFontsLoaded` from `StartPre` with `ExecuteOrder = -1` — VSImGui 1.2.5's `FontManager` static cctor initializes its `GlyphRanges` dictionary by calling `ImGui.GetIO()`. `cimgui` is only loadable after `NativesLoader.Load` runs inside VSImGui's `StartPre`. Touching `FontManager` first poisons the type with a cached `TypeInitializationException`, killing VSImGui mod load outright.

This PR's path:
- `StartPre` at `ExecuteOrder = -1` extracts the TTFs and Harmony-patches `FontManager.Load` via `AccessTools` string lookup — **never references the `FontManager` type**, so its cctor stays unfired.
- VSImGui's `StartPre` runs: `NativesLoader.Load` registers cimgui, then constructs `Controller` → `LoadFonts` → `FontManager.Load`.
- That call finally fires the `FontManager` cctor; `ImGui.GetIO()` succeeds because cimgui is loaded.
- Our Harmony prefix runs, reaches `FontManager.Fonts` via `AccessTools`, and adds the Cinzel paths to the static set before the atlas is built.

## Test plan
- [x] `dotnet build` clean.
- [x] `dotnet test` — 2173 passing.
- [x] Launch VS. No `[vsimgui]` exception on startup; vanilla UI text renders.
- [x] Open dialog (Shift+G). "DIVINE ASCENSION" in the title ribbon renders in serif Roman caps.
- [x] Sidebar chapter headers render in Cinzel; verse rows stay default.
- [x] Chapter pane titles (the "III.i. You" / "II.iii. Letters" strips) render in Cinzel.
- [x] Entity chapter panes (religion / civilization / holy-site detail — anything with a domain glyph and no left icon) show an illuminated drop cap in the domain colour.
- [x] Identity panes (icon present) do not get a drop cap.
- [x] Extracted TTFs land at `~/.config/VintagestoryData/ModData/divineascension/fonts/cinzel-{regular,bold}.ttf`.
- [x] No crash on early frames before the atlas is built (default-font fallback works).