### PR TITLE
Blessings tree: parchment + wax-seal restyle (hybrid)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingNodeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingNodeRenderer.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using DivineAscension.Constants;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models;
 using ImGuiNET;
@@ -10,34 +10,23 @@ using static DivineAscension.GUI.UI.Utilities.FontSizes;
 namespace DivineAscension.GUI.UI.Renderers.Blessing;
 
 /// <summary>
-///     Renders individual blessing nodes in the tree
-///     Displays states: locked, unlockable (glowing), unlocked (gold)
+///     Renders individual blessing nodes as parchment-style wax-seal medallions
+///     using the codex palette. Outer ring + rim show unlock state; inner disc
+///     hosts the blessing's icon (or its initials if no icon is registered).
+///     Tier number and modern fills/glows have been dropped in favour of the
+///     ledger language used by the surrounding chapter.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal static class BlessingNodeRenderer
 {
-    private const float CornerRadius = 4f;
-    private static readonly Vector4 ColorLocked = new(0.573f, 0.502f, 0.416f, 1.0f); // #92806a grey
-    private static readonly Vector4 ColorUnlockable = new(0.478f, 0.776f, 0.184f, 1.0f); // #7ac62f lime
-    private static readonly Vector4 ColorUnlocked = new(0.996f, 0.682f, 0.204f, 1.0f); // #feae34 gold
-    private static readonly Vector4 ColorBranchLocked = new(0.698f, 0.133f, 0.133f, 1.0f); // #b22222 firebrick red
-    private static readonly Vector4 ColorSelected = new(1.0f, 1.0f, 1.0f, 1.0f); // White border
-    private static readonly Vector4 ColorHover = new(0.8f, 0.8f, 1.0f, 1.0f); // Light blue tint
+    private const float SealRadius = 22f;
+    private const float RimThickness = 2.0f;
+    private const float SelectedRimThickness = 3.0f;
+    private const float IconSize = 28f;
 
-    // Static field for glow animation timing
+    // Shared animation clock for the "available" gentle pulse.
     private static float _glowAnimationTime;
 
-    /// <summary>
-    ///     Draw a single blessing node
-    /// </summary>
-    /// <param name="state">Blessing node state</param>
-    /// <param name="offsetX">Scroll offset X</param>
-    /// <param name="offsetY">Scroll offset Y</param>
-    /// <param name="mouseX">Mouse X position (world space)</param>
-    /// <param name="mouseY">Mouse Y position (world space)</param>
-    /// <param name="deltaTime">Time elapsed since last frame (for animations)</param>
-    /// <param name="isSelected">Whether this node is currently selected</param>
-    /// <returns>True if mouse is hovering over this node</returns>
     public static bool DrawNode(
         BlessingNodeState state,
         float offsetX, float offsetY,
@@ -47,128 +36,96 @@ internal static class BlessingNodeRenderer
     {
         var drawList = ImGui.GetWindowDrawList();
 
-        // Calculate screen position (with scroll offset)
+        // Centre of the node within the (Width × Height) hit-box reserved by the layout.
         var screenX = state.PositionX + offsetX;
         var screenY = state.PositionY + offsetY;
+        var center = new Vector2(screenX + state.Width / 2f, screenY + state.Height / 2f);
 
-        // Check if mouse is hovering
         var isHovering = mouseX >= screenX && mouseX <= screenX + state.Width &&
                          mouseY >= screenY && mouseY <= screenY + state.Height;
 
-        // Animate glow effect for unlockable blessings
+        var (fillColor, rimColor, iconTint, textColor) = StyleFor(state.VisualState);
+
+        // Pulse the available seal so the eye can find it without the lime glow.
         if (state.VisualState == BlessingNodeVisualState.Unlockable)
         {
-            // Update animation time (shared across all unlockable blessings for synchronized pulse)
             _glowAnimationTime += deltaTime;
-
-            // Pulse glow alpha between 0.3 and 1.0 using sine wave
-            // Period of 2 seconds for smooth, noticeable pulsing
-            var glowAlpha = 0.5f + 0.5f * (float)Math.Sin(_glowAnimationTime * Math.PI); // 0 to 1
-
-            var glowPadding = 8f;
-            var glowPos1 = new Vector2(screenX - glowPadding, screenY - glowPadding);
-            var glowPos2 = new Vector2(screenX + state.Width + glowPadding, screenY + state.Height + glowPadding);
-            var glowColor = ColorUnlockable * new Vector4(1, 1, 1, glowAlpha * 0.4f);
-            var glowColorU32 = ImGui.ColorConvertFloat4ToU32(glowColor);
-            drawList.AddRectFilled(glowPos1, glowPos2, glowColorU32, 8f);
+            var pulse = 0.5f + 0.5f * (float)Math.Sin(_glowAnimationTime * Math.PI);
+            var glowAlpha = 0.18f + 0.22f * pulse;
+            var glowColor = ColorPalette.Gold;
+            glowColor.W = glowAlpha;
+            drawList.AddCircleFilled(center, SealRadius + 5f,
+                ImGui.ColorConvertFloat4ToU32(glowColor), 32);
         }
 
-        // Draw node background as rounded square
-        var nodePos1 = new Vector2(screenX, screenY);
-        var nodePos2 = new Vector2(screenX + state.Width, screenY + state.Height);
-        var center = new Vector2(screenX + state.Width / 2, screenY + state.Height / 2);
+        // Wax-seal disc + faded-ink rim.
+        drawList.AddCircleFilled(center, SealRadius,
+            ImGui.ColorConvertFloat4ToU32(fillColor), 32);
+        var rim = isSelected
+            ? ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold)
+            : ImGui.ColorConvertFloat4ToU32(rimColor);
+        drawList.AddCircle(center, SealRadius, rim, 32,
+            isSelected ? SelectedRimThickness : RimThickness);
 
-        var nodeColor = state.VisualState switch
+        // Hover halo — single thin gold ring, no blue tint.
+        if (isHovering && !isSelected)
         {
-            BlessingNodeVisualState.Locked => ColorLocked,
-            BlessingNodeVisualState.Unlockable => ColorUnlockable,
-            BlessingNodeVisualState.Unlocked => ColorUnlocked,
-            BlessingNodeVisualState.BranchLocked => ColorBranchLocked,
-            _ => ColorLocked
-        };
+            drawList.AddCircle(center, SealRadius + 2f,
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.5f), 32, 1f);
+        }
 
