### PR TITLE
fix(ui): guard empty label in progress bar renderer

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Components/ProgressBarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/ProgressBarRenderer.cs
@@ -65,6 +65,11 @@ internal static class ProgressBarRenderer
         // Label text — drawn twice with clipping so each half reads against
         // whatever background sits behind it. Dark ink on the gold fill,
         // light cream on the dark-brown empty portion.
+        // Skip when empty: ImGui.CalcTextSize pins the empty span to a null
+        // pointer and UTF8Encoding.GetByteCount throws on it (e.g. the favor
+        // bar passes "" at max rank).
+        if (string.IsNullOrEmpty(labelText)) return;
+
         var textSize = ImGui.CalcTextSize(labelText);
         var textPos = new Vector2(
             x + (width - textSize.X) / 2,


### PR DESCRIPTION
## Crash

```
System.ArgumentNullException: Value cannot be null. (Parameter 'chars')
   at System.Text.UTF8Encoding.GetByteCount(Char* chars, Int32 count)
   at ImGuiNET.ImGui.CalcTextSize(ReadOnlySpan`1 text)
   at ProgressBarRenderer.DrawProgressBar(...)
   at PlayerInfoRenderer.DrawFavorSection(...)
```

## Cause

`ImGui.CalcTextSize` pins the label's `ReadOnlySpan<char>` to a fixed pointer; for an **empty** string that pointer is null, and `UTF8Encoding.GetByteCount(null, 0)` throws `ArgumentNullException`.

The favor / order-standing rows on the III.i "You" chapter pass `string.Empty` as the bar label when the player is at **max rank** (`favor.IsMaxRank ? string.Empty : "N / M"`), so reaching max favor (or prestige) rank crashes the whole dialog render loop.

## Fix

Skip the label draw when the text is null or empty — there's nothing to render anyway. Protects every `DrawProgressBar` caller, not just the You chapter.

Pre-existing bug, independent of any feature branch. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)