### PR TITLE
style(ui): rank-up popup to vestments-modal language

### DIFF
--- a/DivineAscension/GUI/UI/Components/Overlays/RankUpNotificationOverlay.cs
+++ b/DivineAscension/GUI/UI/Components/Overlays/RankUpNotificationOverlay.cs
@@ -4,24 +4,27 @@ using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.UI.Components.Buttons;
+using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
 using ImGuiNET;
+using static DivineAscension.GUI.UI.Utilities.FontSizes;
 
 namespace DivineAscension.GUI.UI.Components.Overlays;
 
+/// <summary>
+/// Rank-up popup styled as a parchment mini-page (vestments-modal language):
+/// faded-ink border, gold serif title, ornamental divider, ink body text,
+/// primary footer button. Mirrors <c>ReligionRolesBrowseRenderer.DrawRoleEditor</c>.
+/// </summary>
 [ExcludeFromCodeCoverage]
 internal static class RankUpNotificationOverlay
 {
     private const float PanelWidth = 500f;
-    private const float IconSize = 64f;
-    private const float Padding = 20f;
-    private const float Spacing = 15f;
-    private const float ButtonWidth = 200f;
-    private const float ButtonHeight = 40f;
-    private const float TitleFontSize = 20f;
-    private const float RankNameFontSize = 18f;
-    private const float DescriptionFontSize = 13f;
+    private const float IconSize = 56f;
+    private const float Padding = 18f;
+    private const float ButtonWidth = 220f;
+    private const float ButtonHeight = 32f;
 
     internal static void Draw(NotificationState state, out bool dismissed, out bool viewBlessingsClicked,
         float windowWidth, float windowHeight)
@@ -33,108 +36,84 @@ internal static class RankUpNotificationOverlay
 
         var drawList = ImGui.GetWindowDrawList();
         var winPos = ImGui.GetWindowPos();
+        var winSize = ImGui.GetWindowSize();
 
-        // Calculate wrapped description height
-        var descriptionWidth = PanelWidth - (Padding * 2);
-        var descriptionHeight = TextRenderer.MeasureWrappedHeight(
-            state.RankDescription,
-            descriptionWidth,
-            DescriptionFontSize);
+        // Warm-dark page dim, matches vestments modal §4.
+        drawList.AddRectFilled(winPos, new Vector2(winPos.X + winSize.X, winPos.Y + winSize.Y),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BlackOverlay));
 
-        // Calculate panel height based on content
-        var panelHeight = Padding + // Top padding
-                          IconSize + // Deity icon
-                          Spacing + // Space after icon
-                          TitleFontSize + 6f + // Title with spacing
-                          Spacing + // Space after title
-                          RankNameFontSize + 6f + // Rank name with spacing
-                          Spacing + // Space after rank name
-                          descriptionHeight + // Description (wrapped)
-                          Spacing + // Space after description
-                          ButtonHeight + // Button
-                          Padding; // Bottom padding
+        var bodyWidth = PanelWidth - Padding * 2;
 
-        // Position panel at top-center of screen
+        var descriptionHeight = TextRenderer.MeasureWrappedHeight(state.RankDescription, bodyWidth, Body);
+
+        var panelHeight =
+            Padding +
+            IconSize + 12f +
+            PageTitle + 6f +
+            14f +
+            16f +
+            SubsectionLabel + 10f +
+            descriptionHeight + 18f +
+            ButtonHeight +
+            Padding;
+
         var panelX = winPos.X + (windowWidth - PanelWidth) / 2f;
-        var panelY = winPos.Y + 50f; // 50px from top
-
-        // Draw panel with rounded corners
+        var panelY = winPos.Y + 50f;
         var panelMin = new Vector2(panelX, panelY);
         var panelMax = new Vector2(panelX + PanelWidth, panelY + panelHeight);
-        var panelColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Background);
-        drawList.AddRectFilled(panelMin, panelMax, panelColor, 8f);
 
-        // Draw panel border
-        var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        drawList.AddRect(panelMin, panelMax, borderColor, 8f, ImDrawFlags.None, 2f);
+        // Parchment surface + faded-ink edge (matches vestments modal).
+        drawList.AddRectFilled(panelMin, panelMax,
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), 6f);
+        drawList.AddRect(panelMin, panelMax,
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 6f, ImDrawFlags.None, 1.5f);
 
-        // Track current Y position for layout
         var currentY = panelY + Padding;
 
-        // Draw deity icon (centered horizontally)
         var iconX = panelX + (PanelWidth - IconSize) / 2f;
         var textureId = DeityIconLoader.GetDeityTextureId(state.DeityDomain);
         if (textureId != IntPtr.Zero)
         {
-            var iconMin = new Vector2(iconX, currentY);
-            var iconMax = new Vector2(iconX + IconSize, currentY + IconSize);
-            drawList.AddImage(textureId, iconMin, iconMax, Vector2.Zero, Vector2.One);
+            drawList.AddImage(textureId,
+                new Vector2(iconX, currentY),
+                new Vector2(iconX + IconSize, currentY + IconSize),
+                Vector2.Zero, Vector2.One);
         }
