### PR TITLE
feat(blessings): broadcast slot count on rank-up (#445)

### DIFF
--- a/DivineAscension.Tests/Systems/Networking/Server/PlayerDataNetworkHandlerTests.cs
+++ b/DivineAscension.Tests/Systems/Networking/Server/PlayerDataNetworkHandlerTests.cs
@@ -1,0 +1,185 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+using DivineAscension.Data;
+using DivineAscension.Models.Enum;
+using DivineAscension.Network;
+using DivineAscension.Services;
+using DivineAscension.Systems;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Systems.Networking.Server;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Tests.Systems.Networking.Server;
+
+/// <summary>
+///     Tests for PlayerDataNetworkHandler — verifies <see cref="PlayerReligionDataPacket"/>
+///     carries the correct <c>MaxBlessingSlots</c> (#445) and that prestige rank-ups
+///     trigger a broadcast refresh to every religion member.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class PlayerDataNetworkHandlerTests
+{
+    private readonly GameBalanceConfig _config;
+    private readonly FakeEventService _eventService;
+    private readonly FakePersistenceService _persistenceService;
+    private readonly FakeTimeService _timeService;
+    private readonly FakeWorldService _worldService;
+    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<ILoggerWrapper> _mockLoggerWrapper;
+    private readonly Mock<IReligionManager> _mockReligionManager;
+    private readonly SpyNetworkService _networkService;
+    private readonly PlayerProgressionDataManager _progression;
+    private readonly ReligionPrestigeManager _prestige;
+    private readonly PlayerDataNetworkHandler _handler;
+
+    public PlayerDataNetworkHandlerTests()
+    {
+        _config = new GameBalanceConfig();
+        _mockLogger = new Mock<ILogger>();
+        _mockLoggerWrapper = new Mock<ILoggerWrapper>();
+        _mockReligionManager = new Mock<IReligionManager>();
+        _eventService = new FakeEventService();
+        _persistenceService = new FakePersistenceService();
+        _worldService = new FakeWorldService();
+        _timeService = new FakeTimeService();
+        _networkService = new SpyNetworkService();
+
+        _progression = new PlayerProgressionDataManager(_mockLoggerWrapper.Object, _eventService,
+            _persistenceService, _worldService, _mockReligionManager.Object, _config, _timeService);
+        _prestige = new ReligionPrestigeManager(_mockLoggerWrapper.Object, _worldService,
+            _mockReligionManager.Object, _config);
+
+        _handler = new PlayerDataNetworkHandler(
+            _mockLogger.Object,
+            _worldService,
+            _eventService,
+            _networkService,
+            _progression,
+            _mockReligionManager.Object,
+            _prestige,
+            _config);
+    }
+
+    /// <summary>
+    ///     Favor rank-up triggers <c>OnPlayerDataChanged</c>, which sends a refreshed
+    ///     <see cref="PlayerReligionDataPacket"/> whose <c>MaxBlessingSlots</c> reflects
+    ///     the new rank (Disciple = 2 slots by default).
+    /// </summary>
+    [Fact]
+    public void AddFavor_RankUp_SendsPacketWithUpdatedSlotCount()
+    {
+        // Arrange: a Fledgling religion (no prestige bonus), founder is the only member.
+        var religion = TestFixtures.CreateTestReligion(domain: DeityDomain.Craft, founderUID: "founder");
+        _mockReligionManager.Setup(m => m.GetPlayerReligion("founder")).Returns(religion);
+        _mockReligionManager.Setup(m => m.GetReligion(religion.ReligionUID)).Returns(religion);
+
+        var player = _worldService.CreatePlayer("founder", "Founder");
+
+        // Player just under the Disciple threshold (Initiate = 1 slot).
+        var data = _progression.GetOrCreatePlayerData("founder");
+        data.SetTotalFavorEarned(DeityDomain.Craft, _config.DiscipleThreshold - 10);
+
+        // Act: cross the threshold; PlayerProgressionDataManager fires OnPlayerDataChanged.
+        _progression.AddFavor("founder", DeityDomain.Craft, 20);
+
+        // Assert: packet carries Disciple slot count.
+        var packet = _networkService.GetLastSentMessage<PlayerReligionDataPacket>();
+        Assert.NotNull(packet);
+        Assert.Equal(_config.DiscipleActiveBlessingSlots, packet!.MaxBlessingSlots);
+    }
+
+    /// <summary>
+    ///     Slot count uses the player's highest favor rank across all five deities plus
+    ///     the religion's prestige bonus — captures "the best you can do" so the toast
+    ///     fires whenever any deity rank-up raises the cap.
+    /// </summary>
+    [Fact]
+    public void SendPlayerDataToClient_UsesHighestFavorRank_PlusPrestigeBonus()
+    {
+        // Arrange: Renowned religion (+1 bonus). Player is Avatar in Wild, Initiate elsewhere.
+        var religion = TestFixtures.CreateTestReligion(domain: DeityDomain.Craft, founderUID: "founder");
+        religion.PrestigeRank = PrestigeRank.Renowned;
+        _mockReligionManager.Setup(m => m.GetPlayerReligion("founder")).Returns(religion);
+        _mockReligionManager.Setup(m => m.GetReligion(religion.ReligionUID)).Returns(religion);
+
+        var player = _worldService.CreatePlayer("founder", "Founder");
+        var data = _progression.GetOrCreatePlayerData("founder");
+        data.SetTotalFavorEarned(DeityDomain.Wild, _config.AvatarThreshold);
+
+        // Act
+        _handler.SendPlayerDataToClient(player);
+
+        // Assert: Avatar (5) + Renowned bonus (1) = 6.
+        var packet = _networkService.GetLastSentMessage<PlayerReligionDataPacket>();
+        Assert.NotNull(packet);
+        Assert.Equal(_config.AvatarActiveBlessingSlots + _config.RenownedBonusSlots,
+            packet!.MaxBlessingSlots);
+    }
+
+    /// <summary>
+    ///     Prestige rank-up that crosses a bonus threshold (Established → Renowned grants
+    ///     +1 slot by default) triggers a refresh for every religion member, not just the
+    ///     player who earned the prestige.
+    /// </summary>
+    [Fact]
+    public void PrestigeRankUp_SendsPacketToAllReligionMembers()
+    {
+        // Arrange: religion with founder + two extra members, sitting just under Renowned.
+        var religion = TestFixtures.CreateTestReligion(domain: DeityDomain.Craft, founderUID: "founder");
+        religion.AddMember("member-2", "Member Two");
+        religion.AddMember("member-3", "Member Three");
+        religion.TotalPrestige = _config.RenownedThreshold - 1;
+        religion.PrestigeRank = PrestigeRank.Established;
+
+        _mockReligionManager.Setup(m => m.GetReligion(religion.ReligionUID)).Returns(religion);
+        _mockReligionManager.Setup(m => m.GetPlayerReligion(It.IsAny<string>())).Returns(religion);
+
+        // All three members are online and have progression data so a packet is built.
+        foreach (var uid in new[] { "founder", "member-2", "member-3" })
+        {
+            _worldService.CreatePlayer(uid, uid);
+            _progression.GetOrCreatePlayerData(uid);
+        }
+
+        // Act: cross the Renowned threshold (Established → Renowned grants +1 bonus slot).
+        _prestige.AddPrestige(religion.ReligionUID, 1);
+
+        // Assert: all three members got a refreshed packet, each carrying the new bonus.
+        var packets = _networkService.GetSentMessages<PlayerReligionDataPacket>().ToList();
+        Assert.Equal(3, packets.Count);
+        Assert.All(packets, p => Assert.Equal(
+            _config.InitiateActiveBlessingSlots + _config.RenownedBonusSlots,
+            p.MaxBlessingSlots));
+    }
+
+    /// <summary>
+    ///     Prestige gain that doesn't cross a rank threshold doesn't trigger a member-wide
+    ///     broadcast — the per-member packet only goes out when the rank itself moves.
+    /// </summary>
+    [Fact]
+    public void PrestigeGain_WithoutRankUp_DoesNotBroadcastToMembers()
+    {
+        // Arrange: religion comfortably within Fledgling, two members.
+        var religion = TestFixtures.CreateTestReligion(domain: DeityDomain.Craft, founderUID: "founder");
+        religion.AddMember("member-2", "Member Two");
+        religion.TotalPrestige = 0;
+        religion.PrestigeRank = PrestigeRank.Fledgling;
+
+        _mockReligionManager.Setup(m => m.GetReligion(religion.ReligionUID)).Returns(religion);
+
+        foreach (var uid in new[] { "founder", "member-2" })
+        {
+            _worldService.CreatePlayer(uid, uid);
+            _progression.GetOrCreatePlayerData(uid);
+        }
+
+        // Act: small bump well below Established threshold.
+        _prestige.AddPrestige(religion.ReligionUID, 10);
+
+        // Assert: handler did not push any packet on behalf of the prestige event.
+        Assert.Empty(_networkService.GetSentMessages<PlayerReligionDataPacket>());
+    }
+}

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -845,6 +845,8 @@ public static class LocalizationKeys
 
     public const string UI_RANKUP_TITLE = "divineascension:ui.rankup.title";
     public const string UI_RANKUP_VIEW_BLESSINGS = "divineascension:ui.rankup.view_blessings";
+    public const string UI_RANKUP_SLOTS_TITLE = "divineascension:ui.rankup.slots.title";
+    public const string UI_RANKUP_SLOTS_DESCRIPTION = "divineascension:ui.rankup.slots.description";
 
     #endregion
 

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DivineAscension.Constants;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.State.Religion;
 using DivineAscension.GUI.UI.Utilities;
@@ -10,6 +11,7 @@ using DivineAscension.Models.Enum;
 using DivineAscension.Network;
 using DivineAscension.Network.Civilization;
 using DivineAscension.Network.HolySite;
+using DivineAscension.Services;
 using Vintagestory.API.Client;
 
 namespace DivineAscension.GUI;
@@ -62,6 +64,7 @@ public partial class GuiDialog
             // Clear previous ranks when player has no religion
             _state.PreviousFavorRank = string.Empty;
             _state.PreviousPrestigeRank = string.Empty;
+            _state.PreviousMaxBlessingSlots = -1;
 
             // Dialog will only open when player presses the keybind (Shift+G)
 
@@ -162,6 +165,7 @@ public partial class GuiDialog
             _manager.NotificationManager.State.PendingNotifications.Clear();
             _state.PreviousFavorRank = string.Empty;
             _state.PreviousPrestigeRank = string.Empty;
+            _state.PreviousMaxBlessingSlots = -1;
             _logger?.Debug(
                 "[DivineAscension] Cleared notification queue and previous ranks due to religion state change");
         }
