### PR TITLE
feat(civ): rename milestones to chronicle voice + chronicleLine (#368)

### DIFF
--- a/DivineAscension/Models/MilestoneDefinition.cs
+++ b/DivineAscension/Models/MilestoneDefinition.cs
@@ -50,6 +50,13 @@ public class MilestoneDefinition
     /// </summary>
     public MilestoneTemporaryBenefit? TemporaryBenefit { get; }
 
+    /// <summary>
+    ///     In-world chronicle-voice line emitted when this milestone fires. Consumed by
+    ///     the civilization chronicle (see issue #369). Empty for legacy milestones that
+    ///     have not yet been rewritten.
+    /// </summary>
+    public string ChronicleLine { get; }
+
     public MilestoneDefinition(
         string milestoneId,
         string name,
@@ -59,7 +66,8 @@ public class MilestoneDefinition
         int rankReward,
         int prestigePayout,
         MilestoneBenefit? permanentBenefit = null,
-        MilestoneTemporaryBenefit? temporaryBenefit = null)
+        MilestoneTemporaryBenefit? temporaryBenefit = null,
+        string chronicleLine = "")
     {
         MilestoneId = milestoneId;
         Name = name;
@@ -70,6 +78,7 @@ public class MilestoneDefinition
         PrestigePayout = prestigePayout;
         PermanentBenefit = permanentBenefit;
         TemporaryBenefit = temporaryBenefit;
+        ChronicleLine = chronicleLine ?? string.Empty;
     }
 }
 

--- a/DivineAscension/Models/MilestoneJsonDto.cs
+++ b/DivineAscension/Models/MilestoneJsonDto.cs
@@ -67,6 +67,12 @@ public class MilestoneJsonDto
     ///     Temporary benefit configuration (optional)
     /// </summary>
     public MilestoneTemporaryBenefitDto? TemporaryBenefit { get; set; }
+
+    /// <summary>
+    ///     In-world chronicle-voice line emitted when this milestone fires. Optional;
+    ///     empty if the milestone has not yet been rewritten in chronicle voice.
+    /// </summary>
+    public string ChronicleLine { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/DivineAscension/Services/MilestoneDefinitionLoader.cs
+++ b/DivineAscension/Services/MilestoneDefinitionLoader.cs
@@ -163,7 +163,8 @@ public class MilestoneDefinitionLoader : IMilestoneDefinitionLoader
             dto.RankReward,
             dto.PrestigePayout,
             permanentBenefit,
-            temporaryBenefit
+            temporaryBenefit,
+            dto.ChronicleLine ?? string.Empty
         );
     }
 

--- a/DivineAscension/assets/divineascension/config/milestones.json
+++ b/DivineAscension/assets/divineascension/config/milestones.json
@@ -3,8 +3,9 @@
   "milestones": [
     {
       "id": "first_alliance",
-      "name": "First Alliance",
+      "name": "The Hands Were Joined",
       "description": "Form an alliance by adding a second religion to your civilization.",
+      "chronicleLine": "In its early days, the civilization opened its gates to a second faith.",
       "type": "major",
       "trigger": {
         "type": "religion_count",
@@ -19,8 +20,9 @@
     },
     {
       "id": "holy_expansion",
-      "name": "Holy Expansion",
+      "name": "Stones Made Sacred",
       "description": "Create two holy sites across your civilization's religions.",
+      "chronicleLine": "Two holy sites now bore the civilization's mark across the land.",
       "type": "major",
       "trigger": {
         "type": "holy_site_count",
@@ -35,8 +37,9 @@
     },
     {
       "id": "ritual_mastery",
-      "name": "Ritual Mastery",
+      "name": "The Smoke Rose Five Times",
       "description": "Complete five rituals across your civilization's holy sites.",
+      "chronicleLine": "Five rites had been completed at the civilization's altars.",
       "type": "major",
       "trigger": {
         "type": "ritual_count",
@@ -52,8 +55,9 @@
     },
     {
       "id": "united_front",
-      "name": "United Front",
-      "description": "Unite all four deity domains under your civilization's banner.",
+      "name": "All Four Winds Bowed",
+      "description": "Unite four deity domains under your civilization's banner.",
+      "chronicleLine": "Four of the great domains stood together beneath one banner.",
       "type": "major",
       "trigger": {
         "type": "domain_count",
@@ -68,8 +72,9 @@
     },
     {
       "id": "population_milestone",
-      "name": "Population Surge",
+      "name": "A People, Not a Few",
       "description": "Reach 25 members across all religions in your civilization.",
+      "chronicleLine": "Five and twenty souls now answered to the civilization's name.",
       "type": "major",
       "trigger": {
         "type": "member_count",
@@ -84,8 +89,9 @@
     },
     {
       "id": "tier_triumph",
-      "name": "Tier Triumph",
+      "name": "The First Temple Rose",
       "description": "Upgrade any holy site to Tier 2 (Temple).",
+      "chronicleLine": "A holy site had been raised to the rank of temple.",
       "type": "minor",
       "trigger": {
         "type": "holy_site_tier",
@@ -96,8 +102,9 @@
     },
     {
       "id": "diplomatic_victory",
-      "name": "Diplomatic Victory",
+      "name": "Quills Met at the Border",
       "description": "Form a Non-Aggression Pact or Alliance with another civilization.",
+      "chronicleLine": "A pact was sealed with a neighbouring civilization.",
       "type": "minor",
       "trigger": {
         "type": "diplomatic_relationship",
@@ -108,8 +115,9 @@
     },
     {
       "id": "war_heroes",
-      "name": "War Heroes",
+      "name": "Fifty Spears, Fifty Names",
       "description": "Achieve 50 PvP kills during active wars.",
+      "chronicleLine": "Fifty had fallen to the civilization's warriors in open war.",
       "type": "minor",
       "trigger": {
         "type": "war_kill_count",
@@ -125,8 +133,9 @@
     },
     {
       "id": "cultural_monument",
-      "name": "Cultural Monument",
+      "name": "The Civilization Endures",
       "description": "Complete all five major milestones to achieve legendary status.",
+      "chronicleLine": "All five great deeds were done. The civilization passed into legend.",
       "type": "minor",
       "trigger": {
         "type": "all_major_milestones",


### PR DESCRIPTION
## Summary
- Renames all nine civilization milestones to in-world chronicle voice; IDs unchanged for save compatibility.
- Adds `chronicleLine` per milestone — the line logged when the milestone fires, consumed by the chronicle list (#369).
- `MilestoneDefinition` gains an optional `chronicleLine` ctor arg (default empty) so existing test fixtures continue to compile; loader pipes the new JSON field through.
- `united_front` chronicle copy is domain-agnostic (threshold is 4-of-5, Stone is also a domain).

Emission on award is intentionally out of scope and belongs to #369.

Closes #368.

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` — 2175/2175 pass
- [x] In-game: load an existing save with completed milestones; confirm IDs still resolve and renamed names display
- [x] In-game: trigger a new milestone; confirm rank/prestige/benefits still award (no behavior change expected)