### PR TITLE
test(gui): align sound mgr + civ state tests with new sound mapping

### DIFF
--- a/DivineAscension.Tests/GUI/Managers/CivilizationStateManagerTests.cs
+++ b/DivineAscension.Tests/GUI/Managers/CivilizationStateManagerTests.cs
@@ -374,7 +374,7 @@ public class CivilizationStateManagerTests
         _sut.OnCivilizationActionCompleted(packet);
 
         // Assert
-        _mockSoundManager.Verify(s => s.PlayClick(), Times.Once);
+        _mockSoundManager.Verify(s => s.PlaySuccess(), Times.Once);
         _mockUiService.Verify(u => u.RequestCivilizationList(It.IsAny<string>()), Times.Once);
         _mockUiService.Verify(u => u.RequestCivilizationInfo(string.Empty), Times.Once);
     }
@@ -440,7 +440,7 @@ public class CivilizationStateManagerTests
         Assert.Equal("civ-new", _sut.CurrentCivilizationId);
         Assert.Equal("Grand Alliance", _sut.CurrentCivilizationName);
         _mockUiService.Verify(u => u.RequestCivilizationAction("create", "", "", "Grand Alliance", "", ""), Times.Once);
-        _mockSoundManager.Verify(s => s.PlayClick(), Times.Once);
+        _mockSoundManager.Verify(s => s.PlaySuccess(), Times.Once);
     }
 
     [Fact]
@@ -505,7 +505,7 @@ public class CivilizationStateManagerTests
         // Assert
         Assert.False(_sut.HasCivilization());
         _mockUiService.Verify(u => u.RequestCivilizationAction("leave", "", "", "", "", ""), Times.Once);
-        _mockSoundManager.Verify(s => s.PlayClick(), Times.Once);
+        _mockSoundManager.Verify(s => s.PlaySuccess(), Times.Once);
     }
 
     [Fact]

--- a/DivineAscension.Tests/GUI/Managers/SoundManagerTests.cs
+++ b/DivineAscension.Tests/GUI/Managers/SoundManagerTests.cs
@@ -49,18 +49,19 @@ public class SoundManagerTests
     }
 
     [Fact]
-    public void PlayClick_PlaysClickAtNormalVolume()
+    public void PlayClick_IsNoOp()
     {
+        // Click sound intentionally disconnected from UI (see SoundManager.PlayClick).
         _sut.PlayClick();
 
         _mockWorld.Verify(w => w.PlaySoundAt(
-            It.Is<AssetLocation>(al => al.ToString() == "divineascension:sounds/click"),
-            _mockEntity.Object,
+            It.IsAny<AssetLocation>(),
+            It.IsAny<Entity>(),
             It.IsAny<IPlayer?>(),
-            false,
-            8f,
-            0.5f
-        ), Times.Once);
+            It.IsAny<bool>(),
+            It.IsAny<float>(),
+            It.IsAny<float>()
+        ), Times.Never);
     }
 
     [Fact]
@@ -79,36 +80,36 @@ public class SoundManagerTests
     }
 
     [Fact]
-    public void PlaySuccess_PlaysUnlockAtLoudVolume()
+    public void PlaySuccess_PlaysWritingAtNormalVolume()
     {
         _sut.PlaySuccess();
 
         _mockWorld.Verify(w => w.PlaySoundAt(
-            It.Is<AssetLocation>(al => al.ToString() == "divineascension:sounds/unlock"),
+            It.Is<AssetLocation>(al => al.ToString() == "divineascension:sounds/writing"),
             _mockEntity.Object,
             It.IsAny<IPlayer?>(),
             false,
             8f,
-            0.7f
+            0.5f
         ), Times.Once);
     }
 
     [Theory]
-    [InlineData(DeityDomain.Craft, "divineascension:sounds/deities/craft")]
-    [InlineData(DeityDomain.Wild, "divineascension:sounds/deities/wild")]
-    [InlineData(DeityDomain.Harvest, "divineascension:sounds/deities/harvest")]
-    [InlineData(DeityDomain.Stone, "divineascension:sounds/deities/stone")]
-    public void PlayDeityUnlock_MapsDeityToSpecificSound_AtLoudVolume(DeityDomain deity, string expectedPath)
+    [InlineData(DeityDomain.Craft)]
+    [InlineData(DeityDomain.Wild)]
+    [InlineData(DeityDomain.Harvest)]
+    [InlineData(DeityDomain.Stone)]
+    public void PlayDeityUnlock_PlaysWritingAtNormalVolume(DeityDomain deity)
     {
         _sut.PlayDeityUnlock(deity);
 
         _mockWorld.Verify(w => w.PlaySoundAt(
-            It.Is<AssetLocation>(al => string.Equals(al.ToString(), expectedPath, StringComparison.OrdinalIgnoreCase)),
+            It.Is<AssetLocation>(al => al.ToString() == "divineascension:sounds/writing"),
             _mockEntity.Object,
             It.IsAny<IPlayer?>(),
             false,
             8f,
-            0.7f
+            0.5f
         ), Times.Once);
     }
 


### PR DESCRIPTION
## Summary
- `SoundManager.PlayClick` is now a no-op and `PlaySuccess` / `PlayDeityUnlock` both route to `sounds/writing` at Normal volume; tests still asserted the old click/unlock/deity paths.
- `CivilizationStateManager.OnCivilizationActionCompleted` calls `PlaySuccess` on success (not `PlayClick`); three civ-state tests still verified `PlayClick`.
- Updated assertions only — no production changes.

## Test plan
- [x] `dotnet test` — 2246 passed, 0 failed