@@ -559,8 +563,30 @@ public partial class GuiDialog
                     _manager.ReligionStateManager.CurrentReligionDomain);
         }
 
+        // Check for blessing-slot increase (#445). Fires whenever the cap grows —
+        // typically alongside a favor or prestige rank-up that crossed a slot threshold,
+        // but also any future config-driven bump. Sentinel -1 suppresses the toast on
+        // the first packet for a session.
+        if (_state.PreviousMaxBlessingSlots >= 0 &&
+            packet.MaxBlessingSlots > _state.PreviousMaxBlessingSlots)
+        {
+            var gained = packet.MaxBlessingSlots - _state.PreviousMaxBlessingSlots;
+            _logger?.Notification(
+                $"[DivineAscension] Blessing slots increased: {_state.PreviousMaxBlessingSlots} → {packet.MaxBlessingSlots}");
+            var slotTitle = LocalizationService.Instance.Get(
+                LocalizationKeys.UI_RANKUP_SLOTS_TITLE, packet.MaxBlessingSlots);
+            var slotDescription = LocalizationService.Instance.Get(
+                LocalizationKeys.UI_RANKUP_SLOTS_DESCRIPTION, packet.MaxBlessingSlots, gained);
+            _manager.NotificationManager.QueueRankUpNotification(
+                NotificationType.BlessingSlotsIncreased,
+                slotTitle,
+                slotDescription,
+                _manager.ReligionStateManager.CurrentReligionDomain);
+        }
+
         _state.PreviousFavorRank = patronRankName;
         if (packet.PrestigeRank != null) _state.PreviousPrestigeRank = packet.PrestigeRank;
