### PR TITLE
feat(ui): gate pane content behind confirm modals (#455)

### DIFF
--- a/DivineAscension.Tests/GUI/UI/Utilities/ModalInputGuardTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Utilities/ModalInputGuardTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.GUI.Events;
+using DivineAscension.GUI.UI.Utilities;
+
+namespace DivineAscension.Tests.GUI.UI.Utilities;
+
+/// <summary>
+///     Tests for <see cref="ModalInputGuard.FilterBackground{T}" /> — the gate that drops a
+///     pane's click-through behind an open confirm modal while keeping the modal's own
+///     confirm/cancel events live (#455). Each test drives the static guard explicitly via
+///     <see cref="ModalInputGuard.MarkOpen" /> / <see cref="ModalInputGuard.BeginFrame" />.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ModalInputGuardTests
+{
+    private record Background : ITestEvent;
+
+    private record ModalControl : ITestEvent, IModalControlEvent;
+
+    private interface ITestEvent;
+
+    /// <summary>Rolls the guard into the not-blocking state for a clean baseline.</summary>
+    private static void SetNotBlocking() => ModalInputGuard.BeginFrame();
+
+    /// <summary>Marks a modal open and rolls it into IsBlocking (mirrors a steady-state modal frame).</summary>
+    private static void SetBlocking()
+    {
+        ModalInputGuard.MarkOpen();
+        ModalInputGuard.BeginFrame();
+    }
+
+    [Fact]
+    public void FilterBackground_WhenNotBlocking_ReturnsEventsUntouched()
+    {
+        SetNotBlocking();
+        var events = new List<ITestEvent> { new Background(), new ModalControl(), new Background() };
+
+        var result = ModalInputGuard.FilterBackground(events);
+
+        Assert.Equal(3, result.Count);
+        Assert.Same(events, result);
+    }
+
+    [Fact]
+    public void FilterBackground_WhenBlocking_DropsBackgroundButKeepsModalControl()
+    {
+        SetBlocking();
+        var events = new List<ITestEvent> { new Background(), new ModalControl(), new Background() };
+
+        var result = ModalInputGuard.FilterBackground(events);
+
+        Assert.Single(result);
+        Assert.IsType<ModalControl>(result[0]);
+    }
+
+    [Fact]
+    public void FilterBackground_WhenBlocking_DropsAllWhenNoModalControl()
+    {
+        SetBlocking();
+        var events = new List<ITestEvent> { new Background(), new Background() };
+
+        Assert.Empty(ModalInputGuard.FilterBackground(events));
+    }
+
+    [Fact]
+    public void FilterBackground_NullOrEmpty_ReturnsEmptyNeverNull()
+    {
+        SetBlocking();
+        Assert.Empty(ModalInputGuard.FilterBackground<ITestEvent>(null));
+
+        SetNotBlocking();
+        Assert.Empty(ModalInputGuard.FilterBackground(new List<ITestEvent>()));
+    }
+
+    [Fact]
+    public void IsBlocking_LagsMarkByOneFrame()
+    {
+        // Opening frame: mark is set but IsBlocking still reflects the prior (clear) frame.
+        SetNotBlocking();
+        ModalInputGuard.MarkOpen();
+        Assert.False(ModalInputGuard.IsBlocking);
+
+        // Next frame promotes the mark.
+        ModalInputGuard.BeginFrame();
+        Assert.True(ModalInputGuard.IsBlocking);
+
+        // Modal closed (no mark this frame) — gate clears on the following frame.
+        ModalInputGuard.BeginFrame();
+        Assert.False(ModalInputGuard.IsBlocking);
+    }
+}

--- a/DivineAscension/GUI/Events/Civilization/InfoEvent.cs
+++ b/DivineAscension/GUI/Events/Civilization/InfoEvent.cs
@@ -36,13 +36,13 @@ public abstract record InfoEvent
 
     public sealed record DisbandOpened : InfoEvent;
 
-    public sealed record DisbandConfirmed : InfoEvent;
+    public sealed record DisbandConfirmed : InfoEvent, IModalControlEvent;
 
-    public sealed record DisbandCancel : InfoEvent;
+    public sealed record DisbandCancel : InfoEvent, IModalControlEvent;
 
     public sealed record KickOpen(string religionId, string religionName) : InfoEvent;
 
-    public sealed record KickConfirm(string religionName) : InfoEvent;
+    public sealed record KickConfirm(string religionName) : InfoEvent, IModalControlEvent;
 
-    public sealed record KickCancel : InfoEvent;
+    public sealed record KickCancel : InfoEvent, IModalControlEvent;
 }

