### PR TITLE
fix(ui): queue dialog open until blessing data ready (#487)

### DIFF
--- a/DivineAscension.Tests/GUI/State/GuiDialogStateTests.cs
+++ b/DivineAscension.Tests/GUI/State/GuiDialogStateTests.cs
@@ -47,6 +47,34 @@ public class GuiDialogStateTests
         Assert.Equal(200.75f, state.WindowPosY);
     }
 
+    [Fact]
+    public void PendingOpen_DefaultsToFalse()
+    {
+        var state = new GuiDialogState();
+
+        Assert.False(state.PendingOpen);
+    }
+
+    [Fact]
+    public void PendingOpen_CanBeSetAndRetrieved()
+    {
+        var state = new GuiDialogState();
+
+        state.PendingOpen = true;
+
+        Assert.True(state.PendingOpen);
+    }
+
+    [Fact]
+    public void Reset_ClearsPendingOpen()
+    {
+        var state = new GuiDialogState { PendingOpen = true };
+
+        state.Reset();
+
+        Assert.False(state.PendingOpen);
+    }
+
     #endregion
 
     #region Reset Tests

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -327,6 +327,7 @@ public static class LocalizationKeys
     public const string UI_BLESSING_CONFIRM_UNLEARN_CASCADE_LIST_HEADER = "divineascension:ui.blessing.confirm.unlearn.cascade.list_header";
     public const string UI_BLESSING_READ_MORE = "divineascension:ui.blessing.read_more";
     public const string UI_BLESSING_READ_LESS = "divineascension:ui.blessing.read_less";
+    public const string UI_DIALOG_LOADING = "divineascension:ui.dialog.loading";
     public const string UI_BLESSING_PAGE_TITLE = "divineascension:ui.blessing.page.title";
     public const string UI_BLESSING_PAGE_INTRO = "divineascension:ui.blessing.page.intro";
     public const string UI_BLESSING_PAGE_ACROSS_DOMAINS = "divineascension:ui.blessing.page.across_domains";

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using DivineAscension.API.Implementation;
+using DivineAscension.Constants;
 using DivineAscension.API.Interfaces;
 using DivineAscension.GUI.Interfaces;
 using DivineAscension.GUI.Managers;
@@ -198,7 +199,14 @@ public partial class GuiDialog : ModSystem
 
         if (!_state.IsReady)
         {
-            // Request data from server
+            // Data race (#487): the open landed before blessing data arrived (common in the
+            // first ~1s after login). Queue the open, fire a data request now (the periodic
+            // tick keeps retrying with backoff), and echo "Loading…" so the click isn't silent.
+            _state.PendingOpen = true;
+            _divineAscensionModSystem?.NetworkClient?.RequestBlessingData();
+            _divineAscensionModSystem?.NetworkClient?.RequestAvailableDomains();
+            _logger?.Debug("[DivineAscension] Open requested before data ready — queued pending open, requested data.");
+            _capi?.ShowChatMessage(LocalizationService.Instance.Get(LocalizationKeys.UI_DIALOG_LOADING));
             return;
         }
 

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -32,19 +32,58 @@ public partial class GuiDialog
     }
 
     /// <summary>
-    ///     Periodically check if player religion data is available
+    ///     Backoff schedule (ms) between blessing-data requests while we wait for the
+    ///     server response. Previously the request fired exactly once and the tick was
+    ///     unregistered immediately — a single dropped packet left the dialog stuck
+    ///     closed until relog (#487). Now we keep retrying with growing gaps so we don't
+    ///     spam the server, and stop only once data lands (see <see cref="MarkReady"/>).
+    /// </summary>
+    private static readonly long[] DataRequestBackoffMs = { 1000, 2000, 5000 };
+
+    private int _dataRequestAttempts;
+    private long _nextDataRequestAtMs;
+
+    /// <summary>
+    ///     Periodically check if player religion data is available, re-requesting with
+    ///     backoff until the server responds.
     /// </summary>
     private void OnCheckDataAvailability(float dt)
     {
-        if (_state.IsReady) return;
+        if (_state.IsReady)
+        {
+            // Defensive: the response normally unregisters us via MarkReady(); ensure we
+            // never keep ticking once ready.
+            _capi?.Event.UnregisterGameTickListener(_checkDataId);
+            return;
+        }
 
-        // Request blessing data from server
+        var now = Environment.TickCount64;
+        if (now < _nextDataRequestAtMs) return;
+
         if (_divineAscensionModSystem != null)
         {
             _divineAscensionModSystem.NetworkClient?.RequestBlessingData();
             _divineAscensionModSystem.NetworkClient?.RequestAvailableDomains();
-            // Don't set _state.IsReady yet - wait for server response in OnBlessingDataReceived
-            _capi!.Event.UnregisterGameTickListener(_checkDataId);
+            // Don't set _state.IsReady yet - wait for server response in OnBlessingDataReceived.
+            var idx = Math.Min(_dataRequestAttempts, DataRequestBackoffMs.Length - 1);
+            _nextDataRequestAtMs = now + DataRequestBackoffMs[idx];
+            _dataRequestAttempts++;
+        }
+    }
+
+    /// <summary>
+    ///     Flip the dialog to ready, stop the data-availability retry tick, and replay a
+    ///     queued open (#487). Called from every spot that marks blessing data as loaded.
+    /// </summary>
+    private void MarkReady()
+    {
+        _state.IsReady = true;
+        _capi?.Event.UnregisterGameTickListener(_checkDataId);
+
+        if (_state.PendingOpen)
+        {
+            _state.PendingOpen = false;
+            Open();
         }
     }
 
