### PR TITLE
feat(ui): recent tidings activity tail on the You chapter (#334)

### DIFF
--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -1948,6 +1948,12 @@ public static class LocalizationKeys
 
     public const string UI_PLAYER_INFO_UNSWORN_TITLE_WORD = "divineascension:ui.playerinfo.title.unsworn_word";
 
+    // Recent Tidings — player-scoped activity tail (#334)
+    public const string UI_PLAYER_INFO_SECTION_TIDINGS = "divineascension:ui.playerinfo.section.tidings";
+    public const string UI_PLAYER_INFO_TIDINGS_ROSE = "divineascension:ui.playerinfo.tidings.rose";
+    public const string UI_PLAYER_INFO_TIDINGS_EMPTY = "divineascension:ui.playerinfo.tidings.empty";
+    public const string UI_PLAYER_INFO_TIDINGS_FOOTER = "divineascension:ui.playerinfo.tidings.footer";
+
     #endregion
 
     #region Civilization Ethos & Epithet (#367)

--- a/DivineAscension/GUI/UI/Renderers/PlayerInfo/PlayerInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/PlayerInfo/PlayerInfoRenderer.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.Extensions;
 using DivineAscension.GUI.Events.PlayerInfo;
 using DivineAscension.GUI.Models.PlayerInfo;
 using DivineAscension.GUI.Models.Religion.Header;
+using DivineAscension.GUI.State;
 using DivineAscension.GUI.UI.Components.Lists;
 using DivineAscension.GUI.UI.Renderers.Components;
 using DivineAscension.GUI.UI.Renderers.Utilities;
@@ -43,6 +45,15 @@ internal static class PlayerInfoRenderer
     private const float ProgressBarHeight = 12f;
     private const float ScrollbarWidth = 16f;
 
+    // Recent Tidings — the player-scoped activity tail (#334).
+    private const int TidingsCap = 5;
+    private const float TidingsRowHeight = 22f;
+    private const float TidingsLeftPadding = 16f;
+    private const float TidingsGlyphSize = 14f;
+    private const float TidingsGlyphGap = 8f;
+    private const float TidingsFooterTopSpacing = 6f;
+    private const float TidingsFooterHeight = 20f;
+
     public static IReadOnlyList<PlayerInfoEvent> Draw(PlayerInfoViewModel vm)
     {
         var events = new List<PlayerInfoEvent>();
@@ -55,7 +66,7 @@ internal static class PlayerInfoRenderer
         var height = vm.Height;
         var header = vm.Header;
 
-        var contentHeightEstimate = ComputeContentHeight(header);
+        var contentHeightEstimate = ComputeContentHeight(header, vm.Notifications.Count);
         var maxScroll = MathF.Max(0f, contentHeightEstimate - height);
 
         var mousePos = ImGui.GetMousePos();
@@ -105,6 +116,10 @@ internal static class PlayerInfoRenderer
             currentY = DrawDivider(drawList, x, currentY, contentWidth);
             currentY = DrawOrderStandingSection(header, drawList, x, currentY, contentWidth);
         }
+
+        // === RECENT TIDINGS === (player-scoped activity tail, #334)
+        currentY = DrawDivider(drawList, x, currentY, contentWidth);
+        DrawRecentTidings(vm.Notifications, drawList, x, currentY, contentWidth);
 
         drawList.PopClipRect();
 
@@ -309,6 +324,82 @@ internal static class PlayerInfoRenderer
         };
     }
 
+    /// <summary>
+    ///     Recent Tidings — the player's own deeds tail (#334). Renders the last
+    ///     <see cref="TidingsCap" /> notification-history entries newest-first as
+    ///     ledger lines (domain glyph + prose), then a footer pointing older
+    ///     deeds to the Annals. Collapses to a single grey line when empty.
+    /// </summary>
+    private static float DrawRecentTidings(IReadOnlyList<NotificationHistoryEntry> notifications,
+        ImDrawListPtr drawList, float x, float y, float width)
+    {
+        var currentY = y;
+        TextRenderer.DrawLabel(drawList,
+            LocalizationService.Instance.Get(LocalizationKeys.UI_PLAYER_INFO_SECTION_TIDINGS),
+            x, currentY, SubsectionLabel, ColorPalette.Gold);
+        currentY += SectionLabelHeight;
+
+        if (notifications.Count == 0)
+        {
+            drawList.AddText(new Vector2(x, currentY),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey),
+                LocalizationService.Instance.Get(LocalizationKeys.UI_PLAYER_INFO_TIDINGS_EMPTY));
+            return currentY + TidingsRowHeight;
+        }
+
+        // History is appended oldest-first; show the newest TidingsCap, newest at top.
+        var recent = notifications
+            .Reverse()
+            .Take(TidingsCap)
+            .ToList();
+
+        foreach (var entry in recent)
+        {
+            DrawTidingRow(entry, drawList, x + TidingsLeftPadding, currentY, width - TidingsLeftPadding);
+            currentY += TidingsRowHeight;
+        }
+
+        // Footer: older deeds rest in the Order's Annals.
+        currentY += TidingsFooterTopSpacing;
+        drawList.AddText(new Vector2(x, currentY),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey),
+            LocalizationService.Instance.Get(LocalizationKeys.UI_PLAYER_INFO_TIDINGS_FOOTER));
+        return currentY + TidingsFooterHeight;
+    }
+
+    private static void DrawTidingRow(NotificationHistoryEntry entry,
+        ImDrawListPtr drawList, float x, float y, float width)
+    {
+        // Domain glyph — small ink mark to the left, matching the Annals feed (#316).
+        var glyphCy = y + TidingsRowHeight / 2f;
+        var glyphMin = new Vector2(x, glyphCy - TidingsGlyphSize / 2f);
+        var glyphMax = new Vector2(x + TidingsGlyphSize, glyphCy + TidingsGlyphSize / 2f);
+        DomainGlyphRenderer.Draw(drawList, entry.Deity, glyphMin, glyphMax, ColorPalette.White);
+
+        var textX = x + TidingsGlyphSize + TidingsGlyphGap;
+        var line = BuildTidingLine(entry);
+        drawList.PushClipRect(new Vector2(textX, y),
+            new Vector2(x + width, y + TidingsRowHeight), true);
+        drawList.AddText(new Vector2(textX, y + 2f),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.White), line);
+        drawList.PopClipRect();
+    }
+
+    /// <summary>
+    ///     Compose a tiding's prose line from existing entry data. Rank-ups read
+    ///     "You rose to <rank>."; other notifications fall back to their stored
+    ///     title verbatim. No invented fields.
+    /// </summary>
+    private static string BuildTidingLine(NotificationHistoryEntry entry)
+    {
+        return entry.Type switch
+        {
+            NotificationType.FavorRankUp or NotificationType.PrestigeRankUp =>
+                LocalizationService.Instance.Get(LocalizationKeys.UI_PLAYER_INFO_TIDINGS_ROSE, entry.Title),
+            _ => entry.Title,
+        };
+    }
+
     private static float DrawDivider(ImDrawListPtr drawList, float x, float y, float width)
     {
         var dividerY = y + DividerYPadding;
@@ -316,7 +407,7 @@ internal static class PlayerInfoRenderer
         return y + DividerHeight;
     }
 