-        // Apply hover tint
-        if (isHovering) nodeColor = Vector4.Lerp(nodeColor, ColorHover, 0.3f);
-
-        var nodeColorU32 = ImGui.ColorConvertFloat4ToU32(nodeColor);
-        drawList.AddRectFilled(nodePos1, nodePos2, nodeColorU32, CornerRadius);
-
-        // Draw border
-        var borderColor = isSelected ? ColorSelected : nodeColor * 0.7f;
-        var borderColorU32 = ImGui.ColorConvertFloat4ToU32(borderColor);
-        var borderThickness = isSelected ? 3f : 2f;
-        drawList.AddRect(nodePos1, nodePos2, borderColorU32, CornerRadius, ImDrawFlags.None, borderThickness);
-
-        // Determine text color based on visual state (used for both icon and text modes)
-        var textColor = state.VisualState == BlessingNodeVisualState.Unlocked
-            ? new Vector4(0.2f, 0.15f, 0.1f, 1.0f) // Dark text on gold
-            : new Vector4(0.9f, 0.9f, 0.9f, 1.0f); // Light text on dark
-
-        // Try to load blessing icon
+        // Inner symbol — icon if registered, else initials in iron-gall ink.
         var iconTextureId = BlessingIconLoader.GetBlessingTextureId(state.Blessing);
