### PR TITLE
feat(blessings): carcassCommunion grants satiety on skinning (#404)

### DIFF
--- a/DivineAscension.Tests/Systems/BlessingEffects/Handlers/LysaCarcassCommunionEffectTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingEffects/Handlers/LysaCarcassCommunionEffectTests.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Services;
+using DivineAscension.Systems.BlessingEffects.Handlers;
+using DivineAscension.Tests.Helpers;
+using Moq;
+
+namespace DivineAscension.Tests.Systems.BlessingEffects.Handlers;
+
+/// <summary>
+/// Tests for the Lysa CarcassCommunion effect handler.
+/// The satiety-grant mechanic itself relies on VS' EntityBehaviorHunger and is covered by
+/// integration testing; these unit tests focus on the lifecycle contract — effect id,
+/// safe (no-op) activation hooks, and clean subscribe/unsubscribe.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class LysaCarcassCommunionEffectTests
+{
+    private readonly Mock<IEventService> _mockEventService = new();
+    private readonly Mock<ILoggerWrapper> _mockLogger = new();
+    private readonly Mock<IWorldService> _mockWorldService = new();
+
+    private LysaEffectHandlers.CarcassCommunionEffect CreateHandler()
+    {
+        return new LysaEffectHandlers.CarcassCommunionEffect();
+    }
+
+    [Fact]
+    public void EffectId_ReturnsCarcassCommunion()
+    {
+        var handler = CreateHandler();
+
+        Assert.Equal(SpecialEffects.CarcassCommunion, handler.EffectId);
+    }
+
+    [Fact]
+    public void Initialize_DoesNotThrow()
+    {
+        var handler = CreateHandler();
+
+        var exception = Record.Exception(() =>
+            handler.Initialize(_mockLogger.Object, _mockEventService.Object, _mockWorldService.Object));
+
+        Assert.Null(exception);
+        handler.Dispose();
+    }
+
+    [Fact]
+    public void ActivateAndDeactivate_AreNoOps_DoNotThrow()
+    {
+        var handler = CreateHandler();
+        handler.Initialize(_mockLogger.Object, _mockEventService.Object, _mockWorldService.Object);
+        var player = TestFixtures.CreateMockServerPlayer().Object;
+
+        var exception = Record.Exception(() =>
+        {
+            handler.ActivateForPlayer(player);
+            handler.DeactivateForPlayer(player);
+        });
+
+        Assert.Null(exception);
+        handler.Dispose();
+    }
+
+    [Fact]
+    public void OnTick_DoesNotThrow()
+    {
+        var handler = CreateHandler();
+        handler.Initialize(_mockLogger.Object, _mockEventService.Object, _mockWorldService.Object);
+
+        var exception = Record.Exception(() => handler.OnTick(0.1f));
+
+        Assert.Null(exception);
+        handler.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_AfterInitialize_DoesNotThrow()
+    {
+        var handler = CreateHandler();
+        handler.Initialize(_mockLogger.Object, _mockEventService.Object, _mockWorldService.Object);
+
+        var exception = Record.Exception(() => handler.Dispose());
+
+        Assert.Null(exception);
+    }
+}

--- a/DivineAscension/Constants/SpecialEffects.cs
+++ b/DivineAscension/Constants/SpecialEffects.cs
@@ -27,6 +27,12 @@ public static class SpecialEffects
     /// </summary>
     public const string TemperatureResistance = "temperature_resistance";
 
+    /// <summary>
+    ///     Carcass Communion: Skinning an animal restores flat satiety. The amount is carried by
+    ///     the carcassCommunion stat, so the handler fires whenever that stat is &gt; 0.
+    /// </summary>
+    public const string CarcassCommunion = "carcass_communion";
+
     #endregion
 
     #region Craft (Forge & Craft) Effects

--- a/DivineAscension/Constants/VintageStoryStats.cs
+++ b/DivineAscension/Constants/VintageStoryStats.cs
@@ -59,6 +59,9 @@ public static class VintageStoryStats
     public const string AnimalHarvestTime = "animalHarvestingTime";
     public const string ForagingYield = "foragingYield";
 
+    // carcassCommunion: flat satiety units restored per animal-skin event (FlatSum, base 0)
+    public const string CarcassCommunion = "carcassCommunion";
+
     // Harvest (Agriculture & Cooking) Stats
     public const string CropYield = "cropYield";
     public const string SeedDropChance = "seedDropChance";

--- a/DivineAscension/Systems/BlessingEffectSystem.cs
+++ b/DivineAscension/Systems/BlessingEffectSystem.cs
@@ -409,6 +409,8 @@ public class BlessingEffectSystem : IBlessingEffectSystem
         RegisterStatIfNeeded(stats, VintageStoryStats.TemperatureResistance, EnumStatBlendType.FlatSum);
         RegisterStatIfNeeded(stats, VintageStoryStats.AnimalHarvestTime, EnumStatBlendType.WeightedSum);
         RegisterStatIfNeeded(stats, VintageStoryStats.ForagingYield, EnumStatBlendType.WeightedSum);
+        // CarcassCommunion uses FlatSum (base 0): blended value is raw satiety units restored per skin
+        RegisterStatIfNeeded(stats, VintageStoryStats.CarcassCommunion, EnumStatBlendType.FlatSum);
 
         // Harvest (Agriculture & Cooking)
         RegisterStatIfNeeded(stats, VintageStoryStats.CropYield, EnumStatBlendType.WeightedSum);
@@ -574,6 +576,7 @@ public class BlessingEffectSystem : IBlessingEffectSystem
         _specialEffectRegistry.RegisterHandler(new LysaEffectHandlers.RareForageChanceEffect());
         _specialEffectRegistry.RegisterHandler(new LysaEffectHandlers.FoodSpoilageEffect());
         _specialEffectRegistry.RegisterHandler(new LysaEffectHandlers.TemperatureResistanceEffect());
+        _specialEffectRegistry.RegisterHandler(new LysaEffectHandlers.CarcassCommunionEffect());
 
         // Harvest (Agriculture & Light) handlers
         _specialEffectRegistry.RegisterHandler(new AethraEffectHandlers.NeverMalnourishedEffect());

--- a/DivineAscension/Systems/BlessingEffects/Handlers/LysaEffectHandlers.cs
+++ b/DivineAscension/Systems/BlessingEffects/Handlers/LysaEffectHandlers.cs
@@ -281,7 +281,10 @@ public static class LysaEffectHandlers
             var satiety = player.Entity.Stats.GetBlended(VintageStoryStats.CarcassCommunion);
             if (satiety <= 0) return;
 
-            player.Entity.GetBehavior<EntityBehaviorHunger>()?.ReceiveSaturation(satiety);
+            var hunger = player.Entity.GetBehavior<EntityBehaviorHunger>();
+            if (hunger == null) return;
+
+            hunger.Saturation = Math.Min(hunger.MaxSaturation, hunger.Saturation + satiety);
         }
     }
 }

