### PR TITLE
fix(ui): drop em-dash from civ ethos hint

### DIFF
--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1311,5 +1311,5 @@
   "divineascension:ui.civilization.info.ethos": "Ethos",
   "divineascension:ui.civilization.detail.ethos": "Ethos",
   "divineascension:ui.civilization.create.ethos.label": "Ethos",
-  "divineascension:ui.civilization.create.ethos.hint": "Chosen once, at founding. Tradition derives ethos from your patron's domain — overrule only with reason."
+  "divineascension:ui.civilization.create.ethos.hint": "Chosen once, at founding. Tradition derives ethos from your patron's domain. Overrule only with reason."
 }


### PR DESCRIPTION
## Summary
The Create-chapter ethos hint rendered as `...your patron's domain ? overrule only with reason.` because the ImGui font in use does not ship a glyph for U+2014 (em-dash) and falls back to `?`. Re-phrased the hint as two sentences so the copy lands as written.

No other strings in `en.json` use the em-dash, so no broader sweep needed.

## Test plan
- [x] In-game: open Found a Realm; confirm the ethos hint reads `Chosen once, at founding. Tradition derives ethos from your patron's domain. Overrule only with reason.` with no `?` glyph