### PR TITLE
feat(civ): Ethos enum + founder epithet + create-form picker (#367)

### DIFF
--- a/DivineAscension.Tests/Data/CivilizationDataTests.cs
+++ b/DivineAscension.Tests/Data/CivilizationDataTests.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using DivineAscension.Data;
+using DivineAscension.Models.Enum;
+using ProtoBuf;
 
 namespace DivineAscension.Tests.Data;
 
@@ -420,6 +423,57 @@ public class CivilizationDataTests
 
         // Assert
         Assert.True(result);
+    }
+
+    #endregion
+
+    #region Ethos & Founder Epithet (#367)
+
+    [Fact]
+    public void Civilization_NewInstance_DefaultsToSovereignEthosAndEmptyEpithet()
+    {
+        var civ = new Civilization("civ-1", "Test", "player-1", "religion-1");
+
+        Assert.Equal(CivilizationEthos.Sovereign, civ.Ethos);
+        Assert.Equal(string.Empty, civ.FounderEpithet);
+    }
+
+    [Fact]
+    public void Civilization_EthosAndEpithet_SurviveProtoRoundTrip()
+    {
+        var original = new Civilization("civ-1", "Test", "player-1", "religion-1")
+        {
+            Ethos = CivilizationEthos.Martial,
+            FounderEpithet = "the Iron-Handed"
+        };
+
+        byte[] bytes;
+        using (var ms = new MemoryStream())
+        {
+            Serializer.Serialize(ms, original);
+            bytes = ms.ToArray();
+        }
+
+        Civilization roundTripped;
+        using (var ms = new MemoryStream(bytes))
+        {
+            roundTripped = Serializer.Deserialize<Civilization>(ms);
+        }
+
+        Assert.Equal(CivilizationEthos.Martial, roundTripped.Ethos);
+        Assert.Equal("the Iron-Handed", roundTripped.FounderEpithet);
+    }
+
+    [Fact]
+    public void Civilization_LegacySerializedBytes_LoadAsSovereignAndEmptyEpithet()
+    {
+        // Civilization populated without the two new ProtoMembers (simulates pre-#367 saves).
+        // Round-tripping through Serializer.Merge against a default instance reproduces the
+        // legacy-load path: unknown/missing fields stay at their initialised defaults.
+        var civ = new Civilization();
+
+        Assert.Equal(CivilizationEthos.Sovereign, civ.Ethos);
+        Assert.Equal(string.Empty, civ.FounderEpithet);
     }
 
     #endregion

--- a/DivineAscension.Tests/Models/CivilizationEthosDeriverTests.cs
+++ b/DivineAscension.Tests/Models/CivilizationEthosDeriverTests.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Constants;
+using DivineAscension.Models;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.Tests.Models;
+
+[ExcludeFromCodeCoverage]
+public class CivilizationEthosDeriverTests
+{
+    [Theory]
+    [InlineData(DeityDomain.Craft, CivilizationEthos.Mercantile, LocalizationKeys.CIVILIZATION_EPITHET_CRAFT)]
+    [InlineData(DeityDomain.Conquest, CivilizationEthos.Martial, LocalizationKeys.CIVILIZATION_EPITHET_CONQUEST)]
+    [InlineData(DeityDomain.Wild, CivilizationEthos.Mystic, LocalizationKeys.CIVILIZATION_EPITHET_WILD)]
+    [InlineData(DeityDomain.Harvest, CivilizationEthos.Ascetic, LocalizationKeys.CIVILIZATION_EPITHET_HARVEST)]
+    [InlineData(DeityDomain.Stone, CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_STONE)]
+    [InlineData(DeityDomain.None, CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_DEFAULT)]
+    public void Derive_MapsDomainToEthosAndEpithetKey(
+        DeityDomain domain, CivilizationEthos expectedEthos, string expectedKey)
+    {
+        var (ethos, key) = CivilizationEthosDeriver.Derive(domain);
+
+        Assert.Equal(expectedEthos, ethos);
+        Assert.Equal(expectedKey, key);
+    }
+}

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -517,6 +517,9 @@ public static class LocalizationKeys
     public const string UI_CIVILIZATION_DETAIL_FOUNDING_ORDER =
         "divineascension:ui.civilization.detail.founding_order";
 
+    public const string UI_CIVILIZATION_DETAIL_ETHOS =
+        "divineascension:ui.civilization.detail.ethos";
+
     public const string UI_CIVILIZATION_DETAIL_MEMBER_ORDERS =
         "divineascension:ui.civilization.detail.member_orders";
 
@@ -548,6 +551,12 @@ public static class LocalizationKeys
         "divineascension:ui.civilization.name.error.profanity";
 
     public const string UI_CIVILIZATION_CREATE_ICON_LABEL = "divineascension:ui.civilization.create.icon.label";
