### PR TITLE
feat(civ): capital name + optional holy-site binding (MVP)

### DIFF
--- a/DivineAscension.Tests/Systems/CivilizationCapitalTests.cs
+++ b/DivineAscension.Tests/Systems/CivilizationCapitalTests.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Data;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Tests.Helpers;
+using Moq;
+
+namespace DivineAscension.Tests.Systems;
+
+/// <summary>
+///     Tests for the civilization capital (CapitalName + optional CapitalHolySiteId binding)
+///     introduced by #370/#394. Covers founder gating, eligibility check, save/load default,
+///     and the two cascade rules (site destroyed, religion leaves civ).
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class CivilizationCapitalTests
+{
+    private readonly CivilizationManager _civ;
+    private readonly Mock<IHolySiteManager> _holySites = new();
+    private readonly Mock<ILoggerWrapper> _logger = new();
+    private readonly Mock<IReligionManager> _religions = new();
+    private readonly FakeEventService _events = new();
+    private readonly FakePersistenceService _persistence = new();
+    private readonly FakeWorldService _world = new();
+
+    public CivilizationCapitalTests()
+    {
+        _civ = new CivilizationManager(_logger.Object, _events, _persistence, _world, _religions.Object);
+        _civ.SetHolySiteManager(_holySites.Object);
+    }
+
+    private Civilization CreateCivWithReligion(string founderUid, string religionId, string civName = "Realm")
+    {
+        var religion = TestFixtures.CreateTestReligion(religionId, "R", DeityDomain.Craft, "D", founderUid);
+        _religions.Setup(r => r.GetReligion(religionId)).Returns(religion);
+        return _civ.CreateCivilization(civName, founderUid, religionId)!;
+    }
+
+    [Fact]
+    public void CreateCivilization_AutoDefaultsCapitalName()
+    {
+        var civ = CreateCivWithReligion("u1", "r1", "Iron Realm");
+        Assert.Equal("Iron Realm Seat", civ.CapitalName);
+        Assert.Null(civ.CapitalHolySiteId);
+    }
+
+    [Fact]
+    public void SetCapital_FounderRenamesWithoutBinding_Succeeds()
+    {
+        var civ = CreateCivWithReligion("u1", "r1");
+
+        var ok = _civ.SetCapital(civ.CivId, "u1", "High Hold", null);
+
+        Assert.True(ok);
+        Assert.Equal("High Hold", civ.CapitalName);
+        Assert.Null(civ.CapitalHolySiteId);
+    }
+
+    [Fact]
+    public void SetCapital_NonFounderRejected()
+    {
+        var civ = CreateCivWithReligion("u1", "r1");
+
+        var ok = _civ.SetCapital(civ.CivId, "stranger", "Usurped Hold", null);
+
+        Assert.False(ok);
+        Assert.NotEqual("Usurped Hold", civ.CapitalName);
+    }
+
+    [Fact]
+    public void SetCapital_BindsMemberReligionSite_Succeeds()
+    {
+        var civ = CreateCivWithReligion("u1", "r1");
+        var site = new HolySiteData { SiteUID = "s1", ReligionUID = "r1", SiteName = "Forge" };
+        _holySites.Setup(h => h.GetHolySite("s1")).Returns(site);
+
+        var ok = _civ.SetCapital(civ.CivId, "u1", "Forge Seat", "s1");
+
+        Assert.True(ok);
+        Assert.Equal("s1", civ.CapitalHolySiteId);
+    }
+
+    [Fact]
+    public void SetCapital_NonMemberReligionSite_Rejected()
+    {
+        var civ = CreateCivWithReligion("u1", "r1");
+        var site = new HolySiteData { SiteUID = "s1", ReligionUID = "outsider", SiteName = "Foreign Altar" };
+        _holySites.Setup(h => h.GetHolySite("s1")).Returns(site);
+
+        var ok = _civ.SetCapital(civ.CivId, "u1", "Bad Bind", "s1");
+
+        Assert.False(ok);
+        Assert.Null(civ.CapitalHolySiteId);
+    }
+
+    [Fact]
+    public void SetCapital_EmptyName_Rejected()
+    {
+        var civ = CreateCivWithReligion("u1", "r1");
+
+        var ok = _civ.SetCapital(civ.CivId, "u1", "   ", null);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void HolySiteRemoved_ClearsBinding_KeepsName()
+    {
+        var civ = CreateCivWithReligion("u1", "r1");
+        var site = new HolySiteData { SiteUID = "s1", ReligionUID = "r1", SiteName = "Forge" };
+        _holySites.Setup(h => h.GetHolySite("s1")).Returns(site);
+        _civ.SetCapital(civ.CivId, "u1", "Forge Seat", "s1");
+
+        _holySites.Raise(h => h.OnHolySiteRemoved += null, "r1", "s1");
+
+        Assert.Null(civ.CapitalHolySiteId);
+        Assert.Equal("Forge Seat", civ.CapitalName);
+    }
+
+    [Fact]
+    public void ReligionLeavesCiv_ClearsBindingIfOwned_KeepsName()
+    {
+        // Founder has r1; invite + accept r2; bind capital to r2's site; r2 leaves.
+        var founderUid = "u1";
+        var civ = CreateCivWithReligion(founderUid, "r1");
+
+        // r2 setup
+        var r2Founder = "u2";
+        var r2 = TestFixtures.CreateTestReligion("r2", "R2", DeityDomain.Wild, "D2", r2Founder);
+        _religions.Setup(r => r.GetReligion("r2")).Returns(r2);
+        _religions.Setup(r => r.GetPlayerReligion(r2Founder)).Returns(r2);
+
+        // Add r2 to the civ via internal data path (bypass invite plumbing)
+        civ.AddReligion("r2");
+
+        var site = new HolySiteData { SiteUID = "s2", ReligionUID = "r2", SiteName = "Grove" };
+        _holySites.Setup(h => h.GetHolySite("s2")).Returns(site);
+        Assert.True(_civ.SetCapital(civ.CivId, founderUid, "Grove Seat", "s2"));
+
+        // r2 leaves
+        Assert.True(_civ.LeaveReligion("r2", r2Founder));
+
+        Assert.Null(civ.CapitalHolySiteId);
+        Assert.Equal("Grove Seat", civ.CapitalName);
+    }
+}

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -520,6 +520,9 @@ public static class LocalizationKeys
     public const string UI_CIVILIZATION_DETAIL_ETHOS =
         "divineascension:ui.civilization.detail.ethos";
 
+    public const string UI_CIVILIZATION_DETAIL_SEAT =
+        "divineascension:ui.civilization.detail.seat";
+
     public const string UI_CIVILIZATION_DETAIL_MEMBER_ORDERS =
         "divineascension:ui.civilization.detail.member_orders";
 
@@ -1779,6 +1782,10 @@ public static class LocalizationKeys
     public const string NET_CIV_DESCRIPTION_UPDATE_FAILED = "divineascension:net.civ.description_update_failed";
     public const string NET_CIV_DESCRIPTION_TOO_LONG = "divineascension:net.civ.description_too_long";
     public const string NET_CIV_DESCRIPTION_PROFANITY = "divineascension:net.civ.description_profanity";
+    public const string NET_CIV_CAPITAL_UPDATED = "divineascension:net.civ.capital_updated";
+    public const string NET_CIV_CAPITAL_UPDATE_FAILED = "divineascension:net.civ.capital_update_failed";
+    public const string NET_CIV_CAPITAL_NAME_INVALID = "divineascension:net.civ.capital_name_invalid";
+    public const string NET_CIV_CAPITAL_NAME_PROFANITY = "divineascension:net.civ.capital_name_profanity";
     public const string NET_CIV_UNKNOWN_ACTION = "divineascension:net.civ.unknown_action";
     public const string NET_CIV_ERROR = "divineascension:net.civ.error";
 
@@ -1911,6 +1918,8 @@ public static class LocalizationKeys
 
     // Header row labels for the civ info chapter.
     public const string UI_CIVILIZATION_INFO_ETHOS = "divineascension:ui.civilization.info.ethos";
+    public const string UI_CIVILIZATION_INFO_SEAT = "divineascension:ui.civilization.info.seat";
+    public const string UI_CIVILIZATION_INFO_CAPITAL_NONE = "divineascension:ui.civilization.info.capital_none";
 
     #endregion
 }

