### PR TITLE
fix: unify blessing slot-cap on patron favor rank (#472)

### DIFF
--- a/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingRegistryTests.cs
@@ -343,7 +343,7 @@ public class BlessingRegistryTests
         var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, null, null);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, null, null);
 
         // Assert
         Assert.False(canUnlock);
@@ -358,7 +358,7 @@ public class BlessingRegistryTests
         var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Craft, BlessingKind.Player);
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, null, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, null, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -375,7 +375,7 @@ public class BlessingRegistryTests
         playerData.UnlockBlessing("test_blessing");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -392,7 +392,7 @@ public class BlessingRegistryTests
         blessing.RequiredFavorRank = 2; // Requires Zealot
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -410,7 +410,7 @@ public class BlessingRegistryTests
         blessing.RequiresPatron = false;
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
-        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         Assert.True(canUnlock);
     }
@@ -425,7 +425,7 @@ public class BlessingRegistryTests
         blessing.RequiresPatron = true;
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         Assert.False(canUnlock);
         Assert.Contains("Capstone blessing requires patron deity: Wild", reason);
@@ -440,7 +440,7 @@ public class BlessingRegistryTests
         blessing.RequiresPatron = true;
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Wild, "player-uid");
 
-        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         Assert.True(canUnlock);
     }
@@ -457,7 +457,7 @@ public class BlessingRegistryTests
         blessing.Cost = 100;
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         Assert.False(canUnlock);
         Assert.Contains("Insufficient favor", reason);
@@ -476,7 +476,7 @@ public class BlessingRegistryTests
         blessing.Cost = 100;
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Wild, "player-uid");
 
-        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         Assert.True(canUnlock);
     }
@@ -499,7 +499,7 @@ public class BlessingRegistryTests
 
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -518,7 +518,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Disciple, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Disciple, FavorRank.Disciple, playerData, religion, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -538,7 +538,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -561,7 +561,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -581,7 +581,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -601,7 +601,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act - pass skipCostCheck: true
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing, skipCostCheck: true);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing, skipCostCheck: true);
 
         // Assert - should return true because cost check is skipped
         Assert.True(canUnlock);
@@ -640,7 +640,7 @@ public class BlessingRegistryTests
         religion.PrestigeRank = PrestigeRank.Fledgling;
 
         var (canUnlock, reason) = registry.CanUnlockBlessing(
-            "player-uid", FavorRank.Initiate, playerData, religion, blessing);
+            "player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         Assert.False(canUnlock);
         // Reason should reflect cap state (current/max) and point at unlearn (#425).
@@ -667,7 +667,7 @@ public class BlessingRegistryTests
         religion.PrestigeRank = PrestigeRank.Fledgling;
 
         var (canUnlock, reason) = registry.CanUnlockBlessing(
-            "player-uid", FavorRank.Disciple, playerData, religion, blessing);
+            "player-uid", FavorRank.Disciple, FavorRank.Disciple, playerData, religion, blessing);
 
         Assert.True(canUnlock);
         Assert.Equal("Can unlock", reason);
@@ -693,7 +693,7 @@ public class BlessingRegistryTests
         religion.PrestigeRank = PrestigeRank.Renowned;
 
         var (canUnlock, reason) = registry.CanUnlockBlessing(
-            "player-uid", FavorRank.Initiate, playerData, religion, blessing);
+            "player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // 2 unlocked, cap of 2 (1 favor + 1 prestige bonus) → rejected with cap reason.
         Assert.False(canUnlock);
@@ -721,9 +721,40 @@ public class BlessingRegistryTests
         blessing.Cost = 0;
 
         var (canUnlock, reason) = registry.CanUnlockBlessing(
-            "player-uid", FavorRank.Disciple, playerData, religionData: null, blessing);
+            "player-uid", FavorRank.Disciple, FavorRank.Disciple, playerData, religionData: null, blessing);
 
         // 2 unlocked, cap of 2 (favor-only) → rejected with cap reason, NOT "Not in a religion".