+
+    public const string UI_CIVILIZATION_CREATE_ETHOS_LABEL =
+        "divineascension:ui.civilization.create.ethos.label";
+
+    public const string UI_CIVILIZATION_CREATE_ETHOS_HINT =
+        "divineascension:ui.civilization.create.ethos.hint";
 
     public const string UI_CIVILIZATION_CREATE_DESCRIPTION_LABEL =
         "divineascension:ui.civilization.create.description.label";
@@ -1880,6 +1889,28 @@ public static class LocalizationKeys
     public const string UI_PLAYER_INFO_ROW_REALM = "divineascension:ui.playerinfo.row.realm";
 
     public const string UI_PLAYER_INFO_UNSWORN_TITLE_WORD = "divineascension:ui.playerinfo.title.unsworn_word";
+
+    #endregion
+
+    #region Civilization Ethos & Epithet (#367)
+
+    // Ethos labels — five identity axes derived from founder religion's patron domain.
+    public const string CIVILIZATION_ETHOS_SOVEREIGN = "divineascension:civilization.ethos.sovereign";
+    public const string CIVILIZATION_ETHOS_MERCANTILE = "divineascension:civilization.ethos.mercantile";
+    public const string CIVILIZATION_ETHOS_MARTIAL = "divineascension:civilization.ethos.martial";
+    public const string CIVILIZATION_ETHOS_MYSTIC = "divineascension:civilization.ethos.mystic";
+    public const string CIVILIZATION_ETHOS_ASCETIC = "divineascension:civilization.ethos.ascetic";
+
+    // Founder epithets — resolved once at civ creation and stored on the civilization.
+    public const string CIVILIZATION_EPITHET_CRAFT = "divineascension:civilization.epithet.craft";
+    public const string CIVILIZATION_EPITHET_CONQUEST = "divineascension:civilization.epithet.conquest";
+    public const string CIVILIZATION_EPITHET_WILD = "divineascension:civilization.epithet.wild";
+    public const string CIVILIZATION_EPITHET_HARVEST = "divineascension:civilization.epithet.harvest";
+    public const string CIVILIZATION_EPITHET_STONE = "divineascension:civilization.epithet.stone";
+    public const string CIVILIZATION_EPITHET_DEFAULT = "divineascension:civilization.epithet.default";
+
+    // Header row labels for the civ info chapter.
+    public const string UI_CIVILIZATION_INFO_ETHOS = "divineascension:ui.civilization.info.ethos";
 
     #endregion
 }

--- a/DivineAscension/Data/CivilizationData.cs
+++ b/DivineAscension/Data/CivilizationData.cs
@@ -157,6 +157,23 @@ public class Civilization
     public HashSet<string> UnlockedBlessings { get; set; } = new();
 
     /// <summary>
+    ///     Narrative identity axis (Mercantile / Martial / Mystic / Ascetic / Sovereign).
+    ///     Derived once at founding from the founder religion's patron domain. Defaults
+    ///     to <see cref="CivilizationEthos.Sovereign" /> for legacy saves that pre-date
+    ///     this field.
+    /// </summary>
+    [ProtoMember(15)]
+    public CivilizationEthos Ethos { get; set; } = CivilizationEthos.Sovereign;
+
+    /// <summary>
+    ///     Founder epithet (e.g. "the Forge-Crowned"). Computed once at founding from
+    ///     the founder religion's patron domain and persisted; survives the founder
+    ///     later changing religion or leaving the civilization. Empty for legacy saves.
+    /// </summary>
+    [ProtoMember(16)]
+    public string FounderEpithet { get; set; } = string.Empty;
+
+    /// <summary>
     ///     Checks if the civilization has a valid number of member religions (1-4)
     /// </summary>
     public bool IsValid

--- a/DivineAscension/GUI/Events/Civilization/CreateEvent.cs
+++ b/DivineAscension/GUI/Events/Civilization/CreateEvent.cs
@@ -8,6 +8,8 @@ public abstract record CreateEvent
 
     public sealed record IconSelected(string icon) : CreateEvent;
 
+    public sealed record EthosSelected(DivineAscension.Models.Enum.CivilizationEthos ethos) : CreateEvent;
+
     public sealed record SubmitClicked : CreateEvent;
 
     public sealed record ClearClicked : CreateEvent;

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -21,6 +21,7 @@ using DivineAscension.GUI.UI.Adapters.Diplomacy;
 using DivineAscension.GUI.UI.Renderers.Civilization;
 using DivineAscension.GUI.UI.Renderers.HolySites;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models;
 using DivineAscension.Models.Enum;
 using DivineAscension.Network.Civilization;
 using DivineAscension.Services;
@@ -301,11 +302,11 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     ///     Request a civilization action (create, invite, accept, leave, kick, disband, updateicon, setdescription)
     /// </summary>
     public void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "")
+        string icon = "", string description = "", int ethos = -1)
     {
         // Clear transient action error; some actions will trigger refreshes
         State.LastActionError = null;
-        _uiService.RequestCivilizationAction(action, civId, targetId, name, icon, description);
+        _uiService.RequestCivilizationAction(action, civId, targetId, name, icon, description, ethos);
     }
 
     /// <summary>