--- a/DivineAscension/GUI/Events/IModalControlEvent.cs
+++ b/DivineAscension/GUI/Events/IModalControlEvent.cs
@@ -1,0 +1,17 @@
+namespace DivineAscension.GUI.Events;
+
+/// <summary>
+///     Marker for pane events that drive a modal overlay's own confirm/cancel and must
+///     stay live while that modal is open. Everything <em>else</em> a pane emits is
+///     "background" interaction (selection, scroll, secondary buttons) that fell through
+///     behind the dim backdrop in immediate mode — see
+///     <see cref="DivineAscension.GUI.UI.Utilities.ModalInputGuard" />.
+///
+///     A pane's event processor passes its frame's events through
+///     <see cref="DivineAscension.GUI.UI.Utilities.ModalInputGuard.FilterBackground{T}" />,
+///     which drops un-marked events while a modal is up. Confirm/cancel records carry this
+///     marker so they survive the filter; the modal's buttons therefore keep working even
+///     though the pane behind it is inert. New confirm modals get the gate for free by
+///     marking their confirm/cancel events.
+/// </summary>
+public interface IModalControlEvent;

--- a/DivineAscension/GUI/Events/Religion/InfoEvent.cs
+++ b/DivineAscension/GUI/Events/Religion/InfoEvent.cs
@@ -45,23 +45,23 @@ public abstract record InfoEvent
     // Disband flow
     public record DisbandOpen : InfoEvent;
 
-    public record DisbandConfirm : InfoEvent;
+    public record DisbandConfirm : InfoEvent, IModalControlEvent;
 
-    public record DisbandCancel : InfoEvent;
+    public record DisbandCancel : InfoEvent, IModalControlEvent;
 
     // Kick flow
     public record KickOpen(string PlayerUID, string PlayerName) : InfoEvent;
 
-    public record KickConfirm(string PlayerUID) : InfoEvent;
+    public record KickConfirm(string PlayerUID) : InfoEvent, IModalControlEvent;
 
-    public record KickCancel : InfoEvent;
+    public record KickCancel : InfoEvent, IModalControlEvent;
 
     // Ban flow
     public record BanOpen(string PlayerUID, string PlayerName) : InfoEvent;
 
-    public record BanConfirm(string PlayerUID) : InfoEvent;
+    public record BanConfirm(string PlayerUID) : InfoEvent, IModalControlEvent;
 
-    public record BanCancel : InfoEvent;
+    public record BanCancel : InfoEvent, IModalControlEvent;
 
     // Unban
     public record UnbanClicked(string PlayerUID) : InfoEvent;

--- a/DivineAscension/GUI/Events/Religion/RoleDetailEvent.cs
+++ b/DivineAscension/GUI/Events/Religion/RoleDetailEvent.cs
@@ -21,7 +21,7 @@ public abstract record RoleDetailEvent
         string NewRoleUID,
         string NewRoleName) : RoleDetailEvent;
 
-    public record AssignRoleConfirm(string MemberUID, string NewRoleUID) : RoleDetailEvent;
+    public record AssignRoleConfirm(string MemberUID, string NewRoleUID) : RoleDetailEvent, IModalControlEvent;
 
-    public record AssignRoleCancel : RoleDetailEvent;
+    public record AssignRoleCancel : RoleDetailEvent, IModalControlEvent;
 }

--- a/DivineAscension/GUI/Events/Religion/RolesBrowseEvent.cs
+++ b/DivineAscension/GUI/Events/Religion/RolesBrowseEvent.cs
@@ -36,9 +36,9 @@ public abstract record RolesBrowseEvent
     // Role deletion
     public record DeleteRoleOpen(string RoleUID, string RoleName) : RolesBrowseEvent;
 
-    public record DeleteRoleConfirm(string RoleUID) : RolesBrowseEvent;
+    public record DeleteRoleConfirm(string RoleUID) : RolesBrowseEvent, IModalControlEvent;
 
-    public record DeleteRoleCancel : RolesBrowseEvent;
+    public record DeleteRoleCancel : RolesBrowseEvent, IModalControlEvent;
 
     // Refresh
     public record RefreshRequested : RolesBrowseEvent;

--- a/DivineAscension/GUI/Events/Religion/RosterEvent.cs
+++ b/DivineAscension/GUI/Events/Religion/RosterEvent.cs
@@ -7,12 +7,12 @@ public abstract record RosterEvent
     public record RowToggled(string PlayerUID) : RosterEvent;
 
     public record KickClicked(string PlayerUID, string PlayerName) : RosterEvent;
