### PR TITLE
feat(blessings): enforce active unlock slot cap (#444)

### DIFF
--- a/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
 using DivineAscension.Models;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services.Interfaces;
@@ -22,6 +23,8 @@ public class BlessingRegistryTests
 
     public BlessingRegistryTests()
     {
+        TestFixtures.InitializeLocalizationForTests();
+
         _mockAPI = TestFixtures.CreateMockCoreAPI();
         _mockLogger = new Mock<ILogger>();
         _mockAPI.Setup(a => a.Logger).Returns(_mockLogger.Object);
@@ -603,6 +606,126 @@ public class BlessingRegistryTests
         // Assert - should return true because cost check is skipped
         Assert.True(canUnlock);
         Assert.Equal("Can unlock", reason);
+    }
+
+    #endregion
+
+    #region CanUnlockBlessing Tests - Unlock Cap (#423.2)
+
+    /// <summary>
+    /// Helper: build a registry with a specific GameBalanceConfig so cap tests
+    /// can stay independent of the shared default-config _registry.
+    /// </summary>
+    private BlessingRegistry CreateRegistryWithConfig(GameBalanceConfig config)
+    {
+        return new BlessingRegistry(_mockAPI.Object, TestBlessingLoader.CreateWithSampleBlessings(), config);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_AtCap_ReturnsFalseWithCapReason()
+    {
+        // Initiate + Fledgling => 1 favor slot + 0 prestige bonus = 1 slot total.
+        // Player already has 1 unlocked blessing, attempting a second.
+        var config = new GameBalanceConfig();
+        var registry = CreateRegistryWithConfig(config);
+
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        playerData.UnlockBlessing("existing_blessing");
+
+        var blessing = TestFixtures.CreateTestBlessing("new_blessing", "New", DeityDomain.Craft, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.Cost = 0;
+
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
+        religion.PrestigeRank = PrestigeRank.Fledgling;
+
+        var (canUnlock, reason) = registry.CanUnlockBlessing(
+            "player-uid", FavorRank.Initiate, playerData, religion, blessing);
+
+        Assert.False(canUnlock);
+        // Reason should reflect cap state (current/max) and point at unlearn (#425).
+        Assert.Contains("1/1", reason);
+        Assert.Contains("Unlearn", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_UnderCap_AllowsUnlock()
+    {
+        // Disciple + Fledgling => 2 favor slots + 0 prestige bonus = 2 slots.
+        // Player has 1 unlocked, attempting a second (under cap).
+        var config = new GameBalanceConfig();
+        var registry = CreateRegistryWithConfig(config);
+
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        playerData.UnlockBlessing("existing_blessing");
+
+        var blessing = TestFixtures.CreateTestBlessing("new_blessing", "New", DeityDomain.Craft, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.Cost = 0;
+
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
+        religion.PrestigeRank = PrestigeRank.Fledgling;
+
+        var (canUnlock, reason) = registry.CanUnlockBlessing(
+            "player-uid", FavorRank.Disciple, playerData, religion, blessing);
+
+        Assert.True(canUnlock);
+        Assert.Equal("Can unlock", reason);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_PrestigeBonusSlotsCountTowardCap()
+    {
+        // Initiate + Renowned => 1 favor + 1 prestige bonus = 2 slots.
+        // Player already has 2 unlocked → cap reached.
+        var config = new GameBalanceConfig();
+        var registry = CreateRegistryWithConfig(config);
+
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        playerData.UnlockBlessing("existing_a");
+        playerData.UnlockBlessing("existing_b");
+
+        var blessing = TestFixtures.CreateTestBlessing("third", "Third", DeityDomain.Craft, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.Cost = 0;
+
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
+        religion.PrestigeRank = PrestigeRank.Renowned;
+
+        var (canUnlock, reason) = registry.CanUnlockBlessing(
+            "player-uid", FavorRank.Initiate, playerData, religion, blessing);
+
+        // 2 unlocked, cap of 2 (1 favor + 1 prestige bonus) → rejected with cap reason.
+        Assert.False(canUnlock);
+        Assert.Contains("2/2", reason);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_NonReligionPlayer_UsesFavorOnlyCap()
+    {
+        // No religion → calculator treats prestige rank as null → favor slots only.
+        // Disciple gives 2 slots regardless of any prestige bonus.
+        var config = new GameBalanceConfig
+        {
+            // Make prestige bonus large so we can prove it is NOT applied without religion.
+            RenownedBonusSlots = 5
+        };
+        var registry = CreateRegistryWithConfig(config);
+
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, religionUID: null);
+        playerData.UnlockBlessing("existing_a");
+        playerData.UnlockBlessing("existing_b");
+
+        var blessing = TestFixtures.CreateTestBlessing("third", "Third", DeityDomain.Craft, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.Cost = 0;
+
+        var (canUnlock, reason) = registry.CanUnlockBlessing(
+            "player-uid", FavorRank.Disciple, playerData, religionData: null, blessing);
+
+        // 2 unlocked, cap of 2 (favor-only) → rejected with cap reason, NOT "Not in a religion".
+        Assert.False(canUnlock);
+        Assert.Contains("2/2", reason);
     }
 
     #endregion

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -1663,6 +1663,8 @@ public static class LocalizationKeys
     public const string NET_BLESSING_UNLOCKED_NOTIFICATION = "divineascension:net.blessing.unlocked_notification";
     public const string NET_BLESSING_ERROR_UNLOCKING = "divineascension:net.blessing.error_unlocking";
 
+    public const string NET_BLESSING_UNLOCK_CAP_REACHED = "divineascension:net.blessing.unlock_cap_reached";
+
     #endregion
 
     #region Network Messages - Diplomacy

--- a/DivineAscension/Systems/BlessingRegistry.cs
+++ b/DivineAscension/Systems/BlessingRegistry.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DivineAscension.Configuration;
+using DivineAscension.Constants;
 using DivineAscension.Data;
 using DivineAscension.Models;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Services.Interfaces;
 using DivineAscension.Systems.Interfaces;
 using Vintagestory.API.Common;
@@ -17,6 +20,7 @@ public class BlessingRegistry : IBlessingRegistry
 {
     private readonly ICoreAPI _api;
     private readonly IBlessingLoader? _blessingLoader;
+    private readonly GameBalanceConfig _config;
     private readonly Dictionary<string, Blessing> _blessings = new();
 
     /// <summary>
@@ -24,10 +28,12 @@ public class BlessingRegistry : IBlessingRegistry
     /// </summary>
     /// <param name="api">The Vintage Story API</param>
     /// <param name="blessingLoader">The blessing loader for JSON assets</param>
-    public BlessingRegistry(ICoreAPI api, IBlessingLoader? blessingLoader = null)
+    /// <param name="config">Balance config used for blessing slot cap enforcement</param>
+    public BlessingRegistry(ICoreAPI api, IBlessingLoader? blessingLoader = null, GameBalanceConfig? config = null)
     {
         _api = api;
         _blessingLoader = blessingLoader;
+        _config = config ?? new GameBalanceConfig();
     }
 
     /// <summary>
@@ -142,10 +148,18 @@ public class BlessingRegistry : IBlessingRegistry
         // Check blessing type and corresponding requirements
         if (blessing.Kind == BlessingKind.Player)
         {
-            if (religionData == null) return (false, "Not in a religion");
-
             // Check if already unlocked
             if (playerData.IsBlessingUnlocked(blessing.BlessingId)) return (false, "Blessing already unlocked");
+
+            // Enforce active blessing slot cap. Calculator falls back to favor-only when no religion.
+            var maxUnlocks = BlessingSlotCalculator.GetMaxUnlocks(_config, playerFavorRank, religionData?.PrestigeRank);
+            var currentCount = playerData.UnlockedBlessings.Count;
+            if (currentCount >= maxUnlocks)
+                return (false,
+                    LocalizationService.Instance.Get(LocalizationKeys.NET_BLESSING_UNLOCK_CAP_REACHED,
+                        currentCount, maxUnlocks));
+
+            if (religionData == null) return (false, "Not in a religion");
 
             // Check favor rank requirement
             if (playerFavorRank < (FavorRank)blessing.RequiredFavorRank)

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -311,7 +311,7 @@ public static class DivineAscensionSystemInitializer
         // Create blessing loader for JSON-based blessing definitions
         IBlessingLoader blessingLoader =
             new BlessingLoader(api, LoggingService.Instance.CreateLogger("BlessingLoader"));
-        var blessingRegistry = new BlessingRegistry(api, blessingLoader);
+        var blessingRegistry = new BlessingRegistry(api, blessingLoader, gameBalanceConfig);
         blessingRegistry.Initialize();
 
         var blessingEffectSystem =

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -957,6 +957,7 @@
   "divineascension:net.blessing.success_unlocked_for_religion": "Successfully unlocked {0} for all religion members!",
   "divineascension:net.blessing.unlocked_notification": "{0} has been unlocked!",
   "divineascension:net.blessing.error_unlocking": "Error unlocking blessing: {0}",
+  "divineascension:net.blessing.unlock_cap_reached": "Blessing slots full ({0}/{1}). Unlearn an existing blessing to free a slot.",
   "divineascension:net.diplomacy.must_be_in_religion": "You must be in a religion to use diplomacy.",
   "divineascension:net.diplomacy.religion_no_longer_exists": "Your religion no longer exists.",
   "divineascension:net.diplomacy.not_part_of_civilization": "Your religion is not part of a civilization.",


### PR DESCRIPTION
Reject blessing unlock requests when a player's UnlockedBlessings count is
at or above BlessingSlotCalculator.GetMaxUnlocks(favor, prestige). The cap
is evaluated before the religion check so non-religion players hit the
favor-only cap with the same reason instead of "Not in a religion".

The cap-reached reason uses a new localization key and points players at
unlearn (#425, not yet implemented) to free a slot.

Admin unlock paths bypass CanUnlockBlessing and remain uncapped.

Part of epic #423.

https://claude.ai/code/session_019tSdbn1YS6gZd5jkZJGwdc