### PR TITLE
fix(commands): /favor uses configured rank thresholds (#207)

### DIFF
--- a/DivineAscension.Tests/Commands/Favor/FavorCommandRanksTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandRanksTests.cs
@@ -58,6 +58,31 @@ public class FavorCommandRanksTests : FavorCommandsTestHelpers
     }
 
     [Fact]
+    public void OnListRanks_WithCustomThresholds_ReflectsConfiguredValues()
+    {
+        // Arrange — server admin tuned thresholds via GameBalanceConfig
+        _gameBalanceConfig.DiscipleThreshold = 750;
+        _gameBalanceConfig.ZealotThreshold = 3000;
+        _gameBalanceConfig.ChampionThreshold = 7500;
+        _gameBalanceConfig.AvatarThreshold = 15000;
+        _sut = InitializeMocksAndSut();
+
+        var mockPlayer = CreateMockPlayer("player-1", "TestPlayer");
+        var args = CreateCommandArgs(mockPlayer.Object);
+
+        // Act
+        var result = _sut!.OnListRanks(args);
+
+        // Assert
+        Assert.Equal(EnumCommandStatus.Success, result.Status);
+        Assert.Contains("750", result.StatusMessage);
+        Assert.Contains("3,000", result.StatusMessage);
+        Assert.Contains("7,500", result.StatusMessage);
+        Assert.Contains("15,000", result.StatusMessage);
+        Assert.DoesNotContain("10,000", result.StatusMessage); // old default Avatar
+    }
+
+    [Fact]
     public void OnListRanks_Always_ShowsBlessingsMessage()
     {
         // Arrange

--- a/DivineAscension.Tests/Commands/Favor/FavorCommandsTests.cs
+++ b/DivineAscension.Tests/Commands/Favor/FavorCommandsTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using DivineAscension.Commands;
+using DivineAscension.Configuration;
 using DivineAscension.Models.Enum;
 using DivineAscension.Tests.Commands.Helpers;
 using DivineAscension.Tests.Helpers;
@@ -72,7 +73,8 @@ public class FavorCommandsTests : FavorCommandsTestHelpers
             null!,
             _playerReligionDataManager.Object,
             _religionManager.Object,
-            _messengerService.Object));
+            _messengerService.Object,
+            _gameBalanceConfig));
     }
 
     [Fact]
@@ -83,7 +85,8 @@ public class FavorCommandsTests : FavorCommandsTestHelpers
             _mockSapi.Object,
             null!,
             _religionManager.Object,
-            _messengerService.Object));
+            _messengerService.Object,
+            _gameBalanceConfig));
     }
 
     [Fact]
@@ -94,7 +97,19 @@ public class FavorCommandsTests : FavorCommandsTestHelpers
             _mockSapi.Object,
             _playerReligionDataManager.Object,
             null!,
-            _messengerService.Object));
+            _messengerService.Object,
+            _gameBalanceConfig));
+    }
+
+    [Fact]
+    public void Constructor_WithNullConfig_ThrowsException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FavorCommands(
+            _mockSapi.Object,
+            _playerReligionDataManager.Object,
+            _religionManager.Object,
+            _messengerService.Object,
+            null!));
     }
 
     #endregion

--- a/DivineAscension.Tests/Commands/Helpers/FavorCommandsTestHelpers.cs
+++ b/DivineAscension.Tests/Commands/Helpers/FavorCommandsTestHelpers.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Commands;
+using DivineAscension.Configuration;
 using DivineAscension.Models.Enum;
 using DivineAscension.Systems;
 using DivineAscension.Systems.Interfaces;
@@ -22,6 +23,7 @@ public class FavorCommandsTestHelpers
     protected Mock<IPlayerProgressionDataManager> _playerReligionDataManager;
     protected Mock<IReligionManager> _religionManager;
     protected Mock<IPlayerMessengerService> _messengerService;
+    protected GameBalanceConfig _gameBalanceConfig = new();
     protected FavorCommands? _sut;
 
     protected FavorCommandsTestHelpers()
@@ -49,7 +51,8 @@ public class FavorCommandsTestHelpers
             _mockSapi.Object,
             _playerReligionDataManager.Object,
             _religionManager.Object,
-            _messengerService.Object);
+            _messengerService.Object,
+            _gameBalanceConfig);
     }
 
     /// <summary>

--- a/DivineAscension/Commands/FavorCommands.cs
+++ b/DivineAscension/Commands/FavorCommands.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text;
 using DivineAscension.API.Interfaces;