+        Assert.False(canUnlock);
+        Assert.Contains("2/2", reason);
+    }
+
+    [Fact]
+    public void CanUnlockBlessing_PlayerBlessing_SlotCapUsesPatronRank_NotBlessingDomainRank()
+    {
+        // Regression for #472: slot cap must derive from the patron-domain favor rank
+        // (slotCapFavorRank), not the blessing's own domain rank (playerFavorRank).
+        // Player: patron Craft = Initiate, incidental Wild = Disciple, prestige Renowned.
+        // Patron rank Initiate + Renowned bonus = 2 slots. With 2 unlocked → cap reached.
+        // A higher Wild rank must NOT inflate the cap to 3.
+        var config = new GameBalanceConfig();
+        var registry = CreateRegistryWithConfig(config);
+
+        var playerData = TestFixtures.CreateTestPlayerReligionData("player-uid", DeityDomain.Craft, "religion-uid");
+        playerData.UnlockBlessing("existing_a");
+        playerData.UnlockBlessing("existing_b");
+
+        var blessing = TestFixtures.CreateTestBlessing("third", "Third", DeityDomain.Wild, BlessingKind.Player);
+        blessing.RequiredFavorRank = 0;
+        blessing.Cost = 0;
+
+        var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
+        religion.PrestigeRank = PrestigeRank.Renowned;
+
+        // playerFavorRank (Wild) = Disciple would give 3 slots if it drove the cap;
+        // slotCapFavorRank (patron Craft) = Initiate gives 2.
+        var (canUnlock, reason) = registry.CanUnlockBlessing(
+            "player-uid", FavorRank.Disciple, FavorRank.Initiate, playerData, religion, blessing);
+
         Assert.False(canUnlock);
         Assert.Contains("2/2", reason);
     }
@@ -740,7 +771,7 @@ public class BlessingRegistryTests
         var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Craft, BlessingKind.Religion);
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, null, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, null, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -759,7 +790,7 @@ public class BlessingRegistryTests
             TestFixtures.CreateTestBlessing("test_blessing", "Test", DeityDomain.Craft, BlessingKind.Religion);
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -778,7 +809,7 @@ public class BlessingRegistryTests
         blessing.RequiredPrestigeRank = 2; // Requires Renowned
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -794,7 +825,7 @@ public class BlessingRegistryTests
         var blessing = TestFixtures.CreateTestBlessing("test", "Test", DeityDomain.Wild, BlessingKind.Religion);
         blessing.RequiresPatron = false;
 
-        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         Assert.True(canUnlock);
     }
@@ -807,7 +838,7 @@ public class BlessingRegistryTests
         var blessing = TestFixtures.CreateTestBlessing("pantheon_of_wild", "Pantheon of Wild", DeityDomain.Wild, BlessingKind.Religion);
         blessing.RequiresPatron = true;
 
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         Assert.False(canUnlock);
         Assert.Contains("Capstone blessing requires patron deity: Wild", reason);
@@ -821,7 +852,7 @@ public class BlessingRegistryTests
         var blessing = TestFixtures.CreateTestBlessing("pantheon_of_wild", "Pantheon of Wild", DeityDomain.Wild, BlessingKind.Religion);
         blessing.RequiresPatron = true;
 
-        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, _) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         Assert.True(canUnlock);
     }
@@ -838,7 +869,7 @@ public class BlessingRegistryTests
         blessing.RequiredPrestigeRank = 0;
         blessing.Cost = 400;
 
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         Assert.False(canUnlock);
         Assert.Contains("Insufficient prestige", reason);