@@ -592,6 +593,8 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
             details?.FounderName ?? string.Empty,
             details?.FounderReligionName ?? string.Empty,
             details?.Rank ?? 0,
+            details?.Ethos ?? 0,
+            details?.FounderEpithet ?? string.Empty,
             details?.MemberReligions ?? new List<CivilizationInfoResponsePacket.MemberReligion>(),
             details?.CreatedDate ?? DateTime.MinValue,
             details?.Description ?? string.Empty,
@@ -647,6 +650,8 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
             civ?.CreatedDate ?? DateTime.MinValue,
             UserIsCivilizationFounder,
             civ?.Rank ?? 0,
+            civ?.Ethos ?? 0,
+            civ?.FounderEpithet ?? string.Empty,
             memberReligions,
             civ?.PendingInvites ?? new List<CivilizationInfoResponsePacket.PendingInvite>(),
             State.InfoState.InviteReligionName ?? string.Empty,
@@ -733,6 +738,13 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
                 out profanityWordInDescription);
         }
 
+        // Default ethos is derived from the founder's patron domain; the founder may
+        // still override before submitting.
+        var defaultEthos = ChromeContext.PlayerPatronDomain.HasValue
+            ? CivilizationEthosDeriver.Derive(ChromeContext.PlayerPatronDomain.Value).Ethos
+            : CivilizationEthos.Sovereign;
+        var displayedEthos = State.CreateState.SelectedEthos ?? defaultEthos;
+
         // Build ViewModel
         var vm = new CivilizationCreateViewModel(
             State.CreateState.CreateCivName,
@@ -746,7 +758,8 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
             x,
             y,
             width,
-            height);
+            height,
+            displayedEthos);
 
         // Render
         var drawList = ImGui.GetWindowDrawList();
@@ -1215,16 +1228,25 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
                     _soundManager.PlayClick();
                     break;
 
+                case CreateEvent.EthosSelected ethosSelected:
+                    State.CreateState.SelectedEthos = ethosSelected.ethos;
+                    _soundManager.PlayClick();
+                    break;
+
                 case CreateEvent.SubmitClicked:
                     if (!string.IsNullOrWhiteSpace(State.CreateState.CreateCivName) &&
                         State.CreateState.CreateCivName.Length >= 3 &&
                         State.CreateState.CreateCivName.Length <= 32)
                     {
+                        var pickedEthos = State.CreateState.SelectedEthos.HasValue
+                            ? (int)State.CreateState.SelectedEthos.Value
+                            : -1;
                         RequestCivilizationAction("create", "", "", State.CreateState.CreateCivName,
-                            State.CreateState.SelectedIcon, State.CreateState.CreateDescription);
+                            State.CreateState.SelectedIcon, State.CreateState.CreateDescription, pickedEthos);
                         State.CreateState.CreateCivName = string.Empty;
                         State.CreateState.SelectedIcon = "default";
                         State.CreateState.CreateDescription = string.Empty;
+                        State.CreateState.SelectedEthos = null;
                     }
                     else
                     {
@@ -1238,6 +1260,7 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
                     State.CreateState.CreateCivName = string.Empty;
                     State.CreateState.SelectedIcon = "default";
                     State.CreateState.CreateDescription = string.Empty;
+                    State.CreateState.SelectedEthos = null;
                     break;
             }
     }