-    public record KickConfirm(string PlayerUID) : RosterEvent;
-    public record KickCancel : RosterEvent;
+    public record KickConfirm(string PlayerUID) : RosterEvent, IModalControlEvent;
+    public record KickCancel : RosterEvent, IModalControlEvent;
 
     public record StrikeClicked(string PlayerUID, string PlayerName) : RosterEvent;
-    public record StrikeConfirm(string PlayerUID) : RosterEvent;
-    public record StrikeCancel : RosterEvent;
+    public record StrikeConfirm(string PlayerUID) : RosterEvent, IModalControlEvent;
+    public record StrikeCancel : RosterEvent, IModalControlEvent;
 
     public record InviteNameChanged(string Text) : RosterEvent;
     public record InviteClicked(string PlayerName) : RosterEvent;

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -268,8 +268,9 @@ public partial class GuiDialog : ModSystem
             return CallbackGUIStatus.Closed;
         }
 
-        // Allow ESC to close
-        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+        // Allow ESC to close — unless a confirm modal is open, in which case Esc cancels
+        // the modal (ConfirmOverlay consumes it) and the dialog stays put (#455).
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape) && !ModalInputGuard.IsBlocking)
         {
             Close();
             return CallbackGUIStatus.Closed;

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -1132,6 +1132,9 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
 
     internal void ProcessInfoEvents(IReadOnlyList<InfoEvent> events)
     {
+        // Block civ info background interaction behind an open disband/kick confirm (#455).
+        events = ModalInputGuard.FilterBackground(events);
+
         var civ = State.InfoState.Info;
         var civId = civ?.CivId ?? string.Empty;
 
@@ -1374,6 +1377,9 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
 
     internal void ProcessDiplomacyEvents(IReadOnlyList<DiplomacyEvent> events)
     {
+        // Block diplomacy background interaction behind an open declare-war confirm (#455).
+        events = ModalInputGuard.FilterBackground(events);
+
         foreach (var evt in events)
             switch (evt)
             {

--- a/DivineAscension/GUI/Managers/ReligionStateManager.cs
+++ b/DivineAscension/GUI/Managers/ReligionStateManager.cs
@@ -667,7 +667,9 @@ public class ReligionStateManager : IReligionStateManager
 
     private void ProcessRosterEvents(IReadOnlyList<RosterEvent> events)
     {
-        if (events == null || events.Count == 0) return;
+        // Block roster background interaction behind an open kick/strike confirm (#455).
+        events = ModalInputGuard.FilterBackground(events);
+        if (events.Count == 0) return;
 
         var religionId = State.InfoState.MyReligionInfo?.ReligionUID;
         var roster = State.RosterState;
@@ -894,7 +896,10 @@ public class ReligionStateManager : IReligionStateManager
     /// </summary>
     private void ProcessInfoEvents(IReadOnlyList<InfoEvent>? events)
     {
-        if (events == null || events.Count == 0) return;
+        // While a confirm modal is up, drop click-through behind it (#455) — only the
+        // modal's own confirm/cancel (IModalControlEvent) survive the filter.
+        events = ModalInputGuard.FilterBackground(events);
+        if (events.Count == 0) return;
 
         // Cache commonly used references
         var info = State.InfoState.MyReligionInfo;
@@ -1426,7 +1431,9 @@ public class ReligionStateManager : IReligionStateManager
     /// </summary>
     private void ProcessRolesBrowseEvents(IReadOnlyList<RolesBrowseEvent>? events)
     {
-        if (events == null || events.Count == 0) return;
+        // Block role-card background interaction behind an open delete (Strike) confirm (#455).
+        events = ModalInputGuard.FilterBackground(events);
+        if (events.Count == 0) return;
 
         foreach (var ev in events)
             switch (ev)
@@ -1535,7 +1542,9 @@ public class ReligionStateManager : IReligionStateManager
     /// </summary>
     private void ProcessRoleDetailEvents(IReadOnlyList<RoleDetailEvent>? events)
     {
-        if (events == null || events.Count == 0) return;
+        // Block role-detail background interaction behind an open assign-role confirm (#455).
+        events = ModalInputGuard.FilterBackground(events);
+        if (events.Count == 0) return;
 
         foreach (var ev in events)
             switch (ev)

--- a/DivineAscension/GUI/UI/Components/Overlays/ConfirmOverlay.cs
+++ b/DivineAscension/GUI/UI/Components/Overlays/ConfirmOverlay.cs
@@ -134,5 +134,10 @@ internal static class ConfirmOverlay
         if (ButtonRenderer.DrawButton(drawList, cancelLabel,
                 btnStartX + confirmBtnW + btnSpacing, btnY, cancelBtnW, btnH))
             canceled = true;
+
+        // Esc cancels the modal. GuiDialog suppresses its own close-on-Esc while a modal
+        // is blocking (see ProcessRender), so the key dismisses the overlay, not the dialog.
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+            canceled = true;
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/DiplomacyTabRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/DiplomacyTabRenderer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using DivineAscension.Constants;
+using DivineAscension.GUI.Events;
 using DivineAscension.GUI.UI.Components.Banners;
 using DivineAscension.GUI.UI.Components.Buttons;
 using DivineAscension.GUI.UI.Components.Lists;
@@ -624,7 +625,7 @@ public abstract record DiplomacyEvent
 
     public record CancelBreak(string TargetCivId) : DiplomacyEvent;
 
-    public record DeclareWar(string TargetCivId) : DiplomacyEvent;
+    public record DeclareWar(string TargetCivId) : DiplomacyEvent, IModalControlEvent;
 
     public record DeclarePeace(string TargetCivId) : DiplomacyEvent;
 
@@ -634,7 +635,7 @@ public abstract record DiplomacyEvent
 
     public record ShowWarConfirmation(string CivId) : DiplomacyEvent;
 
-    public record CancelWarConfirmation() : DiplomacyEvent;
+    public record CancelWarConfirmation() : DiplomacyEvent, IModalControlEvent;
 
     public record ToggleCivDropdown(bool IsOpen) : DiplomacyEvent;
 

--- a/DivineAscension/GUI/UI/Utilities/ModalInputGuard.cs
+++ b/DivineAscension/GUI/UI/Utilities/ModalInputGuard.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using DivineAscension.GUI.Events;
+
 namespace DivineAscension.GUI.UI.Utilities;
 
 /// <summary>
@@ -36,5 +39,26 @@ internal static class ModalInputGuard
     {
         _blockingThisFrame = _markedThisFrame;
         _markedThisFrame = false;
+    }
+
+    /// <summary>
+    ///     Drops a pane's background events while a modal is up, keeping only those marked
+    ///     <see cref="IModalControlEvent" /> (the modal's own confirm/cancel). When no modal is
+    ///     blocking, the list is returned untouched. Pane event processors call this at the top
+    ///     so click-through behind the dim backdrop has no effect, while the modal's buttons —
+    ///     which draw <em>after</em> this frame's <see cref="MarkOpen" /> and so are unaffected by
+    ///     the one-frame-lagged <see cref="IsBlocking" /> — keep working (#455).
+    /// </summary>
+    public static IReadOnlyList<T> FilterBackground<T>(IReadOnlyList<T>? events)
+    {
+        if (events == null || events.Count == 0 || !_blockingThisFrame)
+            return events ?? System.Array.Empty<T>();
+
+        var kept = new List<T>(events.Count);
+        foreach (var ev in events)
+            if (ev is IModalControlEvent)
+                kept.Add(ev);
+
+        return kept;
     }
 }


### PR DESCRIPTION
Closes #455.

## Problem

`ConfirmOverlay` draws on the viewport foreground list, so it paints above all windows — but the dim backdrop is purely visual. In immediate mode, pane content behind the modal still hit-tests the mouse, so buttons/inputs/selections behind it respond (click-through). Only the blessing pane (#453) had a content-level gate.

## Fix (Option B — shared helper)

- **`IModalControlEvent`** marker — tags the confirm/cancel events a modal owns.
- **`ModalInputGuard.FilterBackground<T>`** — while `IsBlocking`, keeps only `IModalControlEvent` events and drops the rest; pass-through otherwise. Same one-frame-lag model already documented on the guard.
- Each pane processor calls `FilterBackground` at the top. New confirm modals get the gate for free by marking their confirm/cancel events.

Marked confirm/cancel events:
- Religion `InfoEvent` (Disband, Ban, Kick), `RosterEvent` (Kick, Strike), `RolesBrowseEvent` (DeleteRole), `RoleDetailEvent` (AssignRole)
- Civ `InfoEvent` (Disband, Kick), `DiplomacyEvent` (DeclareWar / CancelWarConfirmation)

Adopted in `ReligionStateManager` (×4 processors) and `CivilizationStateManager` (×2).

## Esc → Cancel

`ConfirmOverlay` cancels on Esc; `GuiDialog` skips its own close-on-Esc while `ModalInputGuard.IsBlocking`, so Esc dismisses the modal rather than the whole dialog.

## Acceptance

- Pane content behind any open confirm modal is inert (no selection/nav/secondary actions). ✅
- Confirm/Cancel still work. ✅
- Blessing flow (#453) untouched — keeps its own `PendingUnlockBlessingId` gate. ✅

## Tests

`ModalInputGuardTests` — pass-through when not blocking, drops background, keeps modal-control, null/empty safety, one-frame lag. Full suite: 2265 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)