--- a/DivineAscension/Data/CivilizationData.cs
+++ b/DivineAscension/Data/CivilizationData.cs
@@ -174,6 +174,22 @@ public class Civilization
     public string FounderEpithet { get; set; } = string.Empty;
 
     /// <summary>
+    ///     Display name of the civilization's seat. Auto-defaults to "{Name} Seat" at
+    ///     founding; founder may edit later. Empty for legacy saves — repair on load.
+    /// </summary>
+    [ProtoMember(17)]
+    public string CapitalName { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Optional binding to a holy site owned by one of the civ's member religions.
+    ///     Null means unbound. Cleared automatically when the site is destroyed or
+    ///     the owning religion leaves the civilization; <see cref="CapitalName" /> is
+    ///     preserved in both cascades.
+    /// </summary>
+    [ProtoMember(18)]
+    public string? CapitalHolySiteId { get; set; }
+
+    /// <summary>
     ///     Checks if the civilization has a valid number of member religions (1-4)
     /// </summary>
     public bool IsValid

--- a/DivineAscension/GUI/Events/Civilization/InfoEvent.cs
+++ b/DivineAscension/GUI/Events/Civilization/InfoEvent.cs
@@ -18,6 +18,16 @@ public abstract record InfoEvent
 
     public sealed record SaveDescriptionClicked : InfoEvent;
 
+    public sealed record EditCapitalOpen : InfoEvent;
+
+    public sealed record EditCapitalCancel : InfoEvent;
+
+    public sealed record CapitalNameChanged(string text) : InfoEvent;
+
+    public sealed record CapitalBindingChanged(string siteId) : InfoEvent;
+
+    public sealed record SaveCapitalClicked : InfoEvent;
+
     public sealed record LeaveClicked : InfoEvent;
 
     public sealed record EditIconClicked : InfoEvent;

--- a/DivineAscension/GUI/Events/Civilization/InfoEvent.cs
+++ b/DivineAscension/GUI/Events/Civilization/InfoEvent.cs
@@ -28,6 +28,8 @@ public abstract record InfoEvent
 
     public sealed record SaveCapitalClicked : InfoEvent;
 
+    public sealed record ToggleCapitalSiteDropdown(bool isOpen) : InfoEvent;
+
     public sealed record LeaveClicked : InfoEvent;
 
     public sealed record EditIconClicked : InfoEvent;

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -661,6 +661,7 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
             State.InfoState.IsEditingCapital,
             State.InfoState.CapitalNameText,
             State.InfoState.CapitalBindingText,
+            State.InfoState.IsCapitalSiteDropdownOpen,
             State.HolySitesState.Browse.SitesByReligion,
             memberReligions,
             civ?.PendingInvites ?? new List<CivilizationInfoResponsePacket.PendingInvite>(),
@@ -1164,6 +1165,7 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
 
                 case InfoEvent.EditCapitalCancel:
                     State.InfoState.IsEditingCapital = false;
+                    State.InfoState.IsCapitalSiteDropdownOpen = false;
                     State.InfoState.CapitalNameText = civ?.CapitalName ?? string.Empty;
                     State.InfoState.CapitalBindingText = civ?.CapitalHolySiteId ?? string.Empty;
                     break;
@@ -1176,6 +1178,10 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
                     State.InfoState.CapitalBindingText = cbc.siteId ?? string.Empty;
                     break;
 
+                case InfoEvent.ToggleCapitalSiteDropdown tcd:
+                    State.InfoState.IsCapitalSiteDropdownOpen = tcd.isOpen;
+                    break;
+
                 case InfoEvent.SaveCapitalClicked:
                     if (!string.IsNullOrWhiteSpace(civId))
                     {
@@ -1184,6 +1190,7 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
                     }
 
                     State.InfoState.IsEditingCapital = false;
+                    State.InfoState.IsCapitalSiteDropdownOpen = false;
                     break;
 
                 case InfoEvent.LeaveClicked:

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -302,11 +302,13 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     ///     Request a civilization action (create, invite, accept, leave, kick, disband, updateicon, setdescription)
     /// </summary>
     public void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "", int ethos = -1)
+        string icon = "", string description = "", int ethos = -1,
+        string capitalName = "", string holySiteId = "")
     {
         // Clear transient action error; some actions will trigger refreshes
         State.LastActionError = null;
-        _uiService.RequestCivilizationAction(action, civId, targetId, name, icon, description, ethos);
+        _uiService.RequestCivilizationAction(action, civId, targetId, name, icon, description, ethos, capitalName,
+            holySiteId);
     }
 
     /// <summary>
@@ -598,6 +600,8 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
             details?.MemberReligions ?? new List<CivilizationInfoResponsePacket.MemberReligion>(),
             details?.CreatedDate ?? DateTime.MinValue,
             details?.Description ?? string.Empty,
+            details?.CapitalName ?? string.Empty,
+            details?.CapitalHolySiteId ?? string.Empty,
             State.DetailState.MemberScrollY,
             !HasCivilization() && (details?.MemberReligions?.Count ?? 0) < 4,
             x,
@@ -652,6 +656,12 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
             civ?.Rank ?? 0,
             civ?.Ethos ?? 0,
             civ?.FounderEpithet ?? string.Empty,
+            civ?.CapitalName ?? string.Empty,
+            civ?.CapitalHolySiteId ?? string.Empty,
+            State.InfoState.IsEditingCapital,
+            State.InfoState.CapitalNameText,
+            State.InfoState.CapitalBindingText,
+            State.HolySitesState.Browse.SitesByReligion,
             memberReligions,
             civ?.PendingInvites ?? new List<CivilizationInfoResponsePacket.PendingInvite>(),
             State.InfoState.InviteReligionName ?? string.Empty,
@@ -1141,6 +1151,39 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
                     }
 
                     State.InfoState.IsEditingDescription = false;
+                    break;
+
+                case InfoEvent.EditCapitalOpen:
+                    State.InfoState.IsEditingCapital = true;
+                    State.InfoState.CapitalNameText = civ?.CapitalName ?? string.Empty;
+                    State.InfoState.CapitalBindingText = civ?.CapitalHolySiteId ?? string.Empty;
+                    // Lazy-fetch eligible holy sites if not already loaded
+                    if (State.HolySitesState.Browse.SitesByReligion.Count == 0)
+                        RequestCivilizationHolySites();
+                    break;
+
+                case InfoEvent.EditCapitalCancel:
+                    State.InfoState.IsEditingCapital = false;
+                    State.InfoState.CapitalNameText = civ?.CapitalName ?? string.Empty;
+                    State.InfoState.CapitalBindingText = civ?.CapitalHolySiteId ?? string.Empty;
+                    break;
+
+                case InfoEvent.CapitalNameChanged cnc:
+                    State.InfoState.CapitalNameText = cnc.text;
+                    break;
+
+                case InfoEvent.CapitalBindingChanged cbc:
+                    State.InfoState.CapitalBindingText = cbc.siteId ?? string.Empty;
+                    break;
+
+                case InfoEvent.SaveCapitalClicked:
+                    if (!string.IsNullOrWhiteSpace(civId))
+                    {
+                        RequestCivilizationAction("setcapital", civId, "", "", "", "", -1,
+                            State.InfoState.CapitalNameText, State.InfoState.CapitalBindingText);
+                    }
+
+                    State.InfoState.IsEditingCapital = false;
                     break;
 
                 case InfoEvent.LeaveClicked:

--- a/DivineAscension/GUI/Models/Civilization/Detail/CivilizationDetailViewModel.cs
+++ b/DivineAscension/GUI/Models/Civilization/Detail/CivilizationDetailViewModel.cs
@@ -16,6 +16,8 @@ public readonly struct CivilizationDetailViewModel(
     IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> memberReligions,
     DateTime createdDate,
     string description,
+    string capitalName,
+    string capitalHolySiteId,
     float memberScrollY,
     bool canRequestToJoin,
     float x,
@@ -34,6 +36,9 @@ public readonly struct CivilizationDetailViewModel(
     public IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> MemberReligions { get; } = memberReligions;
     public DateTime CreatedDate { get; } = createdDate;
     public string Description { get; } = description;
+    public string CapitalName { get; } = capitalName;
+    public string CapitalHolySiteId { get; } = capitalHolySiteId;
+    public bool HasCapitalBinding => !string.IsNullOrEmpty(CapitalHolySiteId);
     public float MemberScrollY { get; } = memberScrollY;
     public bool CanRequestToJoin { get; } = canRequestToJoin;
     public float X { get; } = x;

--- a/DivineAscension/GUI/Models/Civilization/Info/CivilizationInfoViewModel.cs
+++ b/DivineAscension/GUI/Models/Civilization/Info/CivilizationInfoViewModel.cs
@@ -26,6 +26,7 @@ public readonly struct CivilizationInfoViewModel(
     bool isEditingCapital,
     string capitalNameText,
     string capitalBindingText,
+    bool isCapitalSiteDropdownOpen,
     IReadOnlyDictionary<string, List<HolySiteResponsePacket.HolySiteInfo>> eligibleCapitalSites,
     IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> memberReligions,
     IReadOnlyList<CivilizationInfoResponsePacket.PendingInvite> pendingInvites,
@@ -60,6 +61,7 @@ public readonly struct CivilizationInfoViewModel(
     public bool IsEditingCapital { get; } = isEditingCapital;
     public string CapitalNameText { get; } = capitalNameText;
     public string CapitalBindingText { get; } = capitalBindingText;
+    public bool IsCapitalSiteDropdownOpen { get; } = isCapitalSiteDropdownOpen;
 
     public IReadOnlyDictionary<string, List<HolySiteResponsePacket.HolySiteInfo>> EligibleCapitalSites { get; } =
         eligibleCapitalSites;

--- a/DivineAscension/GUI/Models/Civilization/Info/CivilizationInfoViewModel.cs
+++ b/DivineAscension/GUI/Models/Civilization/Info/CivilizationInfoViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using DivineAscension.Network.Civilization;
+using DivineAscension.Network.HolySite;
 
 namespace DivineAscension.GUI.Models.Civilization.Info;
 
@@ -20,6 +21,12 @@ public readonly struct CivilizationInfoViewModel(
     int rank,
     int ethos,
     string founderEpithet,
+    string capitalName,
+    string capitalHolySiteId,
+    bool isEditingCapital,
+    string capitalNameText,
+    string capitalBindingText,
+    IReadOnlyDictionary<string, List<HolySiteResponsePacket.HolySiteInfo>> eligibleCapitalSites,
     IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> memberReligions,
     IReadOnlyList<CivilizationInfoResponsePacket.PendingInvite> pendingInvites,
     string inviteReligionName,
@@ -47,6 +54,18 @@ public readonly struct CivilizationInfoViewModel(
     public int Rank { get; } = rank;
     public int Ethos { get; } = ethos;
     public string FounderEpithet { get; } = founderEpithet;
+    public string CapitalName { get; } = capitalName;
+    public string CapitalHolySiteId { get; } = capitalHolySiteId;
+    public bool HasCapitalBinding => !string.IsNullOrEmpty(CapitalHolySiteId);
+    public bool IsEditingCapital { get; } = isEditingCapital;
+    public string CapitalNameText { get; } = capitalNameText;
+    public string CapitalBindingText { get; } = capitalBindingText;
+
+    public IReadOnlyDictionary<string, List<HolySiteResponsePacket.HolySiteInfo>> EligibleCapitalSites { get; } =
+        eligibleCapitalSites;
+
+    public bool HasCapitalChanges => CapitalName != CapitalNameText
+                                     || (CapitalHolySiteId ?? string.Empty) != (CapitalBindingText ?? string.Empty);
     public IReadOnlyList<CivilizationInfoResponsePacket.MemberReligion> MemberReligions { get; } = memberReligions;
     public IReadOnlyList<CivilizationInfoResponsePacket.PendingInvite> PendingInvites { get; } = pendingInvites;
     public string InviteReligionName { get; } = inviteReligionName;

--- a/DivineAscension/GUI/State/Civilization/InfoState.cs
+++ b/DivineAscension/GUI/State/Civilization/InfoState.cs
@@ -14,6 +14,7 @@ public class InfoState : IState
     public bool IsEditingCapital { get; set; }
     public string CapitalNameText { get; set; } = string.Empty;
     public string CapitalBindingText { get; set; } = string.Empty;
+    public bool IsCapitalSiteDropdownOpen { get; set; }
     public bool IsLoading { get; set; }
     public string? ErrorMsg { get; set; }
 
@@ -28,6 +29,7 @@ public class InfoState : IState
         IsEditingCapital = false;
         CapitalNameText = string.Empty;
         CapitalBindingText = string.Empty;
+        IsCapitalSiteDropdownOpen = false;
         IsLoading = false;
         ErrorMsg = null;
     }

--- a/DivineAscension/GUI/State/Civilization/InfoState.cs
+++ b/DivineAscension/GUI/State/Civilization/InfoState.cs
@@ -11,6 +11,9 @@ public class InfoState : IState
     public string InviteReligionName { get; set; } = string.Empty;
     public string DescriptionText { get; set; } = string.Empty;
     public bool IsEditingDescription { get; set; }
+    public bool IsEditingCapital { get; set; }
+    public string CapitalNameText { get; set; } = string.Empty;
+    public string CapitalBindingText { get; set; } = string.Empty;
     public bool IsLoading { get; set; }
     public string? ErrorMsg { get; set; }
 
@@ -22,6 +25,9 @@ public class InfoState : IState
         InviteReligionName = string.Empty;
         DescriptionText = string.Empty;
         IsEditingDescription = false;
+        IsEditingCapital = false;
+        CapitalNameText = string.Empty;
+        CapitalBindingText = string.Empty;
         IsLoading = false;
         ErrorMsg = null;
     }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
@@ -172,6 +172,12 @@ internal static class CivilizationDetailRenderer
         currentY += StatRowHeight;
 
         ChromeRenderer.DrawLeader(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_SEAT),
+            string.IsNullOrWhiteSpace(vm.CapitalName) ? "—" : vm.CapitalName,
+            vm.X, currentY, width);
+        currentY += StatRowHeight;
+
+        ChromeRenderer.DrawLeader(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_MEMBER_ORDERS,
                 vm.MemberCount),
             $"{vm.MemberCount}/4",

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -100,7 +100,9 @@ internal static class CivilizationInfoRenderer
 
         currentY = CivilizationInfoHeaderRenderer.Draw(vm, drawList, x, currentY, contentWidth);
 
-        currentY = CivilizationInfoCapitalRenderer.Draw(vm, drawList, x, currentY, contentWidth, events);
+        var (afterCapitalY, capitalLayout) =
+            CivilizationInfoCapitalRenderer.Draw(vm, drawList, x, currentY, contentWidth, events);
+        currentY = afterCapitalY;
 
         currentY = DrawDivider(drawList, x, currentY, contentWidth);
 
@@ -123,6 +125,9 @@ internal static class CivilizationInfoRenderer
 
         if (contentHeightEstimate > height)
             Scrollbar.Draw(drawList, x + width - ScrollbarWidth, y, ScrollbarWidth, height, scrollY, maxScroll);
+
+        // Capital binding dropdown menu — drawn after main content so it floats on top.
+        CivilizationInfoCapitalRenderer.DrawDropdownOverlay(vm, capitalLayout, events);
 
         DrawOverlays(vm, events);
 

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -100,6 +100,8 @@ internal static class CivilizationInfoRenderer
 
         currentY = CivilizationInfoHeaderRenderer.Draw(vm, drawList, x, currentY, contentWidth);
 
+        currentY = CivilizationInfoCapitalRenderer.Draw(vm, drawList, x, currentY, contentWidth, events);
+
         currentY = DrawDivider(drawList, x, currentY, contentWidth);
 
         currentY = CivilizationInfoDescriptionRenderer.Draw(vm, drawList, x, currentY, contentWidth, events);
@@ -270,8 +272,8 @@ internal static class CivilizationInfoRenderer
         h += PaneHeaderRenderer.TotalHeight;
         // Prose intro
         h += Body + LinePadding + 12f;
-        // Stat block (4 rows: founded, founder+epithet, founding order, ethos)
-        h += OrderRowHeight * 4 + 8f;
+        // Stat block (5 rows: founded, founder+epithet, founding order, ethos, seat)
+        h += OrderRowHeight * 5 + 8f;
 
         h += DividerHeight;
 

--- a/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoCapitalRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoCapitalRenderer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.GUI.Events.Civilization;
 using DivineAscension.GUI.Models.Civilization.Info;
@@ -8,6 +7,7 @@ using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Inputs;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Network.HolySite;
 using DivineAscension.Services;
 using ImGuiNET;
 using static DivineAscension.GUI.UI.Utilities.FontSizes;
@@ -15,9 +15,10 @@ using static DivineAscension.GUI.UI.Utilities.FontSizes;
 namespace DivineAscension.GUI.UI.Renderers.Civilization.Info;
 
 /// <summary>
-///     Founder-only inline edit affordance for the civilization's capital. Collapsed
-///     state shows nothing extra (the seat line is already rendered in the header stat
-///     block); editing mode shows a name input plus a holy-site binding picker.
+///     Founder-only inline edit affordance for the civilization's capital. The seat
+///     line is already rendered in the stat block; this renderer adds a pencil glyph
+///     when collapsed and a name input + holy-site binding dropdown when editing.
+///     Binding picker uses the shared <see cref="Dropdown" /> component.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal static class CivilizationInfoCapitalRenderer
@@ -28,10 +29,12 @@ internal static class CivilizationInfoCapitalRenderer
     private const float ButtonWidth = 80f;
     private const float ButtonGap = 8f;
     private const float SectionBottomSpacing = 8f;
-    private const float SiteRowHeight = 22f;
-    private const float MaxSitesShown = 6f;
+    private const float DropdownHeight = 32f;
+    private const float DropdownMenuItemHeight = 28f;
 
-    public static float Draw(
+    public readonly record struct CapitalEditLayout(bool HasDropdown, float DropdownX, float DropdownY, float DropdownWidth);
+
+    public static (float bottomY, CapitalEditLayout layout) Draw(
         CivilizationInfoViewModel vm,
         ImDrawListPtr drawList,
         float x,
@@ -40,7 +43,7 @@ internal static class CivilizationInfoCapitalRenderer
         List<InfoEvent> events)
     {
         if (!vm.IsFounder)
-            return y;
+            return (y, default);
 
         var currentY = y;
 
@@ -60,7 +63,7 @@ internal static class CivilizationInfoCapitalRenderer
                 EditGlyphSize - 8f,
                 ColorPalette.LightText);
 
-            return currentY + EditGlyphSize + SectionBottomSpacing;
+            return (currentY + EditGlyphSize + SectionBottomSpacing, default);
         }
 
         TextRenderer.DrawLabel(drawList,
@@ -76,12 +79,19 @@ internal static class CivilizationInfoCapitalRenderer
 
         currentY += InputHeight + 8f;
 
-        // Binding picker — flat list, "(none)" row first
-        var picked = DrawBindingList(vm, drawList, x, currentY, width, events);
-        currentY = picked;
+        var dropdownX = x;
+        var dropdownY = currentY;
+        var dropdownWidth = width;
+        var label = ResolveSelectedLabel(vm);
 
-        // Buttons
-        currentY += 6f;
+        if (Dropdown.DrawButton(drawList, dropdownX, dropdownY, dropdownWidth, DropdownHeight,
+                label, vm.IsCapitalSiteDropdownOpen))
+        {
+            events.Add(new InfoEvent.ToggleCapitalSiteDropdown(!vm.IsCapitalSiteDropdownOpen));
+        }
+
+        currentY += DropdownHeight + 8f;
+
         var rightX = x + width;
         var cancelX = rightX - ButtonWidth;
         if (ButtonRenderer.DrawButton(drawList,
@@ -105,61 +115,81 @@ internal static class CivilizationInfoCapitalRenderer
         }
 
         currentY += ButtonHeight + SectionBottomSpacing;
-        return currentY;
+        return (currentY, new CapitalEditLayout(true, dropdownX, dropdownY, dropdownWidth));
     }
 
-    private static float DrawBindingList(
+    /// <summary>
+    ///     Second-pass overlay for the binding dropdown menu — called after the
+    ///     main pane content so the menu can paint on top.
+    /// </summary>
+    public static bool DrawDropdownOverlay(
         CivilizationInfoViewModel vm,
-        ImDrawListPtr drawList,
-        float x, float y, float width,
+        CapitalEditLayout layout,
         List<InfoEvent> events)
     {
-        var currentY = y;
-        var totalSites = 0;
-        foreach (var list in vm.EligibleCapitalSites.Values)
-            totalSites += list?.Count ?? 0;
+        if (!layout.HasDropdown || !vm.IsCapitalSiteDropdownOpen)
+            return false;
 
-        var rowCount = 1 /* (none) */ + totalSites;
-        var listHeight = System.MathF.Min(rowCount, MaxSitesShown) * SiteRowHeight;
-        var listEndY = currentY + listHeight;
+        var drawList = ImGui.GetWindowDrawList();
+        var (items, ids, selectedIndex) = BuildItems(vm);
 
-        // Frame
-        drawList.AddRect(new Vector2(x, currentY), new Vector2(x + width, listEndY),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f), 0f, ImDrawFlags.None, 1f);
+        Dropdown.DrawMenuVisual(drawList, layout.DropdownX, layout.DropdownY, layout.DropdownWidth, DropdownHeight,
+            items, selectedIndex, itemHeight: DropdownMenuItemHeight);
 
-        ImGui.SetCursorScreenPos(new Vector2(x + 4f, currentY + 2f));
-        ImGui.BeginChild("##capitalBindingList", new Vector2(width - 8f, listHeight - 4f), false);
+        var (newIndex, shouldClose, consumed) = Dropdown.DrawMenuAndHandleInteraction(
+            layout.DropdownX, layout.DropdownY, layout.DropdownWidth, DropdownHeight,
+            items, selectedIndex, itemHeight: DropdownMenuItemHeight);
 
-        DrawBindingRow(drawList, events, vm.CapitalBindingText, string.Empty,
-            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_CAPITAL_NONE));
+        if (newIndex != selectedIndex && newIndex >= 0 && newIndex < ids.Count)
+            events.Add(new InfoEvent.CapitalBindingChanged(ids[newIndex]));
 
-        foreach (var (religionUid, sites) in vm.EligibleCapitalSites)
+        if (shouldClose)
+            events.Add(new InfoEvent.ToggleCapitalSiteDropdown(false));
+
+        return consumed;
+    }
+
+    private static string ResolveSelectedLabel(CivilizationInfoViewModel vm)
+    {
+        var current = vm.CapitalBindingText ?? string.Empty;
+        if (string.IsNullOrEmpty(current))
+            return LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_CAPITAL_NONE);
+
+        foreach (var (_, sites) in vm.EligibleCapitalSites)
+        {
+            if (sites == null) continue;
+            foreach (var s in sites)
+            {
+                if (s.SiteUID == current)
+                    return s.SiteName;
+            }
+        }
+
+        return current;
+    }
+
+    private static (string[] items, List<string> ids, int selectedIndex) BuildItems(CivilizationInfoViewModel vm)
+    {
+        var items = new List<string>();
+        var ids = new List<string>();
+
+        items.Add(LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_CAPITAL_NONE));
+        ids.Add(string.Empty);
+
+        foreach (var (_, sites) in vm.EligibleCapitalSites)
         {
             if (sites == null) continue;
             foreach (var site in sites)
             {
-                var label = $"{site.SiteName}";
-                DrawBindingRow(drawList, events, vm.CapitalBindingText, site.SiteUID, label);
+                items.Add(site.SiteName);
+                ids.Add(site.SiteUID);
             }
         }
 
-        ImGui.EndChild();
+        var current = vm.CapitalBindingText ?? string.Empty;
+        var idx = ids.IndexOf(current);
+        if (idx < 0) idx = 0;
 
-        return listEndY;
-    }
-
-    private static void DrawBindingRow(
-        ImDrawListPtr drawList,
-        List<InfoEvent> events,
-        string selectedSiteId,
-        string siteId,
-        string label)
-    {
-        var isSelected = (selectedSiteId ?? string.Empty) == (siteId ?? string.Empty);
-        var prefix = isSelected ? "* " : "  ";
-        if (ImGui.Selectable(prefix + label, isSelected, ImGuiSelectableFlags.None, new Vector2(0, SiteRowHeight - 4f)))
-        {
-            events.Add(new InfoEvent.CapitalBindingChanged(siteId ?? string.Empty));
-        }
+        return (items.ToArray(), ids, idx);
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoCapitalRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoCapitalRenderer.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.Constants;
+using DivineAscension.GUI.Events.Civilization;
+using DivineAscension.GUI.Models.Civilization.Info;
+using DivineAscension.GUI.UI.Components.Buttons;
+using DivineAscension.GUI.UI.Components.Inputs;
+using DivineAscension.GUI.UI.Renderers.Utilities;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Services;
+using ImGuiNET;
+using static DivineAscension.GUI.UI.Utilities.FontSizes;
+
+namespace DivineAscension.GUI.UI.Renderers.Civilization.Info;
+
+/// <summary>
+///     Founder-only inline edit affordance for the civilization's capital. Collapsed
+///     state shows nothing extra (the seat line is already rendered in the header stat
+///     block); editing mode shows a name input plus a holy-site binding picker.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class CivilizationInfoCapitalRenderer
+{
+    private const float EditGlyphSize = 20f;
+    private const float InputHeight = 26f;
+    private const float ButtonHeight = 26f;
+    private const float ButtonWidth = 80f;
+    private const float ButtonGap = 8f;
+    private const float SectionBottomSpacing = 8f;
+    private const float SiteRowHeight = 22f;
+    private const float MaxSitesShown = 6f;
+
+    public static float Draw(
+        CivilizationInfoViewModel vm,
+        ImDrawListPtr drawList,
+        float x,
+        float y,
+        float width,
+        List<InfoEvent> events)
+    {
+        if (!vm.IsFounder)
+            return y;
+
+        var currentY = y;
+
+        if (!vm.IsEditingCapital)
+        {
+            var glyphX = x + width - EditGlyphSize;
+            if (ButtonRenderer.DrawButton(drawList, string.Empty,
+                    glyphX, currentY,
+                    EditGlyphSize, EditGlyphSize,
+                    isPrimary: false, enabled: true))
+            {
+                events.Add(new InfoEvent.EditCapitalOpen());
+            }
+            ChromeRenderer.DrawPencil(drawList,
+                glyphX + EditGlyphSize / 2f,
+                currentY + EditGlyphSize / 2f,
+                EditGlyphSize - 8f,
+                ColorPalette.LightText);
+
+            return currentY + EditGlyphSize + SectionBottomSpacing;
+        }
+
+        TextRenderer.DrawLabel(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_SEAT),
+            x, currentY, SubsectionLabel, ColorPalette.Gold);
+        currentY += SubsectionLabel + 6f;
+
+        var newName = TextInput.Draw(drawList, "##civCapitalName",
+            vm.CapitalNameText, x, currentY, width, InputHeight,
+            placeholder: string.Empty, maxLength: 64);
+        if (newName != vm.CapitalNameText)
+            events.Add(new InfoEvent.CapitalNameChanged(newName));
+
+        currentY += InputHeight + 8f;
+
+        // Binding picker — flat list, "(none)" row first
+        var picked = DrawBindingList(vm, drawList, x, currentY, width, events);
+        currentY = picked;
+
+        // Buttons
+        currentY += 6f;
+        var rightX = x + width;
+        var cancelX = rightX - ButtonWidth;
+        if (ButtonRenderer.DrawButton(drawList,
+                LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_CANCEL),
+                cancelX, currentY, ButtonWidth, ButtonHeight,
+                isPrimary: false, enabled: true))
+        {
+            events.Add(new InfoEvent.EditCapitalCancel());
+        }
+
+        if (vm.HasCapitalChanges)
+        {
+            var saveX = cancelX - ButtonGap - ButtonWidth;
+            if (ButtonRenderer.DrawButton(drawList,
+                    LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_SAVE),
+                    saveX, currentY, ButtonWidth, ButtonHeight,
+                    isPrimary: true, enabled: true))
+            {
+                events.Add(new InfoEvent.SaveCapitalClicked());
+            }
+        }
+
+        currentY += ButtonHeight + SectionBottomSpacing;
+        return currentY;
+    }
+
+    private static float DrawBindingList(
+        CivilizationInfoViewModel vm,
+        ImDrawListPtr drawList,
+        float x, float y, float width,
+        List<InfoEvent> events)
+    {
+        var currentY = y;
+        var totalSites = 0;
+        foreach (var list in vm.EligibleCapitalSites.Values)
+            totalSites += list?.Count ?? 0;
+
+        var rowCount = 1 /* (none) */ + totalSites;
+        var listHeight = System.MathF.Min(rowCount, MaxSitesShown) * SiteRowHeight;
+        var listEndY = currentY + listHeight;
+
+        // Frame
+        drawList.AddRect(new Vector2(x, currentY), new Vector2(x + width, listEndY),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f), 0f, ImDrawFlags.None, 1f);
+
+        ImGui.SetCursorScreenPos(new Vector2(x + 4f, currentY + 2f));
+        ImGui.BeginChild("##capitalBindingList", new Vector2(width - 8f, listHeight - 4f), false);
+
+        DrawBindingRow(drawList, events, vm.CapitalBindingText, string.Empty,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_CAPITAL_NONE));
+
+        foreach (var (religionUid, sites) in vm.EligibleCapitalSites)
+        {
+            if (sites == null) continue;
+            foreach (var site in sites)
+            {
+                var label = $"{site.SiteName}";
+                DrawBindingRow(drawList, events, vm.CapitalBindingText, site.SiteUID, label);
+            }
+        }
+
+        ImGui.EndChild();
+
+        return listEndY;
+    }
+
+    private static void DrawBindingRow(
+        ImDrawListPtr drawList,
+        List<InfoEvent> events,
+        string selectedSiteId,
+        string siteId,
+        string label)
+    {
+        var isSelected = (selectedSiteId ?? string.Empty) == (siteId ?? string.Empty);
+        var prefix = isSelected ? "* " : "  ";
+        if (ImGui.Selectable(prefix + label, isSelected, ImGuiSelectableFlags.None, new Vector2(0, SiteRowHeight - 4f)))
+        {
+            events.Add(new InfoEvent.CapitalBindingChanged(siteId ?? string.Empty));
+        }
+    }
+}

