### PR TITLE
Rank-up notification as bottom-right toast

### DIFF
--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -299,10 +299,9 @@ public partial class GuiDialog : ModSystem
         // Update notification timer
         _manager.NotificationManager.Update(deltaSeconds);
 
-        // Get window bounds
-        var window = _capi!.Gui.WindowBounds;
-        var windowWidth = Math.Min(WindowBaseWidth, (int)window.OuterWidth - 128);
-        var windowHeight = Math.Min(WindowBaseHeight, (int)window.OuterHeight - 128);
+        // Toast anchors to the bottom-right of the full viewport.
+        var windowWidth = _viewport.Size.X;
+        var windowHeight = _viewport.Size.Y;
 
         // Create invisible fullscreen window to render notification overlay
         ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0);
@@ -311,10 +310,7 @@ public partial class GuiDialog : ModSystem
         ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0, 0, 0, 0)); // Fully transparent
 
         ImGui.SetNextWindowSize(new Vector2(windowWidth, windowHeight));
-        ImGui.SetNextWindowPos(new Vector2(
-            _viewport.Pos.X + (_viewport.Size.X - windowWidth) / 2,
-            _viewport.Pos.Y + (_viewport.Size.Y - windowHeight) / 2
-        ));
+        ImGui.SetNextWindowPos(new Vector2(_viewport.Pos.X, _viewport.Pos.Y));
 
         var flags = ImGuiWindowFlags.NoTitleBar |
                     ImGuiWindowFlags.NoResize |
@@ -362,8 +358,8 @@ public partial class GuiDialog : ModSystem
         ImGui.PopStyleColor();
         ImGui.PopStyleVar(3);
 
-        // Return GrabMouse to capture input while notification is visible
-        return CallbackGUIStatus.GrabMouse;
+        // Non-modal toast — don't grab mouse, let gameplay continue underneath.
+        return CallbackGUIStatus.Closed;
     }
 
     /// <summary>

--- a/DivineAscension/GUI/UI/Components/Overlays/RankUpNotificationOverlay.cs
+++ b/DivineAscension/GUI/UI/Components/Overlays/RankUpNotificationOverlay.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.GUI.State;
-using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Services;
@@ -13,18 +12,17 @@ using static DivineAscension.GUI.UI.Utilities.FontSizes;
 namespace DivineAscension.GUI.UI.Components.Overlays;
 
 /// <summary>
-/// Rank-up popup styled as a parchment mini-page (vestments-modal language):
-/// faded-ink border, gold serif title, ornamental divider, ink body text,
-/// primary footer button. Mirrors <c>ReligionRolesBrowseRenderer.DrawRoleEditor</c>.
+/// Rank-up toast anchored to the bottom-right of the viewport. Non-modal:
+/// auto-dismisses on timer, no backdrop dim, no input capture. Click the
+/// toast body to jump to the Blessings page.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal static class RankUpNotificationOverlay
 {
-    private const float PanelWidth = 500f;
-    private const float IconSize = 56f;
-    private const float Padding = 18f;
-    private const float ButtonWidth = 220f;
-    private const float ButtonHeight = 32f;
+    private const float PanelWidth = 320f;
+    private const float IconSize = 36f;
+    private const float Padding = 12f;
+    private const float EdgeMargin = 24f;
 
     internal static void Draw(NotificationState state, out bool dismissed, out bool viewBlessingsClicked,
         float windowWidth, float windowHeight)
@@ -36,29 +34,19 @@ internal static class RankUpNotificationOverlay
 
         var drawList = ImGui.GetWindowDrawList();
         var winPos = ImGui.GetWindowPos();
-        var winSize = ImGui.GetWindowSize();
 
-        // Warm-dark page dim, matches vestments modal §4.
-        drawList.AddRectFilled(winPos, new Vector2(winPos.X + winSize.X, winPos.Y + winSize.Y),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BlackOverlay));
-
-        var bodyWidth = PanelWidth - Padding * 2;
-
+        var bodyWidth = PanelWidth - Padding * 2 - IconSize - Padding;
         var descriptionHeight = TextRenderer.MeasureWrappedHeight(state.RankDescription, bodyWidth, Body);
 
-        var panelHeight =
-            Padding +
-            IconSize + 12f +
-            PageTitle + 6f +
-            14f +
-            16f +
-            SubsectionLabel + 10f +
-            descriptionHeight + 18f +
-            ButtonHeight +
-            Padding;
+        var contentHeight =
+            SubsectionLabel + 4f +
+            SubsectionLabel + 6f +
+            descriptionHeight;
+        var iconBlockHeight = IconSize;
+        var panelHeight = Padding + MathF.Max(contentHeight, iconBlockHeight) + Padding;
 
-        var panelX = winPos.X + (windowWidth - PanelWidth) / 2f;
-        var panelY = winPos.Y + 50f;
+        var panelX = winPos.X + windowWidth - PanelWidth - EdgeMargin;
+        var panelY = winPos.Y + windowHeight - panelHeight - EdgeMargin;
         var panelMin = new Vector2(panelX, panelY);
         var panelMax = new Vector2(panelX + PanelWidth, panelY + panelHeight);
 