--- a/DivineAscension/GUI/Models/Civilization/Create/CivilizationCreateViewModel.cs
+++ b/DivineAscension/GUI/Models/Civilization/Create/CivilizationCreateViewModel.cs
@@ -1,3 +1,5 @@
+using DivineAscension.Models.Enum;
+
 namespace DivineAscension.GUI.Models.Civilization.Create;
 
 public readonly struct CivilizationCreateViewModel(
@@ -12,11 +14,13 @@ public readonly struct CivilizationCreateViewModel(
     float x,
     float y,
     float width,
-    float height)
+    float height,
+    CivilizationEthos selectedEthos = CivilizationEthos.Sovereign)
 {
     public string CivilizationName { get; } = civilizationName;
     public string SelectedIcon { get; } = selectedIcon;
     public string Description { get; } = description;
+    public CivilizationEthos SelectedEthos { get; } = selectedEthos;
     public string? ErrorMessage { get; } = errorMessage;
     public bool UserIsReligionFounder { get; } = userIsReligionFounder;
     public bool UserInCivilization { get; } = userInCivilization;

--- a/DivineAscension/GUI/Models/Civilization/Detail/CivilizationDetailViewModel.cs
+++ b/DivineAscension/GUI/Models/Civilization/Detail/CivilizationDetailViewModel.cs
@@ -11,6 +11,8 @@ public readonly struct CivilizationDetailViewModel(
     string founderName,
     string founderReligionName,
     int rank,
+    int ethos,
+    string founderEpithet,
     IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> memberReligions,
     DateTime createdDate,
     string description,
@@ -27,6 +29,8 @@ public readonly struct CivilizationDetailViewModel(
     public string FounderName { get; } = founderName;
     public string FounderReligionName { get; } = founderReligionName;
     public int Rank { get; } = rank;
+    public int Ethos { get; } = ethos;
+    public string FounderEpithet { get; } = founderEpithet;
     public IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> MemberReligions { get; } = memberReligions;
     public DateTime CreatedDate { get; } = createdDate;
     public string Description { get; } = description;

--- a/DivineAscension/GUI/Models/Civilization/Info/CivilizationInfoViewModel.cs
+++ b/DivineAscension/GUI/Models/Civilization/Info/CivilizationInfoViewModel.cs
@@ -18,6 +18,8 @@ public readonly struct CivilizationInfoViewModel(
     DateTime createdDate,
     bool isFounder,
     int rank,
+    int ethos,
+    string founderEpithet,
     IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> memberReligions,
     IReadOnlyList<CivilizationInfoResponsePacket.PendingInvite> pendingInvites,
     string inviteReligionName,
@@ -43,6 +45,8 @@ public readonly struct CivilizationInfoViewModel(
     public DateTime CreatedDate { get; } = createdDate;
     public bool IsFounder { get; } = isFounder;
     public int Rank { get; } = rank;
+    public int Ethos { get; } = ethos;
+    public string FounderEpithet { get; } = founderEpithet;
     public IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> MemberReligions { get; } = memberReligions;
     public IReadOnlyList<CivilizationInfoResponsePacket.PendingInvite> PendingInvites { get; } = pendingInvites;
     public string InviteReligionName { get; } = inviteReligionName;

--- a/DivineAscension/GUI/State/Civilization/CreateState.cs
+++ b/DivineAscension/GUI/State/Civilization/CreateState.cs
@@ -1,4 +1,5 @@
 using DivineAscension.GUI.Interfaces;
+using DivineAscension.Models.Enum;
 
 namespace DivineAscension.GUI.State.Civilization;
 
@@ -8,10 +9,19 @@ public class CreateState : IState
     public string CreateDescription { get; set; } = string.Empty;
     public string SelectedIcon { get; set; } = "default";
 
+    /// <summary>
+    ///     Founder-picked ethos. Null means "no explicit pick yet" — the server will
+    ///     derive from the founder religion's patron domain at create time. The
+    ///     create form seeds this with the derived value as soon as the founder's
+    ///     religion is known, so the picker shows the derived option highlighted.
+    /// </summary>
+    public CivilizationEthos? SelectedEthos { get; set; }
+
     public void Reset()
     {
         CreateCivName = string.Empty;
         CreateDescription = string.Empty;
         SelectedIcon = "default";
+        SelectedEthos = null;
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
@@ -10,6 +10,7 @@ using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Inputs;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
 using DivineAscension.Services;
 using ImGuiNET;
 using static DivineAscension.GUI.UI.Utilities.FontSizes;
@@ -59,6 +60,9 @@ internal static class CivilizationCreateRenderer
 
         currentY = DrawDivider(drawList, vm.X, currentY, contentWidth);
         currentY = DrawSigilSection(drawList, vm, currentY, contentWidth, events);
+
+        currentY = DrawDivider(drawList, vm.X, currentY, contentWidth);
+        currentY = DrawEthosSection(drawList, vm, currentY, contentWidth, events);
 
         currentY = DrawDivider(drawList, vm.X, currentY, contentWidth);
         currentY = DrawFoundingAction(drawList, vm, currentY, contentWidth, events);
@@ -190,6 +194,69 @@ internal static class CivilizationCreateRenderer
 
         return currentY + pickerHeight + SectionGap;
     }
+
+    private static readonly CivilizationEthos[] EthosOrder =
+    {
+        CivilizationEthos.Sovereign,
+        CivilizationEthos.Mercantile,
+        CivilizationEthos.Martial,
+        CivilizationEthos.Mystic,
+        CivilizationEthos.Ascetic
+    };
+
+    private const float EthosButtonHeight = 30f;
+    private const float EthosButtonGap = 6f;
+    private const float EthosHintTopPadding = 4f;
+
+    private static float DrawEthosSection(
+        ImDrawListPtr drawList,
+        CivilizationCreateViewModel vm,
+        float y,
+        float contentWidth,
+        List<CreateEvent> events)
+    {
+        TextRenderer.DrawLabel(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_CREATE_ETHOS_LABEL),
+            vm.X, y, SubsectionLabel, ColorPalette.Gold);
+        var currentY = y + LabelHeight;
+
+        var totalGaps = EthosButtonGap * (EthosOrder.Length - 1);
+        var buttonWidth = MathF.Floor((contentWidth - totalGaps) / EthosOrder.Length);
+
+        for (var i = 0; i < EthosOrder.Length; i++)
+        {
+            var ethos = EthosOrder[i];
+            var buttonX = vm.X + i * (buttonWidth + EthosButtonGap);
+            var isSelected = ethos == vm.SelectedEthos;
+            var label = LocalizationService.Instance.Get(EthosLocKey(ethos));
+
+            if (ButtonRenderer.DrawButton(drawList, label,
+                    buttonX, currentY, buttonWidth, EthosButtonHeight,
+                    isPrimary: isSelected,
+                    enabled: vm.UserIsReligionFounder && !vm.UserInCivilization))
+            {
+                events.Add(new CreateEvent.EthosSelected(ethos));
+            }
+        }
+
+        currentY += EthosButtonHeight + EthosHintTopPadding;
+
+        var hint = LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_CREATE_ETHOS_HINT);
+        TextRenderer.DrawInfoText(drawList, hint, vm.X, currentY, contentWidth, Secondary, ColorPalette.Grey);
+        currentY += MathF.Max(TextRenderer.MeasureWrappedHeight(hint, contentWidth, Secondary),
+            Secondary + LinePadding);
+
+        return currentY + SectionGap;
+    }
+
+    private static string EthosLocKey(CivilizationEthos ethos) => ethos switch
+    {
+        CivilizationEthos.Mercantile => LocalizationKeys.CIVILIZATION_ETHOS_MERCANTILE,
+        CivilizationEthos.Martial => LocalizationKeys.CIVILIZATION_ETHOS_MARTIAL,
+        CivilizationEthos.Mystic => LocalizationKeys.CIVILIZATION_ETHOS_MYSTIC,
+        CivilizationEthos.Ascetic => LocalizationKeys.CIVILIZATION_ETHOS_ASCETIC,
+        _ => LocalizationKeys.CIVILIZATION_ETHOS_SOVEREIGN
+    };
 
     private static float DrawFoundingAction(
         ImDrawListPtr drawList,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
@@ -11,6 +11,7 @@ using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Lists;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
 using DivineAscension.Network.Civilization;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -147,9 +148,13 @@ internal static class CivilizationDetailRenderer
     {
         var currentY = y;
 
+        var founderValue = string.IsNullOrWhiteSpace(vm.FounderName) ? "—" : vm.FounderName;
+        if (!string.IsNullOrWhiteSpace(vm.FounderEpithet))
+            founderValue = $"{founderValue}, {vm.FounderEpithet}";
+
         ChromeRenderer.DrawLeader(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_FOUNDER),
-            string.IsNullOrWhiteSpace(vm.FounderName) ? "—" : vm.FounderName,
+            founderValue,
             vm.X, currentY, width,
             valueColor: ColorPalette.Vermilion);
         currentY += StatRowHeight;
@@ -157,6 +162,12 @@ internal static class CivilizationDetailRenderer
         ChromeRenderer.DrawLeader(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_FOUNDING_ORDER),
             string.IsNullOrWhiteSpace(vm.FounderReligionName) ? "—" : vm.FounderReligionName,
+            vm.X, currentY, width);
+        currentY += StatRowHeight;
+
+        ChromeRenderer.DrawLeader(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_ETHOS),
+            LocalizationService.Instance.Get(EthosLocKey((CivilizationEthos)vm.Ethos)),
             vm.X, currentY, width);
         currentY += StatRowHeight;
 
@@ -169,6 +180,15 @@ internal static class CivilizationDetailRenderer
 
         return currentY + StatBlockBottomSpacing;
     }
+
+    private static string EthosLocKey(CivilizationEthos ethos) => ethos switch
+    {
+        CivilizationEthos.Mercantile => LocalizationKeys.CIVILIZATION_ETHOS_MERCANTILE,
+        CivilizationEthos.Martial => LocalizationKeys.CIVILIZATION_ETHOS_MARTIAL,
+        CivilizationEthos.Mystic => LocalizationKeys.CIVILIZATION_ETHOS_MYSTIC,
+        CivilizationEthos.Ascetic => LocalizationKeys.CIVILIZATION_ETHOS_ASCETIC,
+        _ => LocalizationKeys.CIVILIZATION_ETHOS_SOVEREIGN
+    };
 
     private static float DrawHistoryProse(
         CivilizationDetailViewModel vm,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -270,8 +270,8 @@ internal static class CivilizationInfoRenderer
         h += PaneHeaderRenderer.TotalHeight;
         // Prose intro
         h += Body + LinePadding + 12f;
-        // Stat block (3 rows)
-        h += OrderRowHeight * 3 + 8f;
+        // Stat block (4 rows: founded, founder+epithet, founding order, ethos)
+        h += OrderRowHeight * 4 + 8f;
 
         h += DividerHeight;
 

--- a/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoHeaderRenderer.cs
@@ -5,6 +5,7 @@ using DivineAscension.Constants;
 using DivineAscension.GUI.Models.Civilization.Info;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
 using DivineAscension.Services;
 using ImGuiNET;
 using static DivineAscension.GUI.UI.Utilities.FontSizes;
@@ -77,9 +78,13 @@ internal static class CivilizationInfoHeaderRenderer
             x, currentY, width);
         currentY += StatRowHeight;
 
+        var founderValue = string.IsNullOrWhiteSpace(vm.FounderName) ? "—" : vm.FounderName;
+        if (!string.IsNullOrWhiteSpace(vm.FounderEpithet))
+            founderValue = $"{founderValue}, {vm.FounderEpithet}";
+
         ChromeRenderer.DrawLeader(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_FOUNDER),
-            string.IsNullOrWhiteSpace(vm.FounderName) ? "—" : vm.FounderName,
+            founderValue,
             x, currentY, width,
             valueColor: ColorPalette.Vermilion);
         currentY += StatRowHeight;
