### PR TITLE
feat(ui): banner order rows show deity + soul count

### DIFF
--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -672,6 +672,12 @@ public static class LocalizationKeys
     public const string UI_CIVILIZATION_INFO_BANNER_ORDERS_EMPTY =
         "divineascension:ui.civilization.info.banner_orders.empty";
 
+    public const string UI_CIVILIZATION_INFO_BANNER_ORDER_VALUE_ONE =
+        "divineascension:ui.civilization.info.banner_orders.value_one";
+
+    public const string UI_CIVILIZATION_INFO_BANNER_ORDER_VALUE_MANY =
+        "divineascension:ui.civilization.info.banner_orders.value_many";
+
     public const string UI_CIVILIZATION_INFO_BID_LABEL =
         "divineascension:ui.civilization.info.bid.label";
 

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -156,14 +156,17 @@ internal static class CivilizationInfoRenderer
 
         foreach (var member in vm.MemberReligions)
         {
-            DrawOrderRow(drawList, member.ReligionName, x, currentY);
+            DrawOrderRow(drawList, member, x, currentY, width);
             currentY += OrderRowHeight;
         }
 
         return currentY + 4f;
     }
 
-    private static void DrawOrderRow(ImDrawListPtr drawList, string name, float x, float y)
+    private static void DrawOrderRow(
+        ImDrawListPtr drawList,
+        CivilizationInfoResponsePacket.MemberReligion member,
+        float x, float y, float width)
     {
         var centerY = y + OrderRowHeight / 2f;
         ChromeRenderer.DrawDiamond(drawList,
@@ -171,10 +174,24 @@ internal static class CivilizationInfoRenderer
             DiamondHalfSize,
             ColorPalette.Gold * 0.6f);
 
-        var textX = x + DiamondLeftPadding + DiamondHalfSize * 2f + DiamondLabelGap;
-        drawList.AddText(new Vector2(textX, centerY - Body * 0.5f),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.White),
-            name);
+        var labelX = x + DiamondLeftPadding + DiamondHalfSize * 2f + DiamondLabelGap;
+        var rowY = centerY - Body * 0.5f;
+        var leaderWidth = MathF.Max(width - (labelX - x), 40f);
+
+        var deity = !string.IsNullOrWhiteSpace(member.DeityName)
+            ? member.DeityName
+            : member.Domain ?? string.Empty;
+
+        var valueKey = member.MemberCount == 1
+            ? LocalizationKeys.UI_CIVILIZATION_INFO_BANNER_ORDER_VALUE_ONE
+            : LocalizationKeys.UI_CIVILIZATION_INFO_BANNER_ORDER_VALUE_MANY;
+        var value = LocalizationService.Instance.Get(valueKey, deity, member.MemberCount);
+
+        ChromeRenderer.DrawLeader(drawList,
+            member.ReligionName ?? string.Empty,
+            value,
+            labelX, rowY, leaderWidth,
+            labelColor: ColorPalette.White);
     }
 
     private static float DrawInviteSection(

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -414,6 +414,8 @@
   "divineascension:ui.civilization.info.purpose.empty": "No purpose has yet been set down in the ledger.",
   "divineascension:ui.civilization.info.banner_orders.heading": "Banner Orders",
   "divineascension:ui.civilization.info.banner_orders.empty": "No Orders walk beneath this banner.",
+  "divineascension:ui.civilization.info.banner_orders.value_one": "{0} · {1} soul",
+  "divineascension:ui.civilization.info.banner_orders.value_many": "{0} · {1} souls",
   "divineascension:ui.civilization.info.bid.label": "Bid an Order to your banner:",
   "divineascension:ui.civilization.info.letters.heading": "Letters sent, awaiting reply:",
   "divineascension:ui.civilization.info.letters.empty": "No letters await reply.",


### PR DESCRIPTION
Closes #326.

## Summary
Each "This Realm" Banner Order row now lays out as `✦ <Name> · · · · · <Deity> · <N soul(s)>` via `ChromeRenderer.DrawLeader`, restoring the deity + member-count information that v1 dropped.

- Deity resolves from `MemberReligion.DeityName`, falling back to `Domain` when empty.
- Singular / plural soul handled via two new localization keys.
- No packet changes — `MemberReligion` already carried `DeityName`, `Domain`, and `MemberCount`; the server already populates them.

## Test plan
- [x] Manual: launch VS, open This Realm pane — confirm each Order row shows name on the left, dotted leader, deity + soul count on the right.
- [x] Manual: religion with 1 member shows "soul", >1 shows "souls".
- [x] Manual: religion with empty DeityName falls back to Domain.