--- a/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoHeaderRenderer.cs
@@ -101,6 +101,12 @@ internal static class CivilizationInfoHeaderRenderer
             x, currentY, width);
         currentY += StatRowHeight;
 
+        ChromeRenderer.DrawLeader(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_SEAT),
+            string.IsNullOrWhiteSpace(vm.CapitalName) ? "—" : vm.CapitalName,
+            x, currentY, width);
+        currentY += StatRowHeight;
+
         return currentY + StatBlockBottomSpacing;
     }
 

--- a/DivineAscension/Network/Civilization/CivilizationActionRequestPacket.cs
+++ b/DivineAscension/Network/Civilization/CivilizationActionRequestPacket.cs
@@ -25,7 +25,7 @@ public class CivilizationActionRequestPacket
 
     [ProtoMember(1)]
     public string Action { get; set; } =
-        string.Empty; // "create", "invite", "accept", "leave", "kick", "disband", "updateicon", "setdescription"
+        string.Empty; // "create", "invite", "accept", "leave", "kick", "disband", "updateicon", "setdescription", "setcapital"
 
     [ProtoMember(2)] public string CivId { get; set; } = string.Empty; // Civilization ID (for most actions)
 
@@ -46,4 +46,17 @@ public class CivilizationActionRequestPacket
     /// </summary>
     [ProtoMember(7)]
     public int Ethos { get; set; } = -1;