@@ -90,6 +95,21 @@ internal static class CivilizationInfoHeaderRenderer
             x, currentY, width);
         currentY += StatRowHeight;
 
+        ChromeRenderer.DrawLeader(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_ETHOS),
+            LocalizationService.Instance.Get(EthosLocKey((CivilizationEthos)vm.Ethos)),
+            x, currentY, width);
+        currentY += StatRowHeight;
+
         return currentY + StatBlockBottomSpacing;
     }
+
+    private static string EthosLocKey(CivilizationEthos ethos) => ethos switch
+    {
+        CivilizationEthos.Mercantile => LocalizationKeys.CIVILIZATION_ETHOS_MERCANTILE,
+        CivilizationEthos.Martial => LocalizationKeys.CIVILIZATION_ETHOS_MARTIAL,
+        CivilizationEthos.Mystic => LocalizationKeys.CIVILIZATION_ETHOS_MYSTIC,
+        CivilizationEthos.Ascetic => LocalizationKeys.CIVILIZATION_ETHOS_ASCETIC,
+        _ => LocalizationKeys.CIVILIZATION_ETHOS_SOVEREIGN
+    };
 }

--- a/DivineAscension/Models/CivilizationEthosDeriver.cs
+++ b/DivineAscension/Models/CivilizationEthosDeriver.cs
@@ -1,0 +1,29 @@
+using DivineAscension.Constants;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.Models;
+
+/// <summary>
+///     Maps a founder religion's patron <see cref="DeityDomain" /> to the
+///     civilization's <see cref="CivilizationEthos" /> and founder epithet
+///     localization key. Pure function, computed once at civ creation.
+/// </summary>
+public static class CivilizationEthosDeriver
+{
+    /// <summary>
+    ///     Derives the ethos and the localization key for the founder epithet
+    ///     from the founder religion's patron domain.
+    /// </summary>
+    public static (CivilizationEthos Ethos, string EpithetLocKey) Derive(DeityDomain patronDomain)
+    {
+        return patronDomain switch
+        {
+            DeityDomain.Craft => (CivilizationEthos.Mercantile, LocalizationKeys.CIVILIZATION_EPITHET_CRAFT),
+            DeityDomain.Conquest => (CivilizationEthos.Martial, LocalizationKeys.CIVILIZATION_EPITHET_CONQUEST),
+            DeityDomain.Wild => (CivilizationEthos.Mystic, LocalizationKeys.CIVILIZATION_EPITHET_WILD),
+            DeityDomain.Harvest => (CivilizationEthos.Ascetic, LocalizationKeys.CIVILIZATION_EPITHET_HARVEST),
+            DeityDomain.Stone => (CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_STONE),
+            _ => (CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_DEFAULT)
+        };
+    }
+}