+using DivineAscension.Configuration;
 using DivineAscension.Constants;
 using DivineAscension.Extensions;
 using DivineAscension.Models.Enum;
@@ -22,20 +23,31 @@ public class FavorCommands
     private readonly IReligionManager _religionManager;
     private readonly ICoreServerAPI _sapi;
     private readonly IPlayerMessengerService _messenger;
+    private readonly GameBalanceConfig _config;
 
     // ReSharper disable once ConvertToPrimaryConstructor
     public FavorCommands(
         ICoreServerAPI sapi,
         IPlayerProgressionDataManager playerReligionDataManager,
         IReligionManager religionManager,
-        IPlayerMessengerService messengerService)
+        IPlayerMessengerService messengerService,
+        GameBalanceConfig config)
     {
         _sapi = sapi ?? throw new ArgumentNullException(nameof(sapi));
         _playerProgressionDataManager = playerReligionDataManager ??
                                         throw new ArgumentNullException(nameof(playerReligionDataManager));
         _religionManager = religionManager ?? throw new ArgumentNullException(nameof(religionManager));
         _messenger = messengerService ?? throw new ArgumentNullException(nameof(messengerService));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
     }
+
+    private int RequiredFavorForNextRank(int currentRank) =>
+        RankRequirements.GetRequiredFavorForNextRank(
+            currentRank,
+            _config.DiscipleThreshold,
+            _config.ZealotThreshold,
+            _config.ChampionThreshold,
+            _config.AvatarThreshold);
 
     /// <summary>
     ///     Registers all favor-related commands
@@ -246,7 +258,7 @@ public class FavorCommands
         {
             var nextRank = currentRank + 1;
             var nextRankName = RankRequirements.GetFavorRankName(nextRank);
-            var nextThreshold = RankRequirements.GetRequiredFavorForNextRank(currentRank);
+            var nextThreshold = RequiredFavorForNextRank(currentRank);
 
             sb.AppendLine(
                 $"{LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_LABEL_NEXT_RANK)} {nextRankName} ({nextThreshold:N0} total favor required)");
@@ -320,7 +332,7 @@ public class FavorCommands
         {
             var nextRank = currentRank + 1;
             var nextRankName = RankRequirements.GetFavorRankName(nextRank);
-            var nextThreshold = RankRequirements.GetRequiredFavorForNextRank(currentRank);
+            var nextThreshold = RequiredFavorForNextRank(currentRank);
             var remaining = nextThreshold - totalForDeity;
 
             sb.AppendLine();
@@ -378,7 +390,7 @@ public class FavorCommands
         for (var rank = 0; rank <= 4; rank++)
         {
             var rankName = RankRequirements.GetFavorRankName(rank);
-            var totalRequired = rank == 0 ? 0 : RankRequirements.GetRequiredFavorForNextRank(rank - 1);
+            var totalRequired = rank == 0 ? 0 : RequiredFavorForNextRank(rank - 1);
             sb.AppendLine(LocalizationService.Instance.Get(LocalizationKeys.CMD_FAVOR_FORMAT_RANK_REQUIREMENT, rankName,
                 totalRequired.ToString("N0")));
         }

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -317,7 +317,7 @@ public static class DivineAscensionSystemInitializer
         // CRITICAL: Must be called AFTER DiplomacyManager is initialized
         religionPrestigeManager.SetDiplomacyManager(diplomacyManager, civilizationManager);
 
-        var favorCommands = new FavorCommands(api, playerReligionDataManager, religionManager, messengerService);
+        var favorCommands = new FavorCommands(api, playerReligionDataManager, religionManager, messengerService, gameBalanceConfig);
         favorCommands.RegisterCommands();
 
         var blessingCommands = new BlessingCommands(api, blessingRegistry, playerReligionDataManager, religionManager,


### PR DESCRIPTION
## Summary
- `FavorCommands` called parameterless `RankRequirements.GetRequiredFavorForNextRank(rank)`, so `/favor info`, `/favor stats`, and `/favor ranks` always showed the hardcoded `500 / 2000 / 5000 / 10000` thresholds even when admins tuned `GameBalanceConfig` (ConfigLib YAML).
- Injects `GameBalanceConfig` into `FavorCommands` and routes threshold lookups through a single helper.
- Scopes issue #207's P1 (threshold tuning) as complete. P3 (uncap rank count) remains open.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter FullyQualifiedName~FavorCommand` — 62/62 pass
- [x] New regression: `OnListRanks_WithCustomThresholds_ReflectsConfiguredValues` mutates config and asserts custom values appear (and old defaults don't).
- [x] New `Constructor_WithNullConfig_ThrowsException`.