-        var hasIcon = iconTextureId != IntPtr.Zero;
-
-        // Debug logging
-        var debugIconName = state.Blessing?.IconName ?? "null";
-        var debugBlessingName = state.Blessing?.Name ?? "unknown";
-        Debug.WriteLine(
-            $"[BlessingIcon] Blessing: {debugBlessingName}, IconName: '{debugIconName}', HasIcon: {hasIcon}, TextureId: {iconTextureId}");
-
-        if (hasIcon)
+        if (iconTextureId != IntPtr.Zero)
         {
-            // Draw icon centered in node
-            const float iconSize = 48f;
-            var iconPos = new Vector2(
-                center.X - iconSize / 2,
-                center.Y - iconSize / 2
-            );
-            var iconMin = iconPos;
-            var iconMax = new Vector2(iconPos.X + iconSize, iconPos.Y + iconSize);
-
-            // Apply color tint based on state
-            var iconTint = state.VisualState switch
-            {
-                BlessingNodeVisualState.Unlocked => new Vector4(1f, 1f, 1f, 1f), // Full color
-                BlessingNodeVisualState.Unlockable => new Vector4(0.9f, 1f, 0.9f, 1f), // Slight green tint
-                BlessingNodeVisualState.BranchLocked => new Vector4(0.5f, 0.3f, 0.3f, 0.6f), // Red-tinted and dimmed
-                _ => new Vector4(0.6f, 0.6f, 0.6f, 0.7f) // Desaturated/dimmed for locked
-            };
-            var iconTintU32 = ImGui.ColorConvertFloat4ToU32(iconTint);
-
-            drawList.AddImage(iconTextureId, iconMin, iconMax, Vector2.Zero, Vector2.One, iconTintU32);
+            var iconMin = new Vector2(center.X - IconSize / 2f, center.Y - IconSize / 2f);
+            var iconMax = new Vector2(iconMin.X + IconSize, iconMin.Y + IconSize);
+            drawList.AddImage(iconTextureId, iconMin, iconMax,
+                Vector2.Zero, Vector2.One,
+                ImGui.ColorConvertFloat4ToU32(iconTint));
         }
         else
         {
-            // Fallback: Show initials (first 2-3 letters)
-            var blessingName = state.Blessing!.Name;
-            var initials = blessingName.Length <= 3 ? blessingName : blessingName.Substring(0, 3);
-            const float fontSize = TableHeader; // Larger font for initials
-
-            var textSize = ImGui.CalcTextSize(initials);
-            var textPos = new Vector2(
-                center.X - textSize.X / 2,
-                center.Y - textSize.Y / 2
-            );
-
-            var textColorU32 = ImGui.ColorConvertFloat4ToU32(textColor);
-            drawList.AddText(ImGui.GetFont(), fontSize, textPos, textColorU32, initials);
+            var name = state.Blessing?.Name ?? string.Empty;
+            var initials = name.Length switch
+            {
+                0 => "?",
+                1 => name,
+                2 => name,
+                _ => name.Substring(0, 2)
+            };
+            initials = initials.ToUpperInvariant();
+            var size = ImGui.CalcTextSize(initials);
+            var pos = new Vector2(center.X - size.X / 2f, center.Y - size.Y / 2f);
+            drawList.AddText(ImGui.GetFont(), Body, pos,
+                ImGui.ColorConvertFloat4ToU32(textColor), initials);
         }
 
-        // Draw tier indicator (small number at bottom)
-        var tierText = $"T{state.Tier}";
-        var tierSize = ImGui.CalcTextSize(tierText);
-        var tierPos = new Vector2(
-            center.X - tierSize.X / 2,
-            screenY + state.Height - tierSize.Y - 4f
-        );
-        var tierColorU32 = ImGui.ColorConvertFloat4ToU32(textColor * 0.7f);
-        drawList.AddText(ImGui.GetFont(), Compact, tierPos, tierColorU32, tierText);
+        // Blessing name caption below the seal so the tree reads like a labelled diagram.
+        var caption = state.Blessing?.Name ?? string.Empty;
+        if (!string.IsNullOrEmpty(caption))
+        {
+            var captionSize = ImGui.CalcTextSize(caption);
+            var captionPos = new Vector2(
+                center.X - captionSize.X / 2f,
+                center.Y + SealRadius + 6f);
+            var captionColor = state.VisualState switch
+            {
+                BlessingNodeVisualState.Unlocked => ColorPalette.Gold,
+                BlessingNodeVisualState.Unlockable => ColorPalette.White,
+                _ => ColorPalette.MutedText
+            };
+            drawList.AddText(ImGui.GetFont(), Compact, captionPos,
+                ImGui.ColorConvertFloat4ToU32(captionColor), caption);
+        }
 
         return isHovering;
     }
 
     /// <summary>
-    ///     Draw connection line between prerequisite nodes
+    /// Draw the prerequisite connection between two seals. Single sepia ink
+    /// stroke for met chains; faded ink for unmet ones. No arrowhead — flow
+    /// is implied by tier (top → bottom).
     /// </summary>
     public static void DrawConnectionLine(
         BlessingNodeState fromNode,
@@ -177,55 +134,46 @@ internal static class BlessingNodeRenderer
     {
         var drawList = ImGui.GetWindowDrawList();
 
-        // Calculate centers of both nodes (with scroll offset)
         var fromCenter = new Vector2(
-            fromNode.PositionX + fromNode.Width / 2 + offsetX,
-            fromNode.PositionY + fromNode.Height / 2 + offsetY
-        );
-
+            fromNode.PositionX + fromNode.Width / 2f + offsetX,
+            fromNode.PositionY + fromNode.Height / 2f + offsetY);
         var toCenter = new Vector2(
-            toNode.PositionX + toNode.Width / 2 + offsetX,
-            toNode.PositionY + toNode.Height / 2 + offsetY
-        );
+            toNode.PositionX + toNode.Width / 2f + offsetX,
+            toNode.PositionY + toNode.Height / 2f + offsetY);
 