--- a/DivineAscension/Models/Enum/CivilizationEthos.cs
+++ b/DivineAscension/Models/Enum/CivilizationEthos.cs
@@ -1,0 +1,19 @@
+namespace DivineAscension.Models.Enum;
+
+/// <summary>
+///     Narrative identity axis for a civilization, picked once at founding.
+///     Derived by default from the founder religion's <see cref="DeityDomain" />;
+///     may be overridden by the founder if creation UI exposes the choice.
+/// </summary>
+/// <remarks>
+///     Sovereign is the safe default for legacy saves that pre-date this field.
+///     Domain → Ethos mapping is defined in <see cref="CivilizationEthosDeriver" />.
+/// </remarks>
+public enum CivilizationEthos
+{
+    Sovereign = 0,
+    Mercantile = 1,
+    Martial = 2,
+    Mystic = 3,
+    Ascetic = 4
+}

--- a/DivineAscension/Network/Civilization/CivilizationActionRequestPacket.cs
+++ b/DivineAscension/Network/Civilization/CivilizationActionRequestPacket.cs
@@ -37,4 +37,13 @@ public class CivilizationActionRequestPacket
     [ProtoMember(5)] public string Icon { get; set; } = string.Empty; // Icon identifier (for create/updateicon actions)
 
     [ProtoMember(6)] public string Description { get; set; } = string.Empty; // Description (for create/setdescription actions)
