### PR TITLE
feat(config): add blessing slot config + calculator (#443)

### DIFF
--- a/DivineAscension.Tests/Configuration/BlessingSlotCalculatorTests.cs
+++ b/DivineAscension.Tests/Configuration/BlessingSlotCalculatorTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.Tests.Configuration;
+
+[ExcludeFromCodeCoverage]
+public class BlessingSlotCalculatorTests
+{
+    [Theory]
+    [InlineData(FavorRank.Initiate, PrestigeRank.Fledgling, 1)]
+    [InlineData(FavorRank.Initiate, PrestigeRank.Established, 1)]
+    [InlineData(FavorRank.Initiate, PrestigeRank.Renowned, 2)]
+    [InlineData(FavorRank.Initiate, PrestigeRank.Legendary, 2)]
+    [InlineData(FavorRank.Initiate, PrestigeRank.Mythic, 3)]
+    [InlineData(FavorRank.Disciple, PrestigeRank.Fledgling, 2)]
+    [InlineData(FavorRank.Disciple, PrestigeRank.Established, 2)]
+    [InlineData(FavorRank.Disciple, PrestigeRank.Renowned, 3)]
+    [InlineData(FavorRank.Disciple, PrestigeRank.Legendary, 3)]
+    [InlineData(FavorRank.Disciple, PrestigeRank.Mythic, 4)]
+    [InlineData(FavorRank.Zealot, PrestigeRank.Fledgling, 3)]
+    [InlineData(FavorRank.Zealot, PrestigeRank.Established, 3)]
+    [InlineData(FavorRank.Zealot, PrestigeRank.Renowned, 4)]
+    [InlineData(FavorRank.Zealot, PrestigeRank.Legendary, 4)]
+    [InlineData(FavorRank.Zealot, PrestigeRank.Mythic, 5)]
+    [InlineData(FavorRank.Champion, PrestigeRank.Fledgling, 4)]
+    [InlineData(FavorRank.Champion, PrestigeRank.Established, 4)]
+    [InlineData(FavorRank.Champion, PrestigeRank.Renowned, 5)]
+    [InlineData(FavorRank.Champion, PrestigeRank.Legendary, 5)]
+    [InlineData(FavorRank.Champion, PrestigeRank.Mythic, 6)]
+    [InlineData(FavorRank.Avatar, PrestigeRank.Fledgling, 5)]
+    [InlineData(FavorRank.Avatar, PrestigeRank.Established, 5)]
+    [InlineData(FavorRank.Avatar, PrestigeRank.Renowned, 6)]
+    [InlineData(FavorRank.Avatar, PrestigeRank.Legendary, 6)]
+    [InlineData(FavorRank.Avatar, PrestigeRank.Mythic, 7)]
+    public void GetMaxUnlocks_WithDefaults_ReturnsExpectedMatrix(
+        FavorRank favorRank, PrestigeRank prestigeRank, int expectedSlots)
+    {
+        var config = new GameBalanceConfig();
+
+        var slots = BlessingSlotCalculator.GetMaxUnlocks(config, favorRank, prestigeRank);
+
+        Assert.Equal(expectedSlots, slots);
+    }
+
+    [Theory]
+    [InlineData(FavorRank.Initiate, 1)]
+    [InlineData(FavorRank.Disciple, 2)]
+    [InlineData(FavorRank.Zealot, 3)]
+    [InlineData(FavorRank.Champion, 4)]
+    [InlineData(FavorRank.Avatar, 5)]
+    public void GetMaxUnlocks_WithNullPrestige_ReturnsFavorOnlyCount(
+        FavorRank favorRank, int expectedSlots)
+    {
+        var config = new GameBalanceConfig();
+
+        var slots = BlessingSlotCalculator.GetMaxUnlocks(config, favorRank, null);
+
+        Assert.Equal(expectedSlots, slots);
+    }
+
+    [Fact]
+    public void GetMaxUnlocks_HonoursOverriddenConfigValues()
+    {
+        var config = new GameBalanceConfig
+        {
+            ZealotActiveBlessingSlots = 2,
+            RenownedBonusSlots = 3
+        };
+
+        var slots = BlessingSlotCalculator.GetMaxUnlocks(config, FavorRank.Zealot, PrestigeRank.Renowned);
+
+        Assert.Equal(5, slots);
+    }
+
+    [Fact]
+    public void GetMaxUnlocks_NullConfig_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            BlessingSlotCalculator.GetMaxUnlocks(null!, FavorRank.Initiate, null));
+    }
+}