-        // Line color based on unlock status
-        Vector4 lineColor;
-        if (toNode.IsUnlocked)
-            lineColor = ColorUnlocked * 0.6f; // Gold for unlocked chains
-        else if (fromNode.IsUnlocked)
-            lineColor = ColorUnlockable * 0.6f; // Green if prerequisite unlocked
-        else
-            lineColor = ColorLocked * 0.5f; // Grey for locked chains
+        var color = toNode.IsUnlocked
+            ? ColorPalette.Gold * 0.7f
+            : (fromNode.IsUnlocked ? ColorPalette.Grey : ColorPalette.BorderColor * 0.7f);
 
-        var lineColorU32 = ImGui.ColorConvertFloat4ToU32(lineColor);
-        drawList.AddLine(fromCenter, toCenter, lineColorU32, 2f);
-
-        // Draw small arrow head at destination
-        DrawArrowHead(drawList, fromCenter, toCenter, lineColorU32);
+        drawList.AddLine(fromCenter, toCenter,
+            ImGui.ColorConvertFloat4ToU32(color), 1.25f);
     }
 
-    /// <summary>
-    ///     Draw small arrow head pointing from source to destination
-    /// </summary>
-    private static void DrawArrowHead(ImDrawListPtr drawList, Vector2 from, Vector2 to, uint color)
+    private static (Vector4 Fill, Vector4 Rim, Vector4 IconTint, Vector4 Text) StyleFor(
+        BlessingNodeVisualState visual)
     {
-        const float arrowSize = 6f;
-        const float arrowAngle = 0.4f; // radians
-
-        // Calculate direction vector
-        var direction = Vector2.Normalize(to - from);
-
-        // Calculate arrow points
-        var angle = (float)Math.Atan2(direction.Y, direction.X);
-        var arrowPoint1 = to - new Vector2(
-            (float)Math.Cos(angle - arrowAngle) * arrowSize,
-            (float)Math.Sin(angle - arrowAngle) * arrowSize
-        );
-        var arrowPoint2 = to - new Vector2(
-            (float)Math.Cos(angle + arrowAngle) * arrowSize,
-            (float)Math.Sin(angle + arrowAngle) * arrowSize
-        );
-
-        drawList.AddTriangleFilled(to, arrowPoint1, arrowPoint2, color);
+        return visual switch
+        {
+            BlessingNodeVisualState.Unlocked => (
+                ColorPalette.Gold,            // gilt wax fill
+                ColorPalette.Gold * 0.7f,     // darker gold rim
+                new Vector4(1f, 1f, 1f, 1f),  // full-colour icon
+                ColorPalette.White),          // iron-gall ink initials
+            BlessingNodeVisualState.Unlockable => (
+                ColorPalette.Background,                          // parchment fill
+                ColorPalette.Gold,                                // gilt-ink rim invites
+                new Vector4(0.95f, 0.85f, 0.55f, 1f),             // warm tinted icon
+                ColorPalette.White),
+            BlessingNodeVisualState.BranchLocked => (
+                ColorPalette.Background,
+                ColorPalette.Vermilion,                           // rubric red rim
+                new Vector4(0.5f, 0.3f, 0.3f, 0.6f),
+                ColorPalette.MutedText),
+            _ => (
+                ColorPalette.Background,
+                ColorPalette.BorderColor,                         // faded ink rim
+                new Vector4(0.6f, 0.55f, 0.45f, 0.7f),
+                ColorPalette.MutedText)
+        };
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTabRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTabRenderer.cs
@@ -131,11 +131,14 @@ internal static class BlessingTabRenderer
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
 
-        // --- "Of {Patron}" — bare heading, no parenthetical annotation (issue #335).
+        // --- "Of {Patron}" heading + right-aligned favor balance (matches vows page).
         var patronHeading = LocalizationService.Instance.Get(
             LocalizationKeys.UI_BLESSING_PAGE_PATRON_HEADING, headingName);
-        TextRenderer.DrawLabel(drawList, patronHeading,
-            vm.X + Padding, topY, SubsectionLabel, ColorPalette.Gold);
+        var favorBalance = LocalizationService.Instance.Get(
+            LocalizationKeys.UI_BLESSING_FAVOR_BALANCE, vm.PlayerFavor);
+        ChromeRenderer.DrawLeader(drawList, patronHeading, favorBalance,
+            vm.X + Padding, topY, contentWidth - Padding * 2,
+            labelColor: ColorPalette.Gold, valueColor: ColorPalette.White);
         topY += LeaderRowHeight + 4f;
 
         // --- Deity sub-index (selector strip, glyph primitives) — horizontally centered.
@@ -146,9 +149,8 @@ internal static class BlessingTabRenderer
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
 
-        // --- Tree pane (personal only). Favor balance header stays at the top of the pane.
-        var balanceText = LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_FAVOR_BALANCE,
-            vm.PlayerFavor);
+        // --- Tree pane (personal only). Favor balance moved into the patron-heading
+        // leader row above; no dark panel header on the tree itself.
         var treeVm = new BlessingTreeViewModel(
             vm.PlayerTreeScrollState,
             vm.PlayerBlessingStates,
@@ -156,9 +158,9 @@ internal static class BlessingTabRenderer
             vm.DeltaTime,
             vm.SelectedBlessingId,
             PanelId: "blessing_tree_player",
-            PanelLabel: LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_TREE_PLAYER_PANEL),
-            BalanceText: balanceText,
-            ShowBalanceHeader: true
+            PanelLabel: string.Empty,
+            BalanceText: string.Empty,
+            ShowBalanceHeader: false
         );
         var treeResult = BlessingTreeRenderer.Draw(treeVm);
 