+
+    /// <summary>
+    ///     Founder-picked ethos for the "create" action, stored as
+    ///     <see cref="DivineAscension.Models.Enum.CivilizationEthos" /> cast to int. A
+    ///     negative value (the default) means the server should derive ethos from the
+    ///     founder religion's patron domain. Zero is a valid explicit pick (Sovereign).
+    /// </summary>
+    [ProtoMember(7)]
+    public int Ethos { get; set; } = -1;
 }

--- a/DivineAscension/Network/Civilization/CivilizationInfoResponsePacket.cs
+++ b/DivineAscension/Network/Civilization/CivilizationInfoResponsePacket.cs
@@ -62,6 +62,20 @@ public class CivilizationInfoResponsePacket
         /// </summary>
         [ProtoMember(13)]
         public int Rank { get; set; }
+
+        /// <summary>
+        ///     Narrative ethos derived at founding. Stored as int for proto-compat with
+        ///     <see cref="DivineAscension.Models.Enum.CivilizationEthos" />.
+        /// </summary>
+        [ProtoMember(14)]
+        public int Ethos { get; set; }
+
+        /// <summary>
+        ///     Localized founder epithet (e.g. "the Forge-Crowned"), resolved at founding
+        ///     and persisted on the civilization.
+        /// </summary>
+        [ProtoMember(15)]
+        public string FounderEpithet { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/DivineAscension/Systems/CivilizationManager.cs
+++ b/DivineAscension/Systems/CivilizationManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Data;
+using DivineAscension.Models;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
 using DivineAscension.Systems.Interfaces;
@@ -209,7 +210,7 @@ public class CivilizationManager : ICivilizationManager
     /// <param name="description">Optional description for the civilization</param>
     /// <returns>The created civilization, or null if creation failed</returns>
     public Civilization? CreateCivilization(string name, string founderUID, string founderReligionId,
-        string icon = "default", string description = "")
+        string icon = "default", string description = "", CivilizationEthos? ethosOverride = null)
     {
         lock (Lock)
         {
@@ -267,11 +268,14 @@ public class CivilizationManager : ICivilizationManager
 
                 // Create civilization
                 var civId = Guid.NewGuid().ToString();
+                var (derivedEthos, epithetKey) = CivilizationEthosDeriver.Derive(founderReligion.PatronDomain);
                 var civ = new Civilization(civId, name, founderUID, founderReligionId)
                 {
                     MemberCount = founderReligion.MemberUIDs.Count,
                     Icon = icon,
-                    Description = description
+                    Description = description,
+                    Ethos = ethosOverride ?? derivedEthos,
+                    FounderEpithet = LocalizationService.Instance.Get(epithetKey)
                 };
 
                 _data.AddCivilization(civ);

--- a/DivineAscension/Systems/Interfaces/ICivilizationManager.cs
+++ b/DivineAscension/Systems/Interfaces/ICivilizationManager.cs
@@ -42,7 +42,7 @@ public interface ICivilizationManager
     /// <param name="description">Optional description for the civilization</param>
     /// <returns>The created civilization, or null if creation failed</returns>
     Civilization? CreateCivilization(string name, string founderUID, string founderReligionId, string icon = "default",
-        string description = "");
+        string description = "", CivilizationEthos? ethosOverride = null);
 
     /// <summary>
     ///     Invites a religion to join a civilization

--- a/DivineAscension/Systems/Interfaces/IUiService.cs
+++ b/DivineAscension/Systems/Interfaces/IUiService.cs
@@ -35,7 +35,7 @@ public interface IUiService
     void RequestCivilizationInfo(string civId);
 
     void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "");
+        string icon = "", string description = "", int ethos = -1);
 
     // Diplomacy Operations
     void RequestDiplomacyInfo(string civId);

--- a/DivineAscension/Systems/Networking/Client/DivineAscensionNetworkClient.cs
+++ b/DivineAscension/Systems/Networking/Client/DivineAscensionNetworkClient.cs
@@ -839,7 +839,7 @@ public class DivineAscensionNetworkClient : IClientNetworkHandler
     ///     Request a civilization action (create, invite, accept, leave, kick, disband, setdescription)
     /// </summary>
     public void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "")
+        string icon = "", string description = "", int ethos = -1)
     {
         if (_clientChannel == null)
         {
@@ -847,7 +847,10 @@ public class DivineAscensionNetworkClient : IClientNetworkHandler
             return;
         }
 
-        var request = new CivilizationActionRequestPacket(action, civId, targetId, name, icon, description);
+        var request = new CivilizationActionRequestPacket(action, civId, targetId, name, icon, description)
+        {
+            Ethos = ethos
+        };
         _clientChannel.SendPacket(request);
         _capi?.Logger.Debug($"[DivineAscension] Sent civilization action request: {action}");
     }