+
+    /// <summary>
+    ///     Capital display name for the "setcapital" action (1-64 chars after trim).
+    /// </summary>
+    [ProtoMember(8)]
+    public string CapitalName { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Optional holy site UID to bind as capital for "setcapital". Empty string means
+    ///     "unbind" — keep the name but clear any prior binding.
+    /// </summary>
+    [ProtoMember(9)]
+    public string HolySiteId { get; set; } = string.Empty;
 }

--- a/DivineAscension/Network/Civilization/CivilizationInfoResponsePacket.cs
+++ b/DivineAscension/Network/Civilization/CivilizationInfoResponsePacket.cs
@@ -76,6 +76,18 @@ public class CivilizationInfoResponsePacket
         /// </summary>
         [ProtoMember(15)]
         public string FounderEpithet { get; set; } = string.Empty;
+
+        /// <summary>
+        ///     Civilization capital display name.
+        /// </summary>
+        [ProtoMember(16)]
+        public string CapitalName { get; set; } = string.Empty;
+
+        /// <summary>
+        ///     Optional UID of the holy site bound as capital. Empty when unbound.
+        /// </summary>
+        [ProtoMember(17)]
+        public string CapitalHolySiteId { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/DivineAscension/Systems/CivilizationManager.cs
+++ b/DivineAscension/Systems/CivilizationManager.cs
@@ -31,6 +31,10 @@ public class CivilizationManager : ICivilizationManager
     private readonly IWorldService _worldService;
     private CivilizationWorldData _data = new();
 
+    // Optional dependency wired after construction to break the circular init order
+    // between HolySiteManager and CivilizationManager. Used only for capital cascades.
+    private IHolySiteManager? _holySiteManager;
+
     /// <summary>
     ///     Lazy-initialized lock object for thread safety using Interlocked.CompareExchange
     /// </summary>
@@ -104,9 +108,40 @@ public class CivilizationManager : ICivilizationManager
         _eventService.UnsubscribeSaveGameLoaded(OnSaveGameLoaded);
         _eventService.UnsubscribeGameWorldSave(OnGameWorldSave);
         _religionManager.OnReligionDeleted -= HandleReligionDeleted;
+        if (_holySiteManager != null)
+            _holySiteManager.OnHolySiteRemoved -= HandleHolySiteRemoved;
         OnCivilizationDisbanded = null;
         OnReligionAdded = null;
         OnReligionRemoved = null;
+    }
+
+    /// <summary>
+    ///     Wires the holy-site manager dependency after construction so capital cascades
+    ///     can fire. Called from the system initializer once both managers exist.
+    /// </summary>
+    public void SetHolySiteManager(IHolySiteManager holySiteManager)
+    {
+        _holySiteManager = holySiteManager ?? throw new ArgumentNullException(nameof(holySiteManager));
+        _holySiteManager.OnHolySiteRemoved += HandleHolySiteRemoved;
+    }
+
+    /// <summary>
+    ///     Cascade hook: when a holy site is removed, null the binding on any civ whose
+    ///     capital points at it. Capital name is preserved.
+    /// </summary>
+    private void HandleHolySiteRemoved(string religionUID, string siteUID)
+    {
+        lock (Lock)
+        {
+            foreach (var civ in _data.Civilizations.Values)
+            {
+                if (civ.CapitalHolySiteId == siteUID)
+                {
+                    civ.CapitalHolySiteId = null;
+                    _logger.Debug($"[DivineAscension] Cleared capital binding on civ '{civ.Name}' — site {siteUID} removed");
+                }
+            }
+        }
     }
 
     #region Event Handlers
