### PR TITLE
feat(civ): hide sigil/icon picker until ledger redesign (#385)

### DIFF
--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -1149,10 +1149,9 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
                     break;
 
                 case InfoEvent.EditIconClicked:
-                    State.EditState.IsOpen = true;
-                    State.EditState.CivId = civId;
-                    State.EditState.EditingIcon = civ?.Icon ?? "default";
-                    _soundManager.PlayClick();
+                    // Sigil edit dialog hidden until the ledger redesign — see #385.
+                    // Keep the event handler so any lingering button click is a no-op
+                    // instead of opening the legacy PNG-grid dialog.
                     break;
 
                 case InfoEvent.DisbandOpened:

--- a/DivineAscension/GUI/UI/Renderers/Blessing/ReligionHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/ReligionHeaderRenderer.cs
@@ -159,21 +159,12 @@ internal static class ReligionHeaderRenderer
             return y + 22f;
         }
 
-        var iconPos = new Vector2(x, y);
-        var iconMax = new Vector2(iconPos.X + IconSize, iconPos.Y + IconSize);
-        var civTexture = CivilizationIconLoader.GetIconTextureId(vm.CivilizationIcon ?? "default");
-        // Lapis-tinted backing tile + matching border to mirror the religion
-        // deity-tile pattern above. Lapis is the civilization accent ink —
-        // pairs with the civ name rendered below.
-        drawList.AddRectFilled(iconPos, iconMax,
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Lapis * 0.8f), 4f);
-        drawList.AddImage(civTexture, iconPos, iconMax,
-            Vector2.Zero, Vector2.One,
-            ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f)));
-        drawList.AddRect(iconPos, iconMax,
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Lapis * 0.8f),
-            4f, ImDrawFlags.None, 2f);
-
+        // Civilization sigil hidden until the ledger redesign — see #385.
+        // The lapis-tinted tile + image draw that lived here is intentionally
+        // gone; CivilizationIconLoader and the asset PNGs stay so the sigil
+        // can return without a schema or loader change. The text below keeps
+        // the IconSize offset so the rail's two-row rhythm (deity row above
+        // + civ row here) is preserved.
         var textX = x + IconSize + 8f;
         var civName = vm.CurrentCivilizationName
             ?? LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_UNKNOWN_CIVILIZATION);

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.GUI.Events.Civilization;
 using DivineAscension.GUI.Models.Civilization.Create;
-using DivineAscension.GUI.UI.Components;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Inputs;
 using DivineAscension.GUI.UI.Renderers.Utilities;
@@ -58,8 +57,10 @@ internal static class CivilizationCreateRenderer
         currentY = DrawDivider(drawList, vm.X, currentY, contentWidth);
         currentY = DrawDescriptionSection(drawList, vm, currentY, contentWidth, events);
 
-        currentY = DrawDivider(drawList, vm.X, currentY, contentWidth);
-        currentY = DrawSigilSection(drawList, vm, currentY, contentWidth, events);
+        // Sigil section hidden — current PNG picker does not match the ledger
+        // chrome the rest of the civ flow uses. Tracked in #385; the data path
+        // (Civilization.Icon, packet field, CivilizationIconLoader) is left
+        // intact so the section can return without a schema change.
 
         currentY = DrawDivider(drawList, vm.X, currentY, contentWidth);
         currentY = DrawEthosSection(drawList, vm, currentY, contentWidth, events);
@@ -167,32 +168,6 @@ internal static class CivilizationCreateRenderer
         if (message == null) return y;
         TextRenderer.DrawErrorText(drawList, message, vm.X, y);
         return y + ErrorRowHeight;
-    }
-
-    private static float DrawSigilSection(
-        ImDrawListPtr drawList,
-        CivilizationCreateViewModel vm,
-        float y,
-        float contentWidth,
-        List<CreateEvent> events)
-    {
-        TextRenderer.DrawLabel(drawList,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_CREATE_ICON_LABEL),
-            vm.X, y, SubsectionLabel, ColorPalette.Gold);
-        var currentY = y + LabelHeight;
-
-        var (clickedIcon, pickerHeight) = IconPicker.Draw(
-            drawList,
-            CivilizationIconLoader.GetAvailableIcons(),
-            vm.SelectedIcon,
-            vm.X,
-            currentY,
-            contentWidth);
-
-        if (clickedIcon != null)
-            events.Add(new CreateEvent.IconSelected(clickedIcon));
-
-        return currentY + pickerHeight + SectionGap;
     }
 
     private static readonly CivilizationEthos[] EthosOrder =

--- a/DivineAscension/GUI/UI/Renderers/Components/CivilizationTableRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/CivilizationTableRenderer.cs
@@ -35,7 +35,10 @@ internal static class CivilizationTableRenderer
     private const float RowPaddingVertical = 12f;
     private const float RowSpacing = 8f;
     private const float ScrollbarWidth = 16f;