@@ -68,55 +56,37 @@ internal static class RankUpNotificationOverlay
         drawList.AddRect(panelMin, panelMax,
             ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 6f, ImDrawFlags.None, 1.5f);
 
-        var currentY = panelY + Padding;
-
-        var iconX = panelX + (PanelWidth - IconSize) / 2f;
+        var iconX = panelX + Padding;
+        var iconY = panelY + (panelHeight - IconSize) / 2f;
         var textureId = DeityIconLoader.GetDeityTextureId(state.DeityDomain);
         if (textureId != IntPtr.Zero)
         {
             drawList.AddImage(textureId,
-                new Vector2(iconX, currentY),
-                new Vector2(iconX + IconSize, currentY + IconSize),
+                new Vector2(iconX, iconY),
+                new Vector2(iconX + IconSize, iconY + IconSize),
                 Vector2.Zero, Vector2.One);
         }
-        currentY += IconSize + 12f;
 
-        // Title — gold at PageTitle, centered. Scale CalcTextSize from default to PageTitle.
+        var textX = iconX + IconSize + Padding;
+        var textY = panelY + Padding;
+
         var titleText = LocalizationService.Instance.Get(LocalizationKeys.UI_RANKUP_TITLE);
-        var titleWidth = ImGui.CalcTextSize(titleText).X * (PageTitle / ImGui.GetFontSize());
-        TextRenderer.DrawLabel(drawList, titleText,
-            panelX + (PanelWidth - titleWidth) / 2f, currentY, PageTitle, ColorPalette.Gold);
-        currentY += PageTitle + 6f;
+        TextRenderer.DrawLabel(drawList, titleText, textX, textY, SubsectionLabel, ColorPalette.Gold);
+        textY += SubsectionLabel + 4f;
 
-        ChromeRenderer.DrawDivider(drawList, panelX + Padding, currentY, bodyWidth);
-        currentY += 16f;
-
-        var rankNameWidth = ImGui.CalcTextSize(state.RankName).X * (SubsectionLabel / ImGui.GetFontSize());
-        TextRenderer.DrawLabel(drawList, state.RankName,
-            panelX + (PanelWidth - rankNameWidth) / 2f, currentY, SubsectionLabel, ColorPalette.Gold);
-        currentY += SubsectionLabel + 10f;
+        TextRenderer.DrawLabel(drawList, state.RankName, textX, textY, SubsectionLabel, ColorPalette.White);
+        textY += SubsectionLabel + 6f;
 
         TextRenderer.DrawInfoText(drawList, state.RankDescription,
-            panelX + Padding, currentY, bodyWidth, Body, ColorPalette.White);
-        currentY += descriptionHeight + 18f;
-
-        var buttonX = panelX + (PanelWidth - ButtonWidth) / 2f;
-        if (ButtonRenderer.DrawButton(drawList,
-                LocalizationService.Instance.Get(LocalizationKeys.UI_RANKUP_VIEW_BLESSINGS),
-                buttonX, currentY, ButtonWidth, ButtonHeight, isPrimary: true))
-        {
-            viewBlessingsClicked = true;
-            dismissed = true;
-        }
-
-        if (ImGui.IsKeyPressed(ImGuiKey.Escape)) dismissed = true;
+            textX, textY, bodyWidth, Body, ColorPalette.White);
 
         if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             var mousePos = ImGui.GetMousePos();
-            if (mousePos.X < panelX || mousePos.X > panelX + PanelWidth ||
-                mousePos.Y < panelY || mousePos.Y > panelY + panelHeight)
+            if (mousePos.X >= panelX && mousePos.X <= panelX + PanelWidth &&
+                mousePos.Y >= panelY && mousePos.Y <= panelY + panelHeight)
             {
+                viewBlessingsClicked = true;
                 dismissed = true;
             }
         }


### PR DESCRIPTION
## Summary
- Drop full-screen backdrop dim from the rank-up notification (was painting `BlackOverlay` across the whole host window).
- Re-anchor the panel to the bottom-right of the viewport with a 24px edge margin.
- Shrink to a compact 320px toast: icon left, title + rank name + description right. No primary button.
- Click the toast body to jump to Blessings (same handler as before); auto-dismiss via existing `NotificationManager.Update` timer.
- Host overlay now uses the full viewport and returns `Closed` so input passes through to gameplay (non-modal).

Closes #382.

## Test plan
- [x] Trigger a rank-up (favor or prestige) — toast appears bottom-right, no world dim, world/chat fully visible.
- [x] Toast auto-dismisses after its display duration.
- [x] Clicking the toast opens the dialog on the Blessings page.
- [x] Player movement / mouselook is not captured while the toast is showing.
- [x] Queued notifications still chain (trigger two rank-ups in quick succession).