--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTreeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTreeRenderer.cs
@@ -147,9 +147,13 @@ internal static class BlessingTreeRenderer
         ImGui.SetCursorScreenPos(new Vector2(x, y));
 
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(padding, padding));
-        ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.1f, 0.08f, 0.06f, 0.5f));
+        ImGui.PushStyleVar(ImGuiStyleVar.ChildBorderSize, 0f);
+        // Transparent child: the parchment chapter background shows through. No
+        // dark child fill — that broke the codex feel and forced node colours
+        // to fight a dark surround.
+        ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0f, 0f, 0f, 0f));
 
-        ImGui.BeginChild(panelId, new Vector2(width, height), true,
+        ImGui.BeginChild(panelId, new Vector2(width, height), false,
             ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.AlwaysVerticalScrollbar);
 
         ImGui.Dummy(new Vector2(totalWidth + padding * 2, totalHeight + padding * 2));
@@ -204,7 +208,7 @@ internal static class BlessingTreeRenderer
 
         ImGui.EndChild();
         ImGui.PopStyleColor();
-        ImGui.PopStyleVar();
+        ImGui.PopStyleVar(2);
         return (scrollX, scrollY, hoveringBlessingId, clickedBlessingId, doubleClickedBlessingId);
     }
 


### PR DESCRIPTION
## Summary
Alternative to the leader-row redesign in #398. Keep the existing node-graph tree on **III.ii Blessings** and **I.iii Vows of the Order** so the prereq topology stays visible, but restyle the panel and nodes to fit the codex ledger language.

Refs #399. Comparison branch to #398.

## Changes
- **`BlessingTreeRenderer`** — drops the dark child fill and child border. The parchment chapter background now shows through the tree pane.
- **`BlessingNodeRenderer`** — full rewrite:
  - Round wax-seal medallions (`SealRadius` 22) replace 64×64 rounded squares.
  - Palette: `Gold` (unlocked), parchment + gold rim (available, with subtle gold pulse), parchment + `BorderColor` rim (locked), parchment + `Vermilion` rim (branch-locked). All on parchment, no lime/blue/firebrick.
  - Selected = thicker gold rim; hover = thin gold halo (no blue tint).
  - Inner: blessing icon (or initials in iron-gall ink) — tier number removed (vertical position carries that).
  - Caption: blessing name beneath the seal in `Compact` font, coloured by state.
- **`BlessingNodeRenderer.DrawConnectionLine`** — single sepia stroke at 1.25 px, no arrowhead. Met-prereq chains drift gold, unmet chains stay faded ink.
- **`BlessingTabRenderer`** — drop the dark balance header on the player tree; favor balance moves into the "Of {Patron}" leader row (same shape as the vows page).

## Test plan
- [x] Open Blessings page — tree sits on parchment, seals visible, no dark panel.
- [x] Available blessing pulses gold subtly; hover shows a thin gold halo.
- [x] Selecting + double-clicking still inscribes (interaction unchanged).
- [x] Branch-locked blessing shows vermilion rim.
- [x] Vows page picks up the same styling automatically.
- [x] Tooltip still appears on hover (no renderer changes touched it).