@@ -857,7 +888,7 @@ public class BlessingRegistryTests
         blessing.RequiredPrestigeRank = 1;
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -877,7 +908,7 @@ public class BlessingRegistryTests
         blessing.Cost = 500;
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -899,7 +930,7 @@ public class BlessingRegistryTests
         blessing.Cost = 500;
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -919,7 +950,7 @@ public class BlessingRegistryTests
         blessing.Cost = 0; // Free blessing
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -939,7 +970,7 @@ public class BlessingRegistryTests
         blessing.Cost = 500; // More than available prestige
 
         // Act - pass skipCostCheck: true
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religionData, blessing, skipCostCheck: true);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religionData, blessing, skipCostCheck: true);
 
         // Assert - should return true because cost check is skipped
         Assert.True(canUnlock);
@@ -966,7 +997,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.False(canUnlock);
@@ -990,7 +1021,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -1013,7 +1044,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -1036,7 +1067,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert
         Assert.True(canUnlock);
@@ -1059,7 +1090,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Wild, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert - Should pass because branch lock is domain-specific
         Assert.True(canUnlock);
@@ -1082,7 +1113,7 @@ public class BlessingRegistryTests
         var religion = TestFixtures.CreateTestReligion("test-religion", "Test", DeityDomain.Craft, "player-uid");
 
         // Act
-        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, playerData, religion, blessing);
+        var (canUnlock, reason) = _registry.CanUnlockBlessing("player-uid", FavorRank.Initiate, FavorRank.Initiate, playerData, religion, blessing);
 
         // Assert - Should pass because no branch is locked yet
         Assert.True(canUnlock);