@@ -59,14 +98,15 @@ public partial class GuiDialog
         {
             _logger?.Debug("[DivineAscension] Player has no religion - data ready for 'No Religion' state");
             _manager!.Reset();
-            _state.IsReady = true; // Set ready so dialog can open to show "No Religion" state
 
             // Clear previous ranks when player has no religion
             _state.PreviousFavorRank = string.Empty;
             _state.PreviousPrestigeRank = string.Empty;
             _state.PreviousMaxBlessingSlots = -1;
 
-            // Dialog will only open when player presses the keybind (Shift+G)
+            // Set ready so the dialog can open to the "No Religion" state, and replay a
+            // queued open if the player clicked a lectern / pressed Shift+G during the race.
+            MarkReady();
 
             return;
         }
@@ -149,7 +189,7 @@ public partial class GuiDialog
         _logger?.Debug(
             $"[DivineAscension] Initialized previous ranks: Favor={favorRankName}, Prestige={prestigeRankName}");
 
-        _state.IsReady = true;
+        MarkReady();
         _logger?.Notification(
             $"[DivineAscension] Loaded {playerBlessings.Count} player + {religionBlessings.Count} religion blessings across all five deities; active={patron}");
     }

--- a/DivineAscension/GUI/State/GuiDialogState.cs
+++ b/DivineAscension/GUI/State/GuiDialogState.cs
@@ -21,6 +21,13 @@ public class GuiDialogState
     public bool RequestClose { get; set; }
 
     /// <summary>
+    ///     An open was attempted (lectern or Shift+G) before <see cref="IsReady"/>
+    ///     was set. The open is queued here and replayed once blessing data lands
+    ///     (#487), so a click during the post-login data race isn't dropped.
+    /// </summary>
+    public bool PendingOpen { get; set; }
+
+    /// <summary>
     ///     Current window X position
     /// </summary>
     public float WindowPosX { get; set; }
@@ -72,6 +79,7 @@ public class GuiDialogState
         IsOpen = false;
         IsReady = false;
         RequestClose = false;
+        PendingOpen = false;
         WindowPosX = 0f;
         WindowPosY = 0f;
         WindowWidth = 0f;

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -246,6 +246,7 @@
   "divineascension:ui.blessing.confirm.unlearn.cascade.list_header": "The following will be struck:",
   "divineascension:ui.blessing.read_more": "Read more",
   "divineascension:ui.blessing.read_less": "Read less",
+  "divineascension:ui.dialog.loading": "Loading…",
   "divineascension:ui.blessing.page.title": "The Blessings",
   "divineascension:ui.blessing.page.intro": "The boons each Domain grants to those who serve. Choose your path through the tree.",
   "divineascension:ui.blessing.page.across_domains": "Across the Domains",


### PR DESCRIPTION
## Summary
Fixes #487 — dialog silently failed to open from lectern or Shift+G within ~1s of login (data-ready race).

- `Open()` no longer drops opens fired before `IsReady`. It queues a `PendingOpen` flag, actually fires `RequestBlessingData`/`RequestAvailableDomains`, and shows a "Loading…" chat toast so the click registers visibly.
- `OnCheckDataAvailability` keeps retrying with backoff (1s → 2s → 5s) until the server responds, instead of firing once and immediately unregistering — a dropped packet no longer leaves the dialog stuck closed until relog.
- New `MarkReady()` flips `IsReady = true`, unregisters the retry tick, and replays the queued open. Wired into both branches of `OnBlessingDataReceived` (religion + no-religion).
- New loc key `ui.dialog.loading`.

## Files
- `GuiDialog.cs` — `Open()` guard + pending flag + toast
- `GuiDialogHandlers.cs` — tick backoff lifecycle, `MarkReady()` pending replay
- `GuiDialogState.cs` — new `PendingOpen` flag
- `LocalizationKeys.cs` / `en.json` — `ui.dialog.loading`

## Tests
- 3 new `GuiDialogStateTests` (default false, set/get, reset clears). All 7 pass.
- `dotnet build` clean.
- Manual in-game check of the login-window repro not run (no client here).

## Out of scope (per issue)
- Server `_activeSessions` ghost cleanup — proximity tick already handles it.
- Merging `IsReady`/`IsOpen` into one state machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)