-    private static float ComputeContentHeight(ReligionHeaderViewModel header)
+    private static float ComputeContentHeight(ReligionHeaderViewModel header, int tidingsCount)
     {
         var h = 0f;
         // Chapter strip (drop-cap row + divider below)
@@ -343,6 +434,18 @@ internal static class PlayerInfoRenderer
         {
             h += DividerHeight + SectionLabelHeight + ProgressRowHeight + StatBlockBottomSpacing;
             h += DividerHeight + SectionLabelHeight + ProgressRowHeight + StatBlockBottomSpacing;
+        }
+
+        // Recent Tidings: divider + heading + rows (or one empty-state row) + footer.
+        h += DividerHeight + SectionLabelHeight;
+        if (tidingsCount == 0)
+        {
+            h += TidingsRowHeight;
+        }
+        else
+        {
+            h += TidingsRowHeight * Math.Min(tidingsCount, TidingsCap);
+            h += TidingsFooterTopSpacing + TidingsFooterHeight;
         }
 
         return h;

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1344,6 +1344,10 @@
   "divineascension:ui.playerinfo.row.order": "Order",
   "divineascension:ui.playerinfo.row.vestment": "Vestment",
   "divineascension:ui.playerinfo.row.realm": "Realm",
+  "divineascension:ui.playerinfo.section.tidings": "Recent Tidings",
+  "divineascension:ui.playerinfo.tidings.rose": "You rose to {0}.",
+  "divineascension:ui.playerinfo.tidings.empty": "No tidings yet. Your deeds will be recorded here.",
+  "divineascension:ui.playerinfo.tidings.footer": "Older tidings rest in the Annals.",
 
   "divineascension:civilization.ethos.sovereign": "Sovereign",
   "divineascension:civilization.ethos.mercantile": "Mercantile",


### PR DESCRIPTION
Closes #334. Follow-up to #333 (the You-page ledger redesign).

## What

Adds a **Recent Tidings** section to the bottom of the III.i — You ledger chapter: a player-scoped tail of the player's own deeds, distinct from the Order-wide Annals (#316) and realm-wide Chronicles (#332).

## Approach

The client notification history (`NotificationHistoryEntry` — `FavorRankUp`, `PrestigeRankUp`, `BlessingSlotsIncreased`) is already player-scoped and was **already plumbed into `PlayerInfoViewModel.Notifications`**, but went unused after #333 retired the right-rail feed. This consumes it — **no server / network / data changes.**

## Sections (in `PlayerInfoRenderer`)

- Ornamental divider, then a gold `Recent Tidings` sub-heading.
- Last **5** entries, newest-first: per-entry **domain glyph** (`DomainGlyphRenderer`, same mark as the Annals #316) + prose line. Rank-ups read *"You rose to {rank}."*; other types fall back to their stored title.
- Footer prose: *"Older tidings rest in the Annals."*
- **Collapse-when-empty:** a single grey line instead of reserved rows.
- `ComputeContentHeight` updated so the scrollbar stays honest.

Palette: glyph + body `White` ink, heading `Gold`, footer/empty `Grey`. No inline colors.

## Notes / scope calls

- The mockup's **"Turn page ▸"** to the Annals is rendered as footer prose only — the Annals is Order-wide (I.iii) and only sworn players have one, so wiring a nav jump felt out of scope. Trivial to add later.
- The mockup's **favor-action lines** ("You hunted deer +5") live in the *server* Order-wide activity log, not the client notification history; surfacing them would need network plumbing (out of scope per the issue's no-data-change rule).

## Tests

`dotnet build` + `dotnet test` green — 2316 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)