### PR TITLE
feat(blessing): apostasy penalty — strip domain-locked on religion leave (#461)

### DIFF
--- a/DivineAscension.Tests/Systems/BlessingUnlearnServiceTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingUnlearnServiceTests.cs
@@ -176,4 +176,88 @@ public class BlessingUnlearnServiceTests
     {
         Assert.Empty(_service.ResolveUnlearnCascade(PlayerUid, BlessingId));
     }
+
+    // --- Apostasy penalty (epic #425, slice 3 — #461) ---------------------------------------
+
+    [Fact]
+    public void StripDomainLockedForApostasy_StripsDomainLocked_KeepsGeneric_ZeroRefund()
+    {
+        // BlessingId (craft_blessing) is generic; add a domain-locked capstone the player owns.
+        _registry.RegisterBlessing(new Blessing("craft_patron", "Craft Patron", DeityDomain.Craft)
+        {
+            Kind = BlessingKind.Player,
+            Cost = 200,
+            RequiresPatron = true
+        });
+        _playerData.AddFavor(DeityDomain.Craft, 300); // spendable 300, lifetime 300
+        _playerData.UnlockBlessing(BlessingId);        // generic — kept
+        _playerData.UnlockBlessing("craft_patron");    // domain-locked — stripped
+
+        var stripped = _service.StripDomainLockedForApostasy(PlayerUid);
+
+        Assert.Equal(new[] { "craft_patron" }, stripped);
+        Assert.False(_playerData.IsBlessingUnlocked("craft_patron"));
+        Assert.True(_playerData.IsBlessingUnlocked(BlessingId));                 // generic kept
+        Assert.Equal(300, _playerData.GetFavor(DeityDomain.Craft));             // zero refund
+        Assert.Equal(300, _playerData.GetTotalFavorEarned(DeityDomain.Craft));  // lifetime untouched
+    }
+
+    [Fact]
+    public void StripDomainLockedForApostasy_CascadesDependentsOfDomainLockedParent()
+    {
+        // Domain-locked parent with a generic branch child that depends solely on it; the child
+        // is orphaned and cascades even though it is not itself domain-locked.
+        _registry.RegisterBlessing(new Blessing("craft_patron", "Craft Patron", DeityDomain.Craft)
+        {
+            Kind = BlessingKind.Player,
+            Cost = 200,
+            RequiresPatron = true
+        });
+        _registry.RegisterBlessing(new Blessing("patron_child", "Patron Child", DeityDomain.Craft)
+        {
+            Kind = BlessingKind.Player,
+            Cost = 40,
+            Branch = "branchA",
+            PrerequisiteBlessings = new List<string> { "craft_patron" }
+        });
+        _playerData.UnlockBlessing("craft_patron");
+        _playerData.UnlockBlessing("patron_child");
+
+        var stripped = _service.StripDomainLockedForApostasy(PlayerUid);
+
+        Assert.Contains("craft_patron", stripped);
+        Assert.Contains("patron_child", stripped);
+        Assert.False(_playerData.IsBlessingUnlocked("craft_patron"));
+        Assert.False(_playerData.IsBlessingUnlocked("patron_child"));
+    }
+
+    [Fact]
+    public void StripDomainLockedForApostasy_RefreshesEffects_AndNotifies_OnlyWhenStripped()
+    {
+        _registry.RegisterBlessing(new Blessing("craft_patron", "Craft Patron", DeityDomain.Craft)
+        {
+            Kind = BlessingKind.Player,
+            Cost = 200,
+            RequiresPatron = true
+        });
+        _playerData.UnlockBlessing("craft_patron");
+
+        _service.StripDomainLockedForApostasy(PlayerUid);
+
+        _effectSystem.Verify(e => e.RefreshPlayerBlessings(PlayerUid), Times.Once);
+        _dataManager.Verify(m => m.NotifyPlayerDataChanged(PlayerUid), Times.Once);
+    }
+
+    [Fact]
+    public void StripDomainLockedForApostasy_NoDomainLockedOwned_NoSideEffects()
+    {
+        _playerData.UnlockBlessing(BlessingId); // generic only
+
+        var stripped = _service.StripDomainLockedForApostasy(PlayerUid);
+
+        Assert.Empty(stripped);
+        Assert.True(_playerData.IsBlessingUnlocked(BlessingId));
+        _effectSystem.Verify(e => e.RefreshPlayerBlessings(It.IsAny<string>()), Times.Never);
+        _dataManager.Verify(m => m.NotifyPlayerDataChanged(It.IsAny<string>()), Times.Never);
+    }
 }

--- a/DivineAscension/Systems/BlessingUnlearnService.cs
+++ b/DivineAscension/Systems/BlessingUnlearnService.cs
@@ -95,6 +95,62 @@ public class BlessingUnlearnService : IBlessingUnlearnService
         }
     }
 