+        _state.PreviousMaxBlessingSlots = packet.MaxBlessingSlots;
 
         // Refresh blessing states in case new blessings became available
         // Only do this if dialog is open to avoid unnecessary processing

--- a/DivineAscension/GUI/State/GuiDialogState.cs
+++ b/DivineAscension/GUI/State/GuiDialogState.cs
@@ -47,6 +47,13 @@ public class GuiDialogState
     public string? PreviousPrestigeRank { get; set; }
 
     /// <summary>
+    ///     Last seen <c>MaxBlessingSlots</c> from the server. -1 sentinel means "not yet
+    ///     observed" so the very first packet doesn't trigger a spurious slot-up toast.
+    ///     Compared against the incoming packet to drive the #445 slot-increase notification.
+    /// </summary>
+    public int PreviousMaxBlessingSlots { get; set; } = -1;
+
+    /// <summary>
     ///     Sidebar nav state (Phase 1 scaffold; wired in Phase 3).
     /// </summary>
     public SidebarState Sidebar { get; } = new();

--- a/DivineAscension/Models/Enum/NotificationType.cs
+++ b/DivineAscension/Models/Enum/NotificationType.cs
@@ -4,5 +4,6 @@ public enum NotificationType
 {
     None,
     FavorRankUp,
-    PrestigeRankUp
+    PrestigeRankUp,
+    BlessingSlotsIncreased
 }

