### PR TITLE
feat(ui): blessing tree branch swimlanes layout

### DIFF
--- a/DivineAscension/GUI/BlessingTreeLayout.cs
+++ b/DivineAscension/GUI/BlessingTreeLayout.cs
@@ -7,120 +7,129 @@ using DivineAscension.Models;
 namespace DivineAscension.GUI;
 
 /// <summary>
-///     Calculates positions for blessing nodes in the tree layout
-///     Uses tier-based vertical arrangement with horizontal spacing
+///     Calculates positions for blessing nodes in the tree layout.
+///     Nodes are grouped first by <see cref="Blessing.Branch"/> into vertical
+///     swimlanes, then by tier within each lane. Branchless ("shared") nodes
+///     occupy a centre lane so mutex branches read as parallel columns.
 /// </summary>
 [ExcludeFromCodeCoverage]
 public static class BlessingTreeLayout
 {
-    // Layout constants
     private const float NodeWidth = 64f;
     private const float NodeHeight = 64f;
-    private const float VerticalSpacing = 120f; // Space between tiers
-    private const float HorizontalSpacing = 100f; // Space between nodes in same tier
+    private const float VerticalSpacing = 120f;   // between tiers
+    private const float IntraLaneSpacing = 24f;   // siblings inside one lane/tier
+    private const float LaneSpacing = 72f;        // between swimlanes
     private const float TopPadding = 40f;
     private const float LeftPadding = 40f;
 
-    /// <summary>
-    ///     Calculate layout for a collection of blessing node states
-    ///     Arranges nodes by tier (1-4) vertically, spread horizontally within each tier
-    /// </summary>
+    private const string SharedLaneKey = "";
+
     public static void CalculateLayout(Dictionary<string, BlessingNodeState> blessingStates, float containerWidth)
     {
         if (blessingStates.Count == 0) return;
 
-        // Determine tiers for each blessing based on prerequisites
         AssignTiers(blessingStates);
 
-        // Group nodes by tier
-        var nodesByTier = blessingStates.Values
-            .GroupBy(node => node.Tier)
-            .OrderBy(group => group.Key)
-            .ToList();
+        var byBranch = blessingStates.Values
+            .GroupBy(BranchKey)
+            .ToDictionary(g => g.Key, g => g.ToList());
 
-        var currentY = TopPadding;
+        var lanes = OrderLanes(byBranch.Keys);
 
-        foreach (var tierGroup in nodesByTier)
+        // Per-lane width = widest tier row in that lane.
+        var laneSlots = lanes.ToDictionary(
+            lane => lane,
+            lane => Math.Max(1, byBranch[lane].GroupBy(n => n.Tier).Max(g => g.Count())));
+
+        var laneStartX = new Dictionary<string, float>();
+        var cursorX = LeftPadding;
+        foreach (var lane in lanes)
         {
-            var nodesInTier = tierGroup.ToList();
-            var nodeCount = nodesInTier.Count;
+            laneStartX[lane] = cursorX;
+            cursorX += LaneInnerWidth(laneSlots[lane]) + LaneSpacing;
+        }
 
-            // Calculate horizontal layout for this tier
-            var totalWidth = nodeCount * NodeWidth + (nodeCount - 1) * HorizontalSpacing;
-            var startX = LeftPadding + (containerWidth - totalWidth - LeftPadding * 2) / 2;
+        // Centre the lane block horizontally if there's spare room.
+        var totalLanesWidth = cursorX - LaneSpacing - LeftPadding;
+        var available = containerWidth - LeftPadding * 2;
+        var extraShift = available > totalLanesWidth ? (available - totalLanesWidth) / 2f : 0f;
 
-            // If total width exceeds container, use left alignment with smaller spacing
-            if (totalWidth > containerWidth - LeftPadding * 2)
+        foreach (var lane in lanes)
+        {
+            var slots = laneSlots[lane];
+            var innerWidth = LaneInnerWidth(slots);
+            var startX = laneStartX[lane] + extraShift;
+
+            foreach (var tierGroup in byBranch[lane].GroupBy(n => n.Tier))
             {
-                startX = LeftPadding;
-                var availableWidth = containerWidth - LeftPadding * 2 - nodeCount * NodeWidth;
-                var adjustedSpacing = nodeCount > 1 ? availableWidth / (nodeCount - 1) : 0;
+                var tierNodes = tierGroup.OrderBy(n => n.Blessing?.BlessingId, StringComparer.Ordinal).ToList();
+                var count = tierNodes.Count;
+                var rowWidth = count * NodeWidth + Math.Max(0, count - 1) * IntraLaneSpacing;
+                var rowStartX = startX + (innerWidth - rowWidth) / 2f;
+                var y = TopPadding + (tierGroup.Key - 1) * (NodeHeight + VerticalSpacing);
 
-                // Position nodes with adjusted spacing
-                for (var i = 0; i < nodeCount; i++)
+                for (var i = 0; i < count; i++)
                 {
-                    var node = nodesInTier[i];
-                    node.PositionX = startX + i * (NodeWidth + adjustedSpacing);
-                    node.PositionY = currentY;
+                    var node = tierNodes[i];
+                    node.PositionX = rowStartX + i * (NodeWidth + IntraLaneSpacing);
+                    node.PositionY = y;
                     node.Width = NodeWidth;
                     node.Height = NodeHeight;
                 }
             }
-            else
-            {
-                // Position nodes with standard spacing
-                for (var i = 0; i < nodeCount; i++)
-                {
-                    var node = nodesInTier[i];
-                    node.PositionX = startX + i * (NodeWidth + HorizontalSpacing);
-                    node.PositionY = currentY;
-                    node.Width = NodeWidth;
-                    node.Height = NodeHeight;
-                }
-            }
-
-            currentY += NodeHeight + VerticalSpacing;
         }
     }
 
+    private static string BranchKey(BlessingNodeState n)
+        => string.IsNullOrEmpty(n.Blessing?.Branch) ? SharedLaneKey : n.Blessing!.Branch!;
+
+    private static float LaneInnerWidth(int slots)
+        => slots * NodeWidth + Math.Max(0, slots - 1) * IntraLaneSpacing;
+
     /// <summary>
-    ///     Assign tier levels to blessings based on their prerequisite chains
-    ///     Tier 1 = no prerequisites, Tier 2+ = based on deepest prerequisite + 1
+    /// Order lanes so real branches sit alphabetically left-to-right with the
+    /// shared/branchless lane inserted at the centre.
     /// </summary>
+    private static List<string> OrderLanes(IEnumerable<string> branchKeys)
+    {
+        var real = branchKeys
+            .Where(k => k != SharedLaneKey)
+            .OrderBy(k => k, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (!branchKeys.Contains(SharedLaneKey)) return real;
+
+        var center = real.Count / 2;
+        real.Insert(center, SharedLaneKey);
+        return real;
+    }
+
     private static void AssignTiers(Dictionary<string, BlessingNodeState> blessingStates)
     {
-        // Build a lookup map
         var stateMap = new Dictionary<string, BlessingNodeState>();
         foreach (var kvp in blessingStates)
         {
             stateMap[kvp.Key] = kvp.Value;
-            kvp.Value.Tier = 0; // Initialize
+            kvp.Value.Tier = 0;
         }
 
-        // Calculate tier for each node recursively
         foreach (var state in blessingStates.Values) CalculateTier(state, stateMap, new HashSet<string>());
     }
 
-    /// <summary>
-    ///     Recursively calculate tier for a blessing node
-    /// </summary>
     private static int CalculateTier(BlessingNodeState node, Dictionary<string, BlessingNodeState> stateMap,
         HashSet<string> visiting)
     {
-        // If already calculated, return cached value
         if (node.Tier > 0) return node.Tier;
 
-        // Check for circular dependencies
         if (visiting.Contains(node.Blessing.BlessingId))
         {
-            // Circular dependency detected, assign tier 1 to break cycle
             node.Tier = 1;
             return 1;
         }
 
         visiting.Add(node.Blessing.BlessingId);
 
-        // If no prerequisites, this is tier 1
         if (node.Blessing.PrerequisiteBlessings == null || node.Blessing.PrerequisiteBlessings.Count == 0)
         {
             node.Tier = 1;
@@ -128,7 +137,6 @@ public static class BlessingTreeLayout
             return 1;
         }
 
-        // Find the maximum tier among prerequisites
         var maxPrereqTier = 0;
         foreach (var prereqId in node.Blessing.PrerequisiteBlessings)
             if (stateMap.TryGetValue(prereqId, out var prereqState))
@@ -137,15 +145,11 @@ public static class BlessingTreeLayout
                 maxPrereqTier = Math.Max(maxPrereqTier, prereqTier);
             }
 
-        // This node's tier is one more than the highest prerequisite tier
         node.Tier = maxPrereqTier + 1;
         visiting.Remove(node.Blessing.BlessingId);
         return node.Tier;
     }
 
-    /// <summary>
-    ///     Get total height needed for the tree layout
-    /// </summary>
     public static float GetTotalHeight(Dictionary<string, BlessingNodeState> blessingStates)
     {
         if (blessingStates.Count == 0) return 0;
@@ -154,24 +158,25 @@ public static class BlessingTreeLayout
         return TopPadding + maxTier * (NodeHeight + VerticalSpacing);
     }
 
-    /// <summary>
-    ///     Get total width needed for the tree layout
-    /// </summary>
     public static float GetTotalWidth(Dictionary<string, BlessingNodeState> blessingStates)
     {
         if (blessingStates.Count == 0) return 0;
 
-        // Find tier with most nodes
-        var maxNodesInTier = blessingStates.Values
-            .GroupBy(node => node.Tier)
-            .Max(group => group.Count());
+        var byBranch = blessingStates.Values
+            .GroupBy(BranchKey)
+            .ToDictionary(g => g.Key, g => g.ToList());
 
-        return LeftPadding * 2 + maxNodesInTier * NodeWidth + (maxNodesInTier - 1) * HorizontalSpacing;
+        var laneCount = byBranch.Count;
+        var total = LeftPadding * 2;
+        foreach (var lane in byBranch.Keys)
+        {
+            var slots = Math.Max(1, byBranch[lane].GroupBy(n => n.Tier).Max(g => g.Count()));
+            total += LaneInnerWidth(slots);
+        }
+        total += Math.Max(0, laneCount - 1) * LaneSpacing;
+        return total;
     }
 
-    /// <summary>
-    ///     Check if a point is inside a node's bounds (for click detection)
-    /// </summary>
     public static bool IsPointInNode(BlessingNodeState node, float x, float y)
     {
         return x >= node.PositionX &&
@@ -180,9 +185,6 @@ public static class BlessingTreeLayout
                y <= node.PositionY + node.Height;
     }
 
-    /// <summary>
-    ///     Find which node (if any) contains the given point
-    /// </summary>
     public static BlessingNodeState? FindNodeAtPoint(Dictionary<string, BlessingNodeState> blessingStates, float x,
         float y)
     {

--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingNodeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingNodeRenderer.cs
@@ -144,9 +144,22 @@ internal static class BlessingNodeRenderer
         var color = toNode.IsUnlocked
             ? ColorPalette.Gold * 0.7f
             : (fromNode.IsUnlocked ? ColorPalette.Grey : ColorPalette.BorderColor * 0.7f);
+        var col32 = ImGui.ColorConvertFloat4ToU32(color);
 
-        drawList.AddLine(fromCenter, toCenter,
-            ImGui.ColorConvertFloat4ToU32(color), 1.25f);
+        // Same-lane (vertical) prereqs draw as a straight stroke. Cross-lane
+        // prereqs route as a short vertical-tangent bezier so the curve clears
+        // sibling seals instead of slicing through them.
+        if (Math.Abs(fromCenter.X - toCenter.X) < 0.5f)
+        {
+            drawList.AddLine(fromCenter, toCenter, col32, 1.25f);
+            return;
+        }
+
+        var dy = toCenter.Y - fromCenter.Y;
+        var tangent = Math.Max(24f, Math.Abs(dy) * 0.55f);
+        var cp1 = new Vector2(fromCenter.X, fromCenter.Y + tangent);
+        var cp2 = new Vector2(toCenter.X, toCenter.Y - tangent);
+        drawList.AddBezierCubic(fromCenter, cp1, cp2, toCenter, col32, 1.25f, 24);
     }
 
     private static (Vector4 Fill, Vector4 Rim, Vector4 IconTint, Vector4 Text) StyleFor(


### PR DESCRIPTION
## Summary
- Groups blessing nodes by `Blessing.Branch` into vertical swimlanes; branchless nodes occupy a centre lane so mutex branches read as parallel columns.
- Cross-lane prereq lines route as a short vertical-tangent bezier; same-lane links stay straight.
- `GetTotalWidth` now sums lane widths + spacing so scroll bounds match the new layout.

## Test plan
- [x] Open a domain with 2+ branches (e.g. Lysa Forager vs Hunter) — lanes render in parallel.
- [x] Shared/`null`-branch nodes appear in centre lane.
- [x] No prereq line crosses through a node circle.
- [x] Horizontal/vertical scroll bounds remain correct.

Closes #402