+    /// <summary>
+    ///     Subscribes the apostasy penalty to the player-leaves-religion event. Wired once at
+    ///     startup; the strip runs server-side whenever a player departs a religion.
+    /// </summary>
+    public void Initialize()
+    {
+        _playerProgressionDataManager.OnPlayerLeavesReligion += OnPlayerLeavesReligion;
+    }
+
+    private void OnPlayerLeavesReligion(Vintagestory.API.Server.IServerPlayer player, string religionUID)
+    {
+        if (player != null)
+            StripDomainLockedForApostasy(player.PlayerUID);
+    }
+
+    public IReadOnlyList<string> StripDomainLockedForApostasy(string playerUID)
+    {
+        var playerLock = _playerLocks.GetOrAdd(playerUID, _ => new object());
+        lock (playerLock)
+        {
+            var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(playerUID);
+            var working = new HashSet<string>(playerData.UnlockedBlessings);
+
+            // Domain-locked (RequiresPatron) blessings are forfeit on apostasy. Resolve each in
+            // a deterministic order; an earlier cascade may already have taken a later one.
+            var domainLocked = working
+                .Where(id => _blessingRegistry.GetBlessing(id)?.RequiresPatron == true)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+
+            var stripped = new List<string>();
+            foreach (var id in domainLocked)
+            {
+                if (!working.Contains(id))
+                    continue;
+
+                var cascade = BlessingCascadeResolver.Resolve(id, working, _blessingRegistry.GetBlessing);
+                foreach (var victim in cascade)
+                    if (working.Remove(victim))
+                    {
+                        // Zero refund — the apostasy penalty is forfeiture, not a refunded unlearn.
+                        playerData.LockBlessing(victim);
+                        stripped.Add(victim);
+                    }
+            }
+
+            if (stripped.Count > 0)
+            {
+                _blessingEffectSystem.RefreshPlayerBlessings(playerUID);
+                _playerProgressionDataManager.NotifyPlayerDataChanged(playerUID);
+            }
+
+            return stripped;
+        }
+    }
+
     public IReadOnlyList<string> ResolveUnlearnCascade(string playerUID, string blessingId)
     {
         var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(playerUID);

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -377,6 +377,7 @@ public static class DivineAscensionSystemInitializer
             playerReligionDataManager,
             religionManager,
             gameBalanceConfig);
+        blessingUnlearnService.Initialize(); // apostasy penalty: strip domain-locked on leave (#461)
 
         var blessingHandler = new BlessingNetworkHandler(
             logger,

--- a/DivineAscension/Systems/Interfaces/IBlessingUnlearnService.cs
+++ b/DivineAscension/Systems/Interfaces/IBlessingUnlearnService.cs
@@ -49,4 +49,14 @@ public interface IBlessingUnlearnService
     ///     an empty list when the player does not own the target. Target is first.
     /// </summary>
     System.Collections.Generic.IReadOnlyList<string> ResolveUnlearnCascade(string playerUID, string blessingId);
+
+    /// <summary>
+    ///     Apostasy penalty (epic #425, slice 3 — #461): strips every owned domain-locked
+    ///     (<see cref="DivineAscension.Models.Blessing.RequiresPatron"/>) blessing and the
+    ///     prerequisite cascade beneath each, refunding <b>zero</b> favor. Generic blessings stay
+    ///     unless orphaned by a stripped domain-locked parent. Recomputes effects and notifies on
+    ///     change. System-triggered (player leaving a religion), so no cooldown is stamped.
+    ///     Returns the ids stripped (empty if the player owned no domain-locked blessings).
+    /// </summary>
+    System.Collections.Generic.IReadOnlyList<string> StripDomainLockedForApostasy(string playerUID);
 }


### PR DESCRIPTION
Closes #461. Epic #425 vertical slice 3 — apostasy penalty on leaving a religion. Implements locked decision 6.

## What
- On leaving a religion, cascade-unlearn every owned **domain-locked** (`RequiresPatron`) blessing with **zero refund** (forfeiture, not a refunded unlearn).
- Generic blessings stay unlocked unless orphaned by a stripped domain-locked parent.
- Reuses the #460 `BlessingCascadeResolver` so dependent children cascade identically.
- System-triggered path: no cooldown stamped (it's a penalty, not a player action).

## How
- `IBlessingUnlearnService.StripDomainLockedForApostasy(playerUID)` — collects owned domain-locked ids (deterministic order), resolves each cascade against a working set, strips with `LockBlessing` (zero refund), then refreshes effects + notifies only when something changed.
- `BlessingUnlearnService.Initialize()` subscribes to `PlayerProgressionDataManager.OnPlayerLeavesReligion`; wired in `DivineAscensionSystemInitializer`.

## Tests
4 new cases in `BlessingUnlearnServiceTests`: domain-locked stripped + generic kept + zero refund/lifetime untouched; cascade of dependents of a domain-locked parent; effects refresh/notify only when stripped; no-op when no domain-locked owned. Full suite: 2310 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)