@@ -131,6 +166,8 @@ public class CivilizationManager : ICivilizationManager
                 // Check if the deleted religion was the founder's religion
                 var isFounderReligion = civ.FounderReligionUID == religionId;
                 var civIdForEvent = civ.CivId;
+
+                ClearCapitalIfOwnedByReligion(civ, religionId);
 
                 // Remove religion from civilization
                 _data.RemoveReligionFromCivilization(religionId);
@@ -275,7 +312,8 @@ public class CivilizationManager : ICivilizationManager
                     Icon = icon,
                     Description = description,
                     Ethos = ethosOverride ?? derivedEthos,
-                    FounderEpithet = LocalizationService.Instance.Get(epithetKey)
+                    FounderEpithet = LocalizationService.Instance.Get(epithetKey),
+                    CapitalName = $"{name} Seat"
                 };
 
                 _data.AddCivilization(civ);
@@ -573,6 +611,7 @@ public class CivilizationManager : ICivilizationManager
 
                 // Remove religion from civilization
                 var civIdForEvent = civ.CivId;
+                ClearCapitalIfOwnedByReligion(civ, religionId);
                 _data.RemoveReligionFromCivilization(religionId);
                 civ.MemberCount -= religion.MemberUIDs.Count;
 
@@ -648,6 +687,7 @@ public class CivilizationManager : ICivilizationManager
                 }
 
                 // Remove religion from civilization