--- a/DivineAscension/Systems/Networking/Client/UiService.cs
+++ b/DivineAscension/Systems/Networking/Client/UiService.cs
@@ -117,9 +117,9 @@ public class UiService(DivineAscensionNetworkClient networkClient)
     }
 
     public void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "")
+        string icon = "", string description = "", int ethos = -1)
     {
-        _networkClient.RequestCivilizationAction(action, civId, targetId, name, icon, description);
+        _networkClient.RequestCivilizationAction(action, civId, targetId, name, icon, description, ethos);
     }
 
     public void RequestDiplomacyInfo(string civId)

--- a/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
@@ -179,6 +179,8 @@ public class CivilizationNetworkHandler(
             Description = civ.Description,
             IsFounder = civ.IsFounder(fromPlayer.PlayerUID),
             Rank = (int)civ.Rank,
+            Ethos = (int)civ.Ethos,
+            FounderEpithet = civ.FounderEpithet,
             MemberReligions = new List<CivilizationInfoResponsePacket.MemberReligion>(),
             PendingInvites = new List<CivilizationInfoResponsePacket.PendingInvite>()
         };
@@ -278,8 +280,12 @@ public class CivilizationNetworkHandler(
                     }
 
                     var iconToUse = string.IsNullOrWhiteSpace(packet.Icon) ? "default" : packet.Icon;
+                    CivilizationEthos? ethosOverride = packet.Ethos >= 0 &&
+                                                       System.Enum.IsDefined(typeof(CivilizationEthos), packet.Ethos)
+                        ? (CivilizationEthos)packet.Ethos
+                        : null;
                     var newCiv = civilizationManager.CreateCivilization(packet.Name, fromPlayer.PlayerUID,
-                        religion.ReligionUID, iconToUse, packet.Description);
+                        religion.ReligionUID, iconToUse, packet.Description, ethosOverride);
                     if (newCiv != null)
                     {
                         response.Success = true;

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1293,5 +1293,23 @@
   "divineascension:ui.playerinfo.row.deity": "Deity",
   "divineascension:ui.playerinfo.row.order": "Order",
   "divineascension:ui.playerinfo.row.vestment": "Vestment",
-  "divineascension:ui.playerinfo.row.realm": "Realm"
+  "divineascension:ui.playerinfo.row.realm": "Realm",
+
+  "divineascension:civilization.ethos.sovereign": "Sovereign",
+  "divineascension:civilization.ethos.mercantile": "Mercantile",
+  "divineascension:civilization.ethos.martial": "Martial",
+  "divineascension:civilization.ethos.mystic": "Mystic",
+  "divineascension:civilization.ethos.ascetic": "Ascetic",
+
+  "divineascension:civilization.epithet.craft": "the Forge-Crowned",
+  "divineascension:civilization.epithet.conquest": "the Iron-Handed",
+  "divineascension:civilization.epithet.wild": "the Storm-Voiced",
+  "divineascension:civilization.epithet.harvest": "the Grain-Bearer",
+  "divineascension:civilization.epithet.stone": "the Stone-Bearer",
+  "divineascension:civilization.epithet.default": "the Unmarked",
+
+  "divineascension:ui.civilization.info.ethos": "Ethos",
+  "divineascension:ui.civilization.detail.ethos": "Ethos",
+  "divineascension:ui.civilization.create.ethos.label": "Ethos",
+  "divineascension:ui.civilization.create.ethos.hint": "Chosen once, at founding. Tradition derives ethos from your patron's domain — overrule only with reason."
 }


### PR DESCRIPTION
## Summary
- Adds `CivilizationEthos` enum (Sovereign / Mercantile / Martial / Mystic / Ascetic) and `FounderEpithet` string, both persisted on `Civilization` (proto 15/16). Legacy saves load with Sovereign + empty epithet — no migration required.
- Ethos derivation table in `CivilizationEthosDeriver` maps founder religion's patron `DeityDomain` to ethos + epithet localization key. Epithet is resolved once at founding and stays bound to the original patron domain even if the founder later changes religion or leaves the civ.
- Create flow lets the founder pick: new Ethos section on the Create chapter with 5 buttons, derived default pre-highlighted. `CivilizationActionRequestPacket.Ethos` carries the override (`-1` = derive). Server validates and falls back to derivation on invalid input.
- Info and Detail headers display both: founder leader-row appends the epithet (`"Sigrun, the Iron-Handed"`); new Ethos leader-row below the founding order.

Closes #367.

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` — 2184/2184 pass (incl. new derivation Theory + proto round-trip)
- [ ] In-game: found a civ with each of the 5 ethos picks; confirm the picked value renders on the Info pane and survives save/reload
- [ ] In-game: open an old save's existing civ; confirm it shows as Sovereign with empty epithet (no crash)
- [ ] In-game: founder of a Craft-patron religion overrides to Martial; confirm Ethos = Martial but epithet still reads "the Forge-Crowned" (epithet is patron-bound by design)