--- a/DivineAscension/Network/PlayerReligionDataPacket.cs
+++ b/DivineAscension/Network/PlayerReligionDataPacket.cs
@@ -78,4 +78,12 @@ public class PlayerReligionDataPacket
     /// </summary>
     [ProtoMember(19)]
     public Dictionary<DeityDomain, int> TotalFavorEarnedByDeity { get; set; } = new();
+
+    /// <summary>
+    ///     Maximum number of blessings the player may currently have unlocked
+    ///     (favor-rank slots + prestige bonus). Drives the active-slot cap from #444
+    ///     and the slot-up toast from #445.
+    /// </summary>
+    [ProtoMember(20)]
+    public int MaxBlessingSlots { get; set; }
 }

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -367,6 +367,7 @@ public static class DivineAscensionSystemInitializer
             networkService,
             playerReligionDataManager,
             religionManager,
+            religionPrestigeManager,
             gameBalanceConfig);
         playerDataHandler.RegisterHandlers();
 

--- a/DivineAscension/Systems/Interfaces/IReligionPrestigeManager.cs
+++ b/DivineAscension/Systems/Interfaces/IReligionPrestigeManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using DivineAscension.Models.Enum;
 
@@ -8,6 +9,13 @@ namespace DivineAscension.Systems.Interfaces;
 /// </summary>
 public interface IReligionPrestigeManager
 {
+    /// <summary>
+    ///     Raised when a religion's prestige rank changes. Arguments: religionUID, oldRank, newRank.
+    ///     Subscribed by <c>PlayerDataNetworkHandler</c> so every member gets a refreshed
+    ///     <c>PlayerReligionDataPacket</c> (slot count may have changed via prestige bonus).
+    /// </summary>
+    event Action<string, PrestigeRank, PrestigeRank>? OnPrestigeRankChanged;
+
     /// <summary>
     ///     Sets the blessing registry and effect system (called after they're initialized)
     /// </summary>

--- a/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
@@ -28,6 +28,7 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
 
     private readonly IPlayerProgressionDataManager? _playerProgressionDataManager;
     private readonly IReligionManager? _religionManager;
+    private readonly IReligionPrestigeManager? _religionPrestigeManager;
     private readonly ILogger? _logger;
     private readonly IWorldService? _worldService;
     private readonly IEventService? _eventService;
@@ -44,6 +45,7 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
         INetworkService networkService,
         IPlayerProgressionDataManager playerProgressionDataManager,
         IReligionManager religionManager,
+        IReligionPrestigeManager religionPrestigeManager,
         GameBalanceConfig config)
     {
         _logger = logger;
@@ -52,10 +54,12 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
         _networkService = networkService;
         _playerProgressionDataManager = playerProgressionDataManager;
         _religionManager = religionManager;
+        _religionPrestigeManager = religionPrestigeManager;
         _config = config;
 
         // Subscribe to events
         _playerProgressionDataManager.OnPlayerDataChanged += OnPlayerDataChanged;
+        _religionPrestigeManager.OnPrestigeRankChanged += OnPrestigeRankChanged;
         _eventService!.OnPlayerJoin(OnPlayerJoin);
     }
 
@@ -68,6 +72,9 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
         // Unsubscribe from events
         if (_playerProgressionDataManager != null)
             _playerProgressionDataManager.OnPlayerDataChanged -= OnPlayerDataChanged;
+
+        if (_religionPrestigeManager != null)
+            _religionPrestigeManager.OnPrestigeRankChanged -= OnPrestigeRankChanged;
 
         if (_eventService != null)
             _eventService.UnsubscribePlayerJoin(OnPlayerJoin);