-    private const float CivIconSize = 48f;
+    // Civ sigil column hidden until the ledger redesign — see #385. Set to 0
+    // so the Name column reclaims the space; the loader and asset PNGs are
+    // intentionally left in place.
+    private const float CivIconSize = 0f;
     private const float DeityIconSize = 12f;
     private const float DeityIconSpacing = 4f;
     private const float DescriptionPaddingHorizontal = 12f;
@@ -189,9 +192,10 @@ internal static class CivilizationTableRenderer
         var headerColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
         const float fontSize = TableHeader;
 
-        // Column 1: "Name" — center over the text area after the icon (matches religion table)
-        var nameTextAreaX = x + NamePadding + CivIconSize + NamePadding;
-        var nameTextAreaWidth = nameColumnWidth - CivIconSize - NamePadding * 3;
+        // Column 1: "Name" — sigil column is hidden (see #385), so the name
+        // text area now spans the full Name column.
+        var nameTextAreaX = x + NamePadding;
+        var nameTextAreaWidth = nameColumnWidth - NamePadding * 2;
         DrawCenteredText(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_BROWSE_HEADER_NAME),
             nameTextAreaX, y + 8f, nameTextAreaWidth, headerColor, fontSize);
@@ -269,12 +273,11 @@ internal static class CivilizationTableRenderer
         float rowHeight,
         float columnWidth)
     {
-        var iconX = colX + NamePadding;
-        var iconY = rowY + (rowHeight - CivIconSize) / 2f;
-        DrawCivIcon(drawList, civ.Icon, iconX, iconY);
-
-        var textX = iconX + CivIconSize + NamePadding;
-        var textWidth = columnWidth - CivIconSize - NamePadding * 3;
+        // Sigil draw skipped — see #385. Layout retained for parity with the
+        // religion table (and so the sigil can return without re-shuffling
+        // the column geometry).
+        var textX = colX + NamePadding;
+        var textWidth = columnWidth - NamePadding * 2;
         var textSize = ImGui.CalcTextSize(civ.Name);
         var scale = Body / ImGui.GetFont().FontSize;
         var scaledWidth = textSize.X * scale;
@@ -351,29 +354,7 @@ internal static class CivilizationTableRenderer
         ImGui.PopTextWrapPos();
     }
 
-    private static void DrawCivIcon(ImDrawListPtr drawList, string iconName, float x, float y)
-    {
-        var iconTextureId = CivilizationIconLoader.GetIconTextureId(iconName);
-        var iconMin = new Vector2(x, y);
-        var iconMax = new Vector2(x + CivIconSize, y + CivIconSize);
-
-        if (iconTextureId != IntPtr.Zero)
-        {
-            var tintColorU32 = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f));
-            drawList.AddImage(iconTextureId, iconMin, iconMax, Vector2.Zero, Vector2.One, tintColorU32);
-        }
-        else
-        {
-            var center = new Vector2(x + CivIconSize / 2f, y + CivIconSize / 2f);
-            var fallbackColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.LightBrown);
-            drawList.AddCircleFilled(center, CivIconSize / 2f, fallbackColor, 16);
-        }
-
-        var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
-        drawList.AddRect(iconMin, iconMax, borderColor, 4f, ImDrawFlags.None, 2f);
-    }
-
-    private static void DrawCenteredText(
+private static void DrawCenteredText(
         ImDrawListPtr drawList,
         string text,
         float colX,


### PR DESCRIPTION
## Summary
- Removes the civilization sigil from every live UI surface: Create chapter, Info pane edit trigger, Browse table, and the religion-blessing rail.
- Browse table reclaims the sigil column width into the Name column; the religion rail keeps its two-row rhythm via the existing `IconSize` offset but no longer draws the lapis tile or PNG.
- Edit-icon dialog is unreachable: `InfoEvent.EditIconClicked` is now a defensive no-op so a stray re-introduction of the trigger can't open the legacy PNG-grid dialog.
- Hide, don't delete: `Civilization.Icon`, `CivilizationActionRequestPacket.Icon`, `CivilizationInfoResponsePacket.CivilizationDetails.Icon`, `CivilizationIconLoader`, all 16 PNG assets, and the related localization keys are intentionally left in place. Old saves with non-default `Icon` values round-trip unchanged; the value is just not drawn.

Closes #385.

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` — 2175/2184 pass; the 9 failing tests (`SoundManagerTests.*`, `CivilizationStateManagerTests.CompleteWorkflow_*`, `CivilizationStateManagerTests.OnCivilizationActionCompleted_*`) were verified to fail on master before this branch — pre-existing, not introduced here
- [x] In-game: open Create chapter; confirm no Sigil section and the flow is Name → Description → Ethos → Raise the Banner
- [x] In-game: open This Realm / Other Realms; confirm no sigil renders anywhere
- [x] In-game: open Browse table; confirm names fill the column and rows still align
- [x] In-game: open Blessings → Religion rail; confirm civ name + rank still read, lapis text accents intact
- [x] Save/reload a world that has a civ with a non-default `Icon` value; confirm no errors and the icon value survives a round-trip