--- a/DivineAscension.Tests/Configuration/GameBalanceConfigBlessingSlotsTests.cs
+++ b/DivineAscension.Tests/Configuration/GameBalanceConfigBlessingSlotsTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+
+namespace DivineAscension.Tests.Configuration;
+
+[ExcludeFromCodeCoverage]
+public class GameBalanceConfigBlessingSlotsTests
+{
+    [Fact]
+    public void Defaults_MatchSpec()
+    {
+        var config = new GameBalanceConfig();
+
+        Assert.Equal(1, config.InitiateActiveBlessingSlots);
+        Assert.Equal(2, config.DiscipleActiveBlessingSlots);
+        Assert.Equal(3, config.ZealotActiveBlessingSlots);
+        Assert.Equal(4, config.ChampionActiveBlessingSlots);
+        Assert.Equal(5, config.AvatarActiveBlessingSlots);
+
+        Assert.Equal(0, config.FledglingBonusSlots);
+        Assert.Equal(0, config.EstablishedBonusSlots);
+        Assert.Equal(1, config.RenownedBonusSlots);
+        Assert.Equal(1, config.LegendaryBonusSlots);
+        Assert.Equal(2, config.MythicBonusSlots);
+    }
+
+    [Fact]
+    public void Validate_AcceptsDefaults()
+    {
+        var config = new GameBalanceConfig();
+
+        var ex = Record.Exception(() => config.Validate());
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(nameof(GameBalanceConfig.InitiateActiveBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.DiscipleActiveBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.ZealotActiveBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.ChampionActiveBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.AvatarActiveBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.FledglingBonusSlots))]
+    [InlineData(nameof(GameBalanceConfig.EstablishedBonusSlots))]
+    [InlineData(nameof(GameBalanceConfig.RenownedBonusSlots))]
+    [InlineData(nameof(GameBalanceConfig.LegendaryBonusSlots))]
+    [InlineData(nameof(GameBalanceConfig.MythicBonusSlots))]
+    public void Validate_RejectsNegativeSlotValues(string propertyName)
+    {
+        var config = new GameBalanceConfig();
+        typeof(GameBalanceConfig).GetProperty(propertyName)!.SetValue(config, -1);
+
+        Assert.Throws<InvalidOperationException>(() => config.Validate());
+    }
+
+    [Fact]
+    public void Validate_RejectsTotalAboveHardCap()
+    {
+        var config = new GameBalanceConfig
+        {
+            AvatarActiveBlessingSlots = 7,
+            MythicBonusSlots = 2
+        };
+
+        Assert.Throws<InvalidOperationException>(() => config.Validate());
+    }
+
+    [Fact]
+    public void Validate_AcceptsTotalAtHardCap()
+    {
+        var config = new GameBalanceConfig
+        {
+            AvatarActiveBlessingSlots = 6,
+            MythicBonusSlots = 2
+        };
+
+        var ex = Record.Exception(() => config.Validate());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Validate_RejectsCrossPairAboveHardCap()
+    {
+        var config = new GameBalanceConfig
+        {
+            ChampionActiveBlessingSlots = 6,
+            RenownedBonusSlots = 3
+        };
+
+        Assert.Throws<InvalidOperationException>(() => config.Validate());
+    }
+
+    [Fact]
+    public void HardCapConstant_Is8()
+    {
+        Assert.Equal(8, GameBalanceConfig.MaxTotalBlessingSlots);
+    }
+}

--- a/DivineAscension/Configuration/BlessingSlotCalculator.cs
+++ b/DivineAscension/Configuration/BlessingSlotCalculator.cs
@@ -1,0 +1,49 @@
+using System;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.Configuration;
+
+/// <summary>
+/// Resolves the maximum number of active blessing slots a player may unlock,
+/// based on their favor rank and (optionally) their religion's prestige rank.
+/// </summary>
+public static class BlessingSlotCalculator
+{
+    /// <summary>
+    /// Returns the player's active blessing slot allowance: favor-rank slots plus
+    /// any prestige-rank bonus. When <paramref name="prestigeRank"/> is null (player
+    /// has no religion), only the favor-rank slot count is returned.
+    /// </summary>
+    public static int GetMaxUnlocks(GameBalanceConfig config, FavorRank favorRank, PrestigeRank? prestigeRank)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var favorSlots = GetFavorSlots(config, favorRank);
+        if (prestigeRank is null)
+        {
+            return favorSlots;
+        }
+
+        return favorSlots + GetPrestigeBonus(config, prestigeRank.Value);
+    }
+
+    private static int GetFavorSlots(GameBalanceConfig config, FavorRank rank) => rank switch
+    {
+        FavorRank.Initiate => config.InitiateActiveBlessingSlots,
+        FavorRank.Disciple => config.DiscipleActiveBlessingSlots,
+        FavorRank.Zealot => config.ZealotActiveBlessingSlots,
+        FavorRank.Champion => config.ChampionActiveBlessingSlots,
+        FavorRank.Avatar => config.AvatarActiveBlessingSlots,
+        _ => throw new ArgumentOutOfRangeException(nameof(rank), rank, "Unknown favor rank")
+    };
+
+    private static int GetPrestigeBonus(GameBalanceConfig config, PrestigeRank rank) => rank switch
+    {
+        PrestigeRank.Fledgling => config.FledglingBonusSlots,
+        PrestigeRank.Established => config.EstablishedBonusSlots,
+        PrestigeRank.Renowned => config.RenownedBonusSlots,
+        PrestigeRank.Legendary => config.LegendaryBonusSlots,
+        PrestigeRank.Mythic => config.MythicBonusSlots,
+        _ => throw new ArgumentOutOfRangeException(nameof(rank), rank, "Unknown prestige rank")
+    };
+}