@@ -86,6 +93,24 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
     {
         var player = _worldService!.GetPlayerByUID(playerUID);
         if (player != null) SendPlayerDataToClient(player);
+    }
+
+    /// <summary>
+    ///     Religion prestige rank changed (#445): every member needs a refreshed packet
+    ///     so the client can detect any change in <c>MaxBlessingSlots</c> and toast.
+    /// </summary>
+    private void OnPrestigeRankChanged(string religionUID, PrestigeRank oldRank, PrestigeRank newRank)
+    {
+        if (_religionManager == null || _worldService == null) return;
+
+        var religion = _religionManager.GetReligion(religionUID);
+        if (religion == null) return;
+
+        foreach (var memberUID in religion.MemberUIDs)
+        {
+            var player = _worldService.GetPlayerByUID(memberUID);
+            if (player != null) SendPlayerDataToClient(player);
+        }
     }
 
     /// <summary>
@@ -115,6 +140,19 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
                 totalByDeity[domain] = playerReligionData.GetTotalFavorEarned(domain);
             }
 
+            // Effective slot cap: take the player's best favor rank across deities and add
+            // the religion's prestige bonus. Captures "best you can do" — favor rank-ups on
+            // any deity (or prestige rank-ups that grant bonus slots) raise this, which is
+            // what the client compares to drive the slot-up toast (#445).
+            var maxFavorRank = FavorRank.Initiate;
+            foreach (var domain in AllDeities)
+            {
+                var rank = _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, domain);
+                if (rank > maxFavorRank) maxFavorRank = rank;
+            }
+            var maxBlessingSlots =
+                BlessingSlotCalculator.GetMaxUnlocks(_config, maxFavorRank, religionData.PrestigeRank);
+
             var packet = new PlayerReligionDataPacket(
                 religionData.ReligionName,
                 religionData.PatronDomain,
@@ -134,7 +172,8 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
                 EstablishedThreshold = _config.EstablishedThreshold,
                 RenownedThreshold = _config.RenownedThreshold,
                 LegendaryThreshold = _config.LegendaryThreshold,
-                MythicThreshold = _config.MythicThreshold
+                MythicThreshold = _config.MythicThreshold,
+                MaxBlessingSlots = maxBlessingSlots
             };
 
             _networkService.SendToPlayer(player, packet);

--- a/DivineAscension/Systems/ReligionPrestigeManager.cs
+++ b/DivineAscension/Systems/ReligionPrestigeManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DivineAscension.API.Interfaces;
@@ -35,6 +36,9 @@ public class ReligionPrestigeManager : IReligionPrestigeManager
         _religionManager = religionManager;
         _config = config;
     }
+
+    /// <inheritdoc />
+    public event Action<string, PrestigeRank, PrestigeRank>? OnPrestigeRankChanged;
 
     /// <summary>
     ///     Sets the blessing registry and effect system (called after they're initialized)
@@ -155,6 +159,10 @@ public class ReligionPrestigeManager : IReligionPrestigeManager
 
             // Check for new blessing unlocks
             CheckForNewBlessingUnlocks(religionUID, newRank);
+
+            // Notify listeners (PlayerDataNetworkHandler refreshes every member so their
+            // blessing-slot count reflects any prestige bonus crossed).
+            OnPrestigeRankChanged?.Invoke(religionUID, oldRank, newRank);
         }
     }
 

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -547,6 +547,8 @@
   "divineascension:ui.common.never": "Never",
   "divineascension:ui.rankup.title": "Rank Up!",
   "divineascension:ui.rankup.view_blessings": "View Blessings (Shift+G)",
+  "divineascension:ui.rankup.slots.title": "Blessing slots: {0}",
+  "divineascension:ui.rankup.slots.description": "You can now hold {0} active blessings (+{1}).",
   "divineascension:ui.table.name": "Name",
   "divineascension:ui.table.deity_name": "Deity",
   "divineascension:ui.table.prestige": "Prestige",


### PR DESCRIPTION
PlayerReligionDataPacket now carries the player's MaxBlessingSlots
(highest favor rank across deities + religion prestige bonus).
ReligionPrestigeManager raises OnPrestigeRankChanged on rank
transitions; PlayerDataNetworkHandler refreshes every member so a
prestige rank-up that grants bonus slots reaches the whole religion.
Client tracks the previous slot count and queues a slot-up toast via
the existing RankUpNotificationOverlay infrastructure.

https://claude.ai/code/session_01UTQPeyfxpCXiwnDjarxB5j