+        currentY += IconSize + 12f;
 
-        currentY += IconSize + Spacing;
-
-        // Draw "Rank Up!" title (centered, white, 20pt)
+        // Title — gold at PageTitle, centered. Scale CalcTextSize from default to PageTitle.
         var titleText = LocalizationService.Instance.Get(LocalizationKeys.UI_RANKUP_TITLE);
-        var titleSize = ImGui.CalcTextSize(titleText);
-        var titleX = panelX + (PanelWidth - titleSize.X) / 2f;
-        TextRenderer.DrawLabel(drawList, titleText, titleX, currentY, TitleFontSize, ColorPalette.White);
-        currentY += TitleFontSize + 6f + Spacing;
+        var titleWidth = ImGui.CalcTextSize(titleText).X * (PageTitle / ImGui.GetFontSize());
+        TextRenderer.DrawLabel(drawList, titleText,
+            panelX + (PanelWidth - titleWidth) / 2f, currentY, PageTitle, ColorPalette.Gold);
+        currentY += PageTitle + 6f;
 
-        // Draw rank name (centered, gold, 18pt)
-        var rankNameSize = ImGui.CalcTextSize(state.RankName);
-        var rankNameX = panelX + (PanelWidth - rankNameSize.X) / 2f;
-        TextRenderer.DrawLabel(drawList, state.RankName, rankNameX, currentY, RankNameFontSize, ColorPalette.Gold);
-        currentY += RankNameFontSize + 6f + Spacing;
+        ChromeRenderer.DrawDivider(drawList, panelX + Padding, currentY, bodyWidth);
+        currentY += 16f;
 
-        // Draw description (word-wrapped, grey, 13pt)
-        var descriptionX = panelX + Padding;
-        TextRenderer.DrawInfoText(
-            drawList,
-            state.RankDescription,
-            descriptionX,
-            currentY,
-            descriptionWidth,
-            DescriptionFontSize);
-        currentY += descriptionHeight + Spacing;
+        var rankNameWidth = ImGui.CalcTextSize(state.RankName).X * (SubsectionLabel / ImGui.GetFontSize());
+        TextRenderer.DrawLabel(drawList, state.RankName,
+            panelX + (PanelWidth - rankNameWidth) / 2f, currentY, SubsectionLabel, ColorPalette.Gold);
+        currentY += SubsectionLabel + 10f;
 
-        // Draw "View Blessings" button (centered)
+        TextRenderer.DrawInfoText(drawList, state.RankDescription,
+            panelX + Padding, currentY, bodyWidth, Body, ColorPalette.White);
+        currentY += descriptionHeight + 18f;
+
         var buttonX = panelX + (PanelWidth - ButtonWidth) / 2f;
-        var buttonClicked = ButtonRenderer.DrawButton(
-            drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_RANKUP_VIEW_BLESSINGS),
-            buttonX,
-            currentY,
-            ButtonWidth,
-            ButtonHeight,
-            isPrimary: true);
-
-        if (buttonClicked)
+        if (ButtonRenderer.DrawButton(drawList,
+                LocalizationService.Instance.Get(LocalizationKeys.UI_RANKUP_VIEW_BLESSINGS),
+                buttonX, currentY, ButtonWidth, ButtonHeight, isPrimary: true))
         {
             viewBlessingsClicked = true;
             dismissed = true;
         }
 
-        // Check for ESC key press to dismiss
-        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
-        {
-            dismissed = true;
-        }
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape)) dismissed = true;
 
-        // Handle mouse clicks for dismissal
         if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             var mousePos = ImGui.GetMousePos();
-            // Only dismiss if click is outside the notification panel
             if (mousePos.X < panelX || mousePos.X > panelX + PanelWidth ||
                 mousePos.Y < panelY || mousePos.Y > panelY + panelHeight)
             {


### PR DESCRIPTION
## Summary
- Restyle `RankUpNotificationOverlay` to match the vestments edit modal (`ReligionRolesBrowseRenderer.DrawRoleEditor`): warm-dark page dim, parchment surface with faded-ink `BorderColor` edge (1.5f), 6f corner radius.
- Gold `PageTitle` title + `ChromeRenderer.DrawDivider` ornament, gold `SubsectionLabel` rank name, `Body` ink description on parchment, primary footer button.
- Text widths scaled from default font to target size for accurate centering.

## Test plan
- [x] Trigger a rank-up in-game; popup renders as parchment mini-page with ornamental divider
- [x] Long descriptions wrap correctly inside body padding
- [x] ESC and outside-click still dismiss
- [x] `View Blessings` button opens dialog