--- a/DivineAscension/Configuration/GameBalanceConfig.cs
+++ b/DivineAscension/Configuration/GameBalanceConfig.cs
@@ -80,6 +80,45 @@ public class GameBalanceConfig
     /// <summary>Religion prestige required for Mythic rank (default: 50000)</summary>
     public int MythicThreshold { get; set; } = 50000;
 
+    // === BLESSING SLOTS ===
+
+    // Active blessing slots granted by favor rank.
+
+    /// <summary>Active blessing slots granted at Initiate favor rank (default: 1)</summary>
+    public int InitiateActiveBlessingSlots { get; set; } = 1;
+
+    /// <summary>Active blessing slots granted at Disciple favor rank (default: 2)</summary>
+    public int DiscipleActiveBlessingSlots { get; set; } = 2;
+
+    /// <summary>Active blessing slots granted at Zealot favor rank (default: 3)</summary>
+    public int ZealotActiveBlessingSlots { get; set; } = 3;
+
+    /// <summary>Active blessing slots granted at Champion favor rank (default: 4)</summary>
+    public int ChampionActiveBlessingSlots { get; set; } = 4;
+
+    /// <summary>Active blessing slots granted at Avatar favor rank (default: 5)</summary>
+    public int AvatarActiveBlessingSlots { get; set; } = 5;
+
+    // Bonus active blessing slots granted by religion prestige rank.
+
+    /// <summary>Bonus active blessing slots from Fledgling religion prestige (default: 0)</summary>
+    public int FledglingBonusSlots { get; set; } = 0;
+
+    /// <summary>Bonus active blessing slots from Established religion prestige (default: 0)</summary>
+    public int EstablishedBonusSlots { get; set; } = 0;
+
+    /// <summary>Bonus active blessing slots from Renowned religion prestige (default: 1)</summary>
+    public int RenownedBonusSlots { get; set; } = 1;
+
+    /// <summary>Bonus active blessing slots from Legendary religion prestige (default: 1)</summary>
+    public int LegendaryBonusSlots { get; set; } = 1;
+
+    /// <summary>Bonus active blessing slots from Mythic religion prestige (default: 2)</summary>
+    public int MythicBonusSlots { get; set; } = 2;
+
+    /// <summary>Hard cap on total active blessing slots (favor + prestige bonus).</summary>
+    public const int MaxTotalBlessingSlots = 8;
+
     // === PVP SYSTEM ===
 
     /// <summary>Base favor awarded for PvP kill (default: 10)</summary>
@@ -183,6 +222,57 @@ public class GameBalanceConfig
               HolySiteTier2Multiplier <= HolySiteTier3Multiplier))
         {
             throw new InvalidOperationException("Holy site tier multipliers must be ascending");
+        }
+
+        ValidateBlessingSlots();
+    }
+
+    private void ValidateBlessingSlots()
+    {
+        int[] favorSlots =
+        {
+            InitiateActiveBlessingSlots,
+            DiscipleActiveBlessingSlots,
+            ZealotActiveBlessingSlots,
+            ChampionActiveBlessingSlots,
+            AvatarActiveBlessingSlots
+        };
+
+        int[] prestigeBonus =
+        {
+            FledglingBonusSlots,
+            EstablishedBonusSlots,
+            RenownedBonusSlots,
+            LegendaryBonusSlots,
+            MythicBonusSlots
+        };
+
+        foreach (var slots in favorSlots)
+        {
+            if (slots < 0)
+            {
+                throw new InvalidOperationException("Active blessing slot counts must be >= 0");
+            }
+        }
+
+        foreach (var bonus in prestigeBonus)
+        {
+            if (bonus < 0)
+            {
+                throw new InvalidOperationException("Prestige bonus blessing slot counts must be >= 0");
+            }
+        }
+
+        foreach (var favor in favorSlots)
+        {
+            foreach (var bonus in prestigeBonus)
+            {
+                if (favor + bonus > MaxTotalBlessingSlots)
+                {
+                    throw new InvalidOperationException(
+                        $"Total active blessing slots (favor + prestige bonus) must not exceed {MaxTotalBlessingSlots}");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Add per-favor-rank active blessing slot fields and per-prestige-rank bonus
fields to GameBalanceConfig, plus a BlessingSlotCalculator helper that
returns the player's slot allowance (favor slots + prestige bonus, with
prestige bonus omitted when the player has no religion). Validate()
rejects negatives and enforces an 8-slot hard cap on any (favor, prestige)
pair.

Part of epic #423.