+                ClearCapitalIfOwnedByReligion(civ, religionId);
                 _data.RemoveReligionFromCivilization(religionId);
                 civ.MemberCount -= religion.MemberUIDs.Count;
 
@@ -876,6 +916,78 @@ public class CivilizationManager : ICivilizationManager
         }
     }
 
+    /// <inheritdoc />
+    public bool SetCapital(string civId, string requestorUID, string capitalName, string? holySiteId)
+    {
+        lock (Lock)
+        {
+            try
+            {
+                var civ = _data.Civilizations.GetValueOrDefault(civId);
+                if (civ == null)
+                {
+                    _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
+                    return false;
+                }
+
+                if (!civ.IsFounder(requestorUID))
+                {
+                    _logger.Warning("[DivineAscension] Only civilization founder can set capital");
+                    return false;
+                }
+
+                var trimmed = (capitalName ?? string.Empty).Trim();
+                if (trimmed.Length == 0 || trimmed.Length > 64)
+                {
+                    _logger.Warning("[DivineAscension] Capital name must be 1-64 characters");
+                    return false;
+                }
+
+                if (!string.IsNullOrEmpty(holySiteId))
+                {
+                    var site = _holySiteManager?.GetHolySite(holySiteId);
+                    if (site == null)
+                    {
+                        _logger.Warning($"[DivineAscension] Holy site '{holySiteId}' not found");
+                        return false;
+                    }
+
+                    if (!civ.HasReligion(site.ReligionUID))
+                    {
+                        _logger.Warning("[DivineAscension] Holy site does not belong to a member religion");
+                        return false;
+                    }
+                }
+
+                civ.CapitalName = trimmed;
+                civ.CapitalHolySiteId = string.IsNullOrEmpty(holySiteId) ? null : holySiteId;
+
+                _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' capital set to '{trimmed}'");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"[DivineAscension] Error setting capital: {ex.Message}");
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Cascade: when a religion leaves a civ, if it owned the civ's bound capital
+    ///     site, null the binding. Capital name is preserved. Must be called inside Lock.
+    /// </summary>
+    private void ClearCapitalIfOwnedByReligion(Civilization civ, string religionId)
+    {
+        if (civ.CapitalHolySiteId == null) return;
+        var site = _holySiteManager?.GetHolySite(civ.CapitalHolySiteId);
+        if (site != null && site.ReligionUID == religionId)
+        {
+            civ.CapitalHolySiteId = null;
+            _logger.Debug($"[DivineAscension] Cleared capital binding on civ '{civ.Name}' — religion {religionId} left");
+        }
+    }
+
     #endregion
 
     #region Query Methods
@@ -1055,6 +1167,11 @@ public class CivilizationManager : ICivilizationManager
                 if (loadedData != null)
                 {
                     _data = loadedData;
+                    foreach (var civ in _data.Civilizations.Values)
+                    {
+                        if (string.IsNullOrEmpty(civ.CapitalName))
+                            civ.CapitalName = $"{civ.Name} Seat";
+                    }
                     _logger.Notification($"[DivineAscension] Loaded {_data.Civilizations.Count} civilizations");
                 }
                 else

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -125,6 +125,9 @@ public static class DivineAscensionSystemInitializer
         // Subscribe to religion deletion events for cascading cleanup
         religionManager.OnReligionDeleted += holySiteManager.HandleReligionDeleted;
 
+        // Wire holy-site manager into civilization manager for capital cascades
+        civilizationManager.SetHolySiteManager(holySiteManager);
+
         // Initialize Holy Site Area Tracker (tracks player enter/exit events for holy sites)
         var holySiteAreaTracker = new HolySiteAreaTracker(
             eventService,

--- a/DivineAscension/Systems/HolySiteManager.cs
+++ b/DivineAscension/Systems/HolySiteManager.cs
@@ -33,6 +33,9 @@ public class HolySiteManager : IHolySiteManager
     /// <inheritdoc />
     public event Action<string, string>? OnHolySiteCreated;
 
+    /// <inheritdoc />
+    public event Action<string, string>? OnHolySiteRemoved;
+
     // Dependencies (API wrappers)
     private readonly ILoggerWrapper _logger;
     private readonly IPersistenceService _persistenceService;
@@ -362,6 +365,8 @@ public class HolySiteManager : IHolySiteManager
                 _logger.Notification($"[DivineAscension] Holy site '{site.SiteName}' deconsecrated");
 
                 SaveHolySites();
+
+                OnHolySiteRemoved?.Invoke(site.ReligionUID, siteUID);
 
                 return true;
             }
@@ -757,6 +762,8 @@ public class HolySiteManager : IHolySiteManager
                 if (sites.Count == 0)
                     _sitesByReligion.TryRemove(site.ReligionUID, out _);
             }
+
+            OnHolySiteRemoved?.Invoke(site.ReligionUID, siteUID);
 
             return true;
         }

--- a/DivineAscension/Systems/Interfaces/ICivilizationManager.cs
+++ b/DivineAscension/Systems/Interfaces/ICivilizationManager.cs
@@ -93,6 +93,20 @@ public interface ICivilizationManager
     bool UpdateCivilizationDescription(string civId, string requestorUID, string description);
 
     /// <summary>
+    ///     Sets the civilization's capital — a display name plus optional binding to one
+    ///     holy site owned by a member religion. Founder-only.
+    /// </summary>
+    /// <param name="civId">ID of the civilization</param>
+    /// <param name="requestorUID">Player UID requesting the change (must be founder)</param>
+    /// <param name="capitalName">New capital name (1-64 chars after trim)</param>
+    /// <param name="holySiteId">
+    ///     Optional holy site to bind. Must be owned by one of the civ's member religions.
+    ///     Pass null to clear the binding while keeping the name.
+    /// </param>
+    /// <returns>True if applied, false on validation failure.</returns>
+    bool SetCapital(string civId, string requestorUID, string capitalName, string? holySiteId);
+
+    /// <summary>
     ///     Gets a civilization by ID
     /// </summary>
     Civilization? GetCivilization(string civId);

--- a/DivineAscension/Systems/Interfaces/IHolySiteManager.cs
+++ b/DivineAscension/Systems/Interfaces/IHolySiteManager.cs
@@ -18,6 +18,12 @@ public interface IHolySiteManager
     event Action<string, string>? OnHolySiteCreated;
 
     /// <summary>
+    /// Event fired when a holy site is removed (deconsecrated or owning religion deleted).
+    /// Parameters: religionUID, siteUID
+    /// </summary>
+    event Action<string, string>? OnHolySiteRemoved;
+
+    /// <summary>
     /// Initializes the manager and registers event handlers.
     /// </summary>
     void Initialize();

--- a/DivineAscension/Systems/Interfaces/IUiService.cs
+++ b/DivineAscension/Systems/Interfaces/IUiService.cs
@@ -35,7 +35,8 @@ public interface IUiService
     void RequestCivilizationInfo(string civId);
 
     void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "", int ethos = -1);
+        string icon = "", string description = "", int ethos = -1,
+        string capitalName = "", string holySiteId = "");
 
     // Diplomacy Operations
     void RequestDiplomacyInfo(string civId);

--- a/DivineAscension/Systems/Networking/Client/DivineAscensionNetworkClient.cs
+++ b/DivineAscension/Systems/Networking/Client/DivineAscensionNetworkClient.cs
@@ -839,7 +839,8 @@ public class DivineAscensionNetworkClient : IClientNetworkHandler
     ///     Request a civilization action (create, invite, accept, leave, kick, disband, setdescription)
     /// </summary>
     public void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "", int ethos = -1)