--- a/DivineAscension/Commands/BlessingCommands.cs
+++ b/DivineAscension/Commands/BlessingCommands.cs
@@ -522,9 +522,10 @@ public class BlessingCommands(
         var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(playerUid);
         var religion = _religionManager.GetPlayerReligion(playerUid);
         var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(playerUid, blessing.Domain);
+        var slotCapFavorRank = _playerProgressionDataManager.GetPlayerPatronFavorRank(playerUid);
 
         // Skip cost check here - we'll handle it atomically below
-        var (canUnlock, reason) = _blessingRegistry.CanUnlockBlessing(playerUid, playerFavorRank, playerData, religion, blessing, skipCostCheck: true);
+        var (canUnlock, reason) = _blessingRegistry.CanUnlockBlessing(playerUid, playerFavorRank, slotCapFavorRank, playerData, religion, blessing, skipCostCheck: true);
         if (!canUnlock)
             return TextCommandResult.Error(reason);
 

--- a/DivineAscension/Systems/BlessingRegistry.cs
+++ b/DivineAscension/Systems/BlessingRegistry.cs
@@ -129,7 +129,8 @@ public class BlessingRegistry : IBlessingRegistry
     ///     Checks if a blessing can be unlocked by a player/religion
     /// </summary>
     /// <param name="playerUID">The player's UID</param>
-    /// <param name="playerFavorRank">The player's current favor rank</param>
+    /// <param name="playerFavorRank">The blessing-domain favor rank, gating the per-blessing favor requirement</param>
+    /// <param name="slotCapFavorRank">The patron-domain favor rank, driving the active slot-cap calculation</param>
     /// <param name="playerData">The player's progression data</param>
     /// <param name="religionData">The player's religion data (can be null)</param>
     /// <param name="blessing">The blessing to check</param>
@@ -137,6 +138,7 @@ public class BlessingRegistry : IBlessingRegistry
     /// <returns>A tuple of (canUnlock, reason)</returns>
     public (bool canUnlock, string reason) CanUnlockBlessing(string playerUID,
         FavorRank playerFavorRank,
+        FavorRank slotCapFavorRank,
         PlayerProgressionData playerData,
         ReligionData? religionData,
         Blessing? blessing,
@@ -152,7 +154,7 @@ public class BlessingRegistry : IBlessingRegistry
             if (playerData.IsBlessingUnlocked(blessing.BlessingId)) return (false, "Blessing already unlocked");
 
             // Enforce active blessing slot cap. Calculator falls back to favor-only when no religion.
-            var maxUnlocks = BlessingSlotCalculator.GetMaxUnlocks(_config, playerFavorRank, religionData?.PrestigeRank);
+            var maxUnlocks = BlessingSlotCalculator.GetMaxUnlocks(_config, slotCapFavorRank, religionData?.PrestigeRank);
             var currentCount = playerData.UnlockedBlessings.Count;
             if (currentCount >= maxUnlocks)
                 return (false,

--- a/DivineAscension/Systems/Interfaces/IBlessingRegistry.cs
+++ b/DivineAscension/Systems/Interfaces/IBlessingRegistry.cs
@@ -36,7 +36,8 @@ public interface IBlessingRegistry
     ///     Checks if a blessing can be unlocked by a player/religion
     /// </summary>
     /// <param name="playerUID">The player's UID</param>
-    /// <param name="playerFavorRank">The player's current favor rank</param>
+    /// <param name="playerFavorRank">The blessing-domain favor rank, gating the per-blessing favor requirement</param>
+    /// <param name="slotCapFavorRank">The patron-domain favor rank, driving the active slot-cap calculation</param>
     /// <param name="playerData">The player's progression data</param>
     /// <param name="religionData">The player's religion data (can be null)</param>
     /// <param name="blessing">The blessing to check</param>
@@ -44,6 +45,7 @@ public interface IBlessingRegistry
     /// <returns>A tuple of (canUnlock, reason)</returns>
     (bool canUnlock, string reason) CanUnlockBlessing(string playerUID,
         FavorRank playerFavorRank,
+        FavorRank slotCapFavorRank,
         PlayerProgressionData playerData,
         ReligionData? religionData,
         Blessing? blessing,

--- a/DivineAscension/Systems/Interfaces/IPlayerProgressionDataManager.cs
+++ b/DivineAscension/Systems/Interfaces/IPlayerProgressionDataManager.cs
@@ -121,6 +121,12 @@ public interface IPlayerProgressionDataManager : IDisposable
     public FavorRank GetPlayerFavorRank(string playerUID, DeityDomain domain);
 
     /// <summary>
+    /// Favor rank for the player's patron domain — the canonical "player's favor rank"
+    /// used for blessing slot-cap calculations. Returns Initiate if the player has no religion.
+    /// </summary>
+    public FavorRank GetPlayerPatronFavorRank(string playerUID);
+
+    /// <summary>
     /// [DEPRECATED] Gets the timestamp when the player is next allowed to pray (elapsed milliseconds).
     /// Returns 0 if no cooldown is active. Use GetPrayerCooldownExpiryUtc instead.
     /// </summary>

--- a/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
@@ -106,9 +106,10 @@ public class BlessingNetworkHandler : IServerNetworkHandler
                 var playerData = _playerProgressionDataManager.GetOrCreatePlayerData(fromPlayer.PlayerUID);
                 var religion = _religionManager.GetPlayerReligion(fromPlayer.PlayerUID);
                 var playerFavorRank = _playerProgressionDataManager.GetPlayerFavorRank(fromPlayer.PlayerUID, blessing.Domain);
+                var slotCapFavorRank = _playerProgressionDataManager.GetPlayerPatronFavorRank(fromPlayer.PlayerUID);
 
                 // Skip cost check here - we'll handle it atomically below
-                var (canUnlock, reason) = _blessingRegistry.CanUnlockBlessing(fromPlayer.PlayerUID, playerFavorRank, playerData, religion, blessing, skipCostCheck: true);
+                var (canUnlock, reason) = _blessingRegistry.CanUnlockBlessing(fromPlayer.PlayerUID, playerFavorRank, slotCapFavorRank, playerData, religion, blessing, skipCostCheck: true);
                 if (!canUnlock)
                 {
                     message = reason;

--- a/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
@@ -140,18 +140,13 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
                 totalByDeity[domain] = playerReligionData.GetTotalFavorEarned(domain);
             }
 
-            // Effective slot cap: take the player's best favor rank across deities and add
-            // the religion's prestige bonus. Captures "best you can do" — favor rank-ups on
-            // any deity (or prestige rank-ups that grant bonus slots) raise this, which is
-            // what the client compares to drive the slot-up toast (#445).
-            var maxFavorRank = FavorRank.Initiate;
-            foreach (var domain in AllDeities)
-            {
-                var rank = _playerProgressionDataManager.GetPlayerFavorRank(player.PlayerUID, domain);
-                if (rank > maxFavorRank) maxFavorRank = rank;
-            }
+            // Effective slot cap: the player's patron-domain favor rank plus the religion's
+            // prestige bonus. Patron rank is the canonical "player's favor rank" per design
+            // (#423) and must match the server-side unlock check in BlessingRegistry, else the
+            // header advertises slots the unlock path then refuses (#472).
+            var patronFavorRank = _playerProgressionDataManager.GetPlayerPatronFavorRank(player.PlayerUID);
             var maxBlessingSlots =
-                BlessingSlotCalculator.GetMaxUnlocks(_config, maxFavorRank, religionData.PrestigeRank);
+                BlessingSlotCalculator.GetMaxUnlocks(_config, patronFavorRank, religionData.PrestigeRank);
 
             var packet = new PlayerReligionDataPacket(
                 religionData.ReligionName,

--- a/DivineAscension/Systems/PlayerProgressionDataManager.cs
+++ b/DivineAscension/Systems/PlayerProgressionDataManager.cs
@@ -293,6 +293,17 @@ public class PlayerProgressionDataManager : IPlayerProgressionDataManager
     }
 
     /// <summary>
+    ///     Favor rank for the player's patron domain — the canonical "player's favor rank"
+    ///     used for blessing slot-cap calculations. Returns Initiate if the player has no religion.
+    /// </summary>
+    public FavorRank GetPlayerPatronFavorRank(string playerUID)
+    {
+        var religion = _religionManager.GetPlayerReligion(playerUID);
+        if (religion == null) return FavorRank.Initiate;
+        return GetPlayerFavorRank(playerUID, religion.PatronDomain);
+    }
+
+    /// <summary>
     ///     [DEPRECATED] Gets the timestamp when the player is next allowed to pray (elapsed milliseconds).
     ///     Returns 0 if no cooldown is active or player data doesn't exist.
     ///     Use GetPrayerCooldownExpiryUtc instead.


### PR DESCRIPTION
## Summary
- Both server paths that compute the active blessing slot cap now use the **patron-domain favor rank** (the canonical "player's favor rank" per epic #423), so the UI header and the unlock check agree.
- `PlayerDataNetworkHandler` (drives `PlayerReligionDataPacket.MaxBlessingSlots`) previously took the *highest* favor rank across all five deities (#445); `BlessingRegistry.CanUnlockBlessing` took the *blessing's own domain* rank. They disagreed — UI showed `2/3`, server rejected at `2/2`.
- Adds `IPlayerProgressionDataManager.GetPlayerPatronFavorRank(playerUID)` (returns patron-domain rank, or `Initiate` if no religion).
- Splits the slot-cap rank from the per-blessing favor-requirement gate: `CanUnlockBlessing` gains a `slotCapFavorRank` parameter; the per-blessing favor check still uses the blessing's own domain rank.

## Test plan
- [x] `dotnet build` clean
- [x] New regression test `CanUnlockBlessing_PlayerBlessing_SlotCapUsesPatronRank_NotBlessingDomainRank` — patron Craft=Initiate, incidental Wild=Disciple, Renowned prestige, 2 unlocked → rejected `2/2` (Disciple Wild would have given 3 on the old path).
- [x] All 58 `BlessingRegistryTests` pass.

Fixes #472