--- a/DivineAscension/Systems/BlessingEffects/Handlers/LysaEffectHandlers.cs
+++ b/DivineAscension/Systems/BlessingEffects/Handlers/LysaEffectHandlers.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Constants;
 using DivineAscension.Services;
+using DivineAscension.Systems.Patches;
 using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Config;
 using Vintagestory.API.Server;
 using Vintagestory.GameContent;
@@ -233,6 +235,53 @@ public static class LysaEffectHandlers
                 // Proxy for finding rare items: chance to double quantity
                 if (_worldService!.World.Rand.NextDouble() < 0.5)
                     dropQuantityMultiplier *= 2.0f;
+        }
+    }
+
+    /// <summary>
+    ///     Carcass Communion: skinning/butchering an animal restores a flat amount of satiety.
+    ///     Stat-driven — the carcassCommunion stat (FlatSum, base 0) carries the satiety units to
+    ///     restore per skin event, so the effect fires whenever that stat blends to &gt; 0. Activation
+    ///     is therefore implicit in the stat and the per-player activation hooks are no-ops.
+    /// </summary>
+    public class CarcassCommunionEffect : ISpecialEffectHandler, IDisposable
+    {
+        private ILoggerWrapper? _logger;
+        public string EffectId => SpecialEffects.CarcassCommunion;
+
+        public void Initialize(ILoggerWrapper logger, IEventService eventService, IWorldService worldService)
+        {
+            _logger = logger;
+            SkinningPatches.OnAnimalSkinned += OnAnimalSkinned;
+            _logger.Debug($"{SystemConstants.LogPrefix} Initialized {EffectId} handler");
+        }
+
+        public void ActivateForPlayer(IServerPlayer player)
+        {
+        }
+
+        public void DeactivateForPlayer(IServerPlayer player)
+        {
+        }
+
+        public void OnTick(float deltaTime)
+        {
+        }
+
+        public void Dispose()
+        {
+            SkinningPatches.OnAnimalSkinned -= OnAnimalSkinned;
+        }
+
+        private void OnAnimalSkinned(IServerPlayer player, Entity entity, float weight)
+        {
+            if (player?.Entity?.Stats == null) return;
+
+            // FlatSum stat (base 0): the blended value is the satiety units to restore.
+            var satiety = player.Entity.Stats.GetBlended(VintageStoryStats.CarcassCommunion);
+            if (satiety <= 0) return;
+
+            player.Entity.GetBehavior<EntityBehaviorHunger>()?.ReceiveSaturation(satiety);
         }
     }
 }


### PR DESCRIPTION
Adds the Wild/Lysa carcassCommunion custom stat (FlatSum) and a
stat-driven special-effect handler that restores flat satiety via
EntityBehaviorHunger whenever an animal is skinned. The stat carries the
satiety amount, so the effect activates implicitly once a blessing grants
it; tree-node assignment remains deferred per epic #403.

https://claude.ai/code/session_01ShapMoKTyZGXRaaPNgNyN2