+        string icon = "", string description = "", int ethos = -1,
+        string capitalName = "", string holySiteId = "")
     {
         if (_clientChannel == null)
         {
@@ -849,7 +850,9 @@ public class DivineAscensionNetworkClient : IClientNetworkHandler
 
         var request = new CivilizationActionRequestPacket(action, civId, targetId, name, icon, description)
         {
-            Ethos = ethos
+            Ethos = ethos,
+            CapitalName = capitalName,
+            HolySiteId = holySiteId
         };
         _clientChannel.SendPacket(request);
         _capi?.Logger.Debug($"[DivineAscension] Sent civilization action request: {action}");

--- a/DivineAscension/Systems/Networking/Client/UiService.cs
+++ b/DivineAscension/Systems/Networking/Client/UiService.cs
@@ -117,9 +117,11 @@ public class UiService(DivineAscensionNetworkClient networkClient)
     }
 
     public void RequestCivilizationAction(string action, string civId = "", string targetId = "", string name = "",
-        string icon = "", string description = "", int ethos = -1)
+        string icon = "", string description = "", int ethos = -1,
+        string capitalName = "", string holySiteId = "")
     {
-        _networkClient.RequestCivilizationAction(action, civId, targetId, name, icon, description, ethos);
+        _networkClient.RequestCivilizationAction(action, civId, targetId, name, icon, description, ethos, capitalName,
+            holySiteId);
     }
 
     public void RequestDiplomacyInfo(string civId)

--- a/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
@@ -181,6 +181,8 @@ public class CivilizationNetworkHandler(
             Rank = (int)civ.Rank,
             Ethos = (int)civ.Ethos,
             FounderEpithet = civ.FounderEpithet,
+            CapitalName = civ.CapitalName,
+            CapitalHolySiteId = civ.CapitalHolySiteId ?? string.Empty,
             MemberReligions = new List<CivilizationInfoResponsePacket.MemberReligion>(),
             PendingInvites = new List<CivilizationInfoResponsePacket.PendingInvite>()
         };
@@ -484,6 +486,38 @@ public class CivilizationNetworkHandler(
                         : LocalizationService.Instance.Get(LocalizationKeys.NET_CIV_DESCRIPTION_UPDATE_FAILED);
                     response.CivId = packet.CivId;
                     break;
+
+                case "setcapital":
+                {
+                    var trimmedCapital = (packet.CapitalName ?? string.Empty).Trim();
+                    if (trimmedCapital.Length == 0 || trimmedCapital.Length > 64)
+                    {
+                        response.Success = false;
+                        response.Message =
+                            LocalizationService.Instance.Get(LocalizationKeys.NET_CIV_CAPITAL_NAME_INVALID);
+                        response.CivId = packet.CivId;
+                        break;
+                    }
+
+                    if (ProfanityFilterService.Instance.ContainsProfanity(trimmedCapital))
+                    {
+                        response.Success = false;
+                        response.Message =
+                            LocalizationService.Instance.Get(LocalizationKeys.NET_CIV_CAPITAL_NAME_PROFANITY);
+                        response.CivId = packet.CivId;
+                        break;
+                    }
+
+                    var holySiteId = string.IsNullOrEmpty(packet.HolySiteId) ? null : packet.HolySiteId;
+                    success = civilizationManager.SetCapital(packet.CivId, fromPlayer.PlayerUID, trimmedCapital,
+                        holySiteId);
+                    response.Success = success;
+                    response.Message = success
+                        ? LocalizationService.Instance.Get(LocalizationKeys.NET_CIV_CAPITAL_UPDATED)
+                        : LocalizationService.Instance.Get(LocalizationKeys.NET_CIV_CAPITAL_UPDATE_FAILED);
+                    response.CivId = packet.CivId;
+                    break;
+                }
 
                 default:
                     response.Success = false;

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1056,6 +1056,10 @@
   "divineascension:net.civ.description_update_failed": "Failed to update description. Only the founder can update the civilization description.",
   "divineascension:net.civ.description_too_long": "Description must be 200 characters or less.",
   "divineascension:net.civ.description_profanity": "Description contains inappropriate content.",
+  "divineascension:net.civ.capital_updated": "Capital updated.",
+  "divineascension:net.civ.capital_update_failed": "Failed to update capital. Only the founder can set the capital, and any bound holy site must belong to a member religion.",
+  "divineascension:net.civ.capital_name_invalid": "Capital name must be 1-64 characters.",
+  "divineascension:net.civ.capital_name_profanity": "Capital name contains inappropriate content.",
   "divineascension:net.civ.unknown_action": "Unknown action: {0}",
   "divineascension:net.civ.error": "An error occurred while processing your request.",
   "divineascension:cmd.blessing.error.must_be_in_religion": "You must join a religion to view blessings. Use /religion to get started.",
@@ -1309,7 +1313,10 @@
   "divineascension:civilization.epithet.default": "the Unmarked",
 
   "divineascension:ui.civilization.info.ethos": "Ethos",
+  "divineascension:ui.civilization.info.seat": "Seat",
+  "divineascension:ui.civilization.info.capital_none": "(no holy site bound)",
   "divineascension:ui.civilization.detail.ethos": "Ethos",
+  "divineascension:ui.civilization.detail.seat": "Seat",
   "divineascension:ui.civilization.create.ethos.label": "Ethos",
   "divineascension:ui.civilization.create.ethos.hint": "Chosen once, at founding. Tradition derives ethos from your patron's domain. Overrule only with reason."
 }


### PR DESCRIPTION
MVP for civilization capital per #394, implementing #370.

## What
- `Civilization.CapitalName` (auto-defaults to \`{Name} Seat\` at founding; legacy saves repaired on load) and optional `CapitalHolySiteId` binding.
- Founder-gated `CivilizationManager.SetCapital` with eligibility check (bound site must belong to a member religion).
- Server cascades:
  - Holy site removed → null any civ's binding referencing it. Capital name preserved.
  - Religion leaves civ (delete / kick / voluntary leave) → if the leaving religion owned the bound site, null the binding. Name preserved.
- Networking: extended `CivilizationActionRequestPacket` with \`setcapital\` action + `CapitalName` / `HolySiteId` fields. Server validates length (1-64) + profanity.
- UI:
  - Seat line added to `CivilizationDetailRenderer` and `CivilizationInfoRenderer` stat blocks.
  - Founder-only inline edit on the Info pane (pencil glyph → name input + flat holy-site picker sourced from existing `SitesByReligion`; `(no holy site bound)` row unbinds).
- Tests: 8 new unit tests in `CivilizationCapitalTests` covering founder gating, eligibility, cascade rules, defaults.

## Test plan
- [x] Unit tests pass (`dotnet test --filter ~CivilizationCapitalTests`) — already green locally.
- [x] Manual: launch Vintage Story, found a civ → seat auto-named `{Name} Seat`, visible on Detail + Info panes.
- [x] Manual: edit capital name from Info pane pencil → persists, broadcasts to other clients.
- [x] Manual: bind capital to a member-religion holy site → confirm Detail/Info still show name.
- [x] Manual: deconsecrate the bound altar → binding clears, name preserved.
- [x] Manual: kick/leave the religion owning the bound site → binding clears, name preserved.
- [x] Manual: reload world → state persisted across save/load.

Closes #370.
Closes #394.

Follow-ups remain open: #395 (cross-link site ↔ capital), #396 (group dropdown by religion).