### PR TITLE
fix(ui): codex reopens on last visited page (#474)

### DIFF
--- a/DivineAscension.Tests/Data/UiPrefsTests.cs
+++ b/DivineAscension.Tests/Data/UiPrefsTests.cs
@@ -17,7 +17,7 @@ public class UiPrefsTests
         Assert.Equal(900, prefs.WindowHeight);
         Assert.False(prefs.SidebarCollapsed);
         Assert.Empty(prefs.CollapsedGroups);
-        Assert.Equal(SidebarNavId.ReligionInfo, prefs.LastNavId);
+        Assert.Equal(SidebarNavId.PlayerInfo, prefs.LastNavId);
     }
 
     [Fact]

--- a/DivineAscension.Tests/GUI/UI/Sidebar/SidebarNavMapperTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Sidebar/SidebarNavMapperTests.cs
@@ -235,6 +235,35 @@ public class SidebarNavMapperTests
     }
 
     [Fact]
+    public void ResolveRestoreNav_EnabledPage_IsRestored()
+    {
+        // CivilizationDiplomacy is enabled when the player has a civilization.
+        var nav = SidebarNavMapper.ResolveRestoreNav(
+            SidebarNavId.CivilizationDiplomacy,
+            Ctx(hasReligion: true, hasCivilization: true));
+
+        Assert.Equal(SidebarNavId.CivilizationDiplomacy, nav);
+    }
+
+    [Fact]
+    public void ResolveRestoreNav_DisabledPage_FallsBackToPlayerInfo()
+    {
+        // CivilizationDiplomacy is disabled with no civilization (e.g. player left it).
+        var nav = SidebarNavMapper.ResolveRestoreNav(
+            SidebarNavId.CivilizationDiplomacy,
+            Ctx());
+
+        Assert.Equal(SidebarNavId.PlayerInfo, nav);
+    }
+
+    [Fact]
+    public void ResolveRestoreNav_PlayerInfo_AlwaysRestored()
+    {
+        Assert.Equal(SidebarNavId.PlayerInfo,
+            SidebarNavMapper.ResolveRestoreNav(SidebarNavId.PlayerInfo, Ctx()));
+    }
+
+    [Fact]
     public void Apply_BlessingsNav_SetsCurrentNav()
     {
         var state = new GuiDialogState();

--- a/DivineAscension/Data/UiPrefs.cs
+++ b/DivineAscension/Data/UiPrefs.cs
@@ -19,5 +19,5 @@ public class UiPrefs
 
     [ProtoMember(4)] public Dictionary<string, bool> CollapsedGroups { get; set; } = new();
 
-    [ProtoMember(5)] public SidebarNavId LastNavId { get; set; } = SidebarNavId.ReligionInfo;
+    [ProtoMember(5)] public SidebarNavId LastNavId { get; set; } = SidebarNavId.PlayerInfo;
 }

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -9,6 +9,7 @@ using DivineAscension.Commands;
 using DivineAscension.Configuration;
 using DivineAscension.Constants;
 using DivineAscension.Data;
+using DivineAscension.GUI.State;
 using DivineAscension.Network;
 using DivineAscension.Network.Civilization;
 using DivineAscension.Network.Diplomacy;
@@ -562,15 +563,21 @@ public class DivineAscensionModSystem : ModSystem
     }
 
     /// <summary>
-    ///     Persists the user's chosen dialog window size into <c>UiPrefs</c> and
-    ///     writes the mod config. Safe to call on the client; <c>SaveModConfig</c>
+    ///     Persists the user's chosen dialog window size and last-visited codex page
+    ///     into <c>UiPrefs</c> and writes the mod config. Window size is only updated
+    ///     when valid (&gt; 0); the nav id is always persisted so the codex reopens on
+    ///     the last page (#474). Safe to call on the client; <c>SaveModConfig</c>
     ///     silently no-ops if no server save-game is available.
     /// </summary>
-    public void SaveUiPrefs(int width, int height)
+    public void SaveUiPrefs(int width, int height, SidebarNavId lastNavId)
     {
-        if (width <= 0 || height <= 0) return;
-        _configData.UiPrefs.WindowWidth = width;
-        _configData.UiPrefs.WindowHeight = height;
+        _configData.UiPrefs.LastNavId = lastNavId;
+        if (width > 0 && height > 0)
+        {
+            _configData.UiPrefs.WindowWidth = width;
+            _configData.UiPrefs.WindowHeight = height;
+        }
+
         SaveModConfig();
     }
 

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -252,12 +252,11 @@ public partial class GuiDialog : ModSystem
 
         _state.IsOpen = false;
 
-        // Persist the most recent window size captured during DrawWindow.
-        // Snapshot lives on _state; DrawWindow refreshes it each frame.
-        if (_state.WindowWidth > 0f && _state.WindowHeight > 0f)
-        {
-            _divineAscensionModSystem?.SaveUiPrefs((int)_state.WindowWidth, (int)_state.WindowHeight);
-        }
+        // Persist the most recent window size captured during DrawWindow (snapshot
+        // lives on _state; DrawWindow refreshes it each frame) and the page the
+        // player was on, so the codex reopens where they left off (#474).
+        _divineAscensionModSystem?.SaveUiPrefs(
+            (int)_state.WindowWidth, (int)_state.WindowHeight, _state.Sidebar.CurrentNav);
 
         _logger?.Debug("[DivineAscension] Blessing Dialog closed");
     }

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using DivineAscension.Constants;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.State.Religion;
+using DivineAscension.GUI.UI.Renderers.Sidebar;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.GUI.Utilities;
 using DivineAscension.Models;
@@ -278,12 +279,27 @@ public partial class GuiDialog
         }
         else
         {
-            _state.Sidebar.CurrentNav = SidebarNavId.Blessings;
+            _state.Sidebar.CurrentNav = ResolveRestoreNav();
             Open();
         }
         return true;
     }
 #endif
+
+    /// <summary>
+    ///     Resolve the page the codex should land on: the player's last-visited
+    ///     page (<see cref="UiPrefs.LastNavId" />), falling back to
+    ///     <see cref="SidebarNavId.PlayerInfo" /> when that page is disabled for the
+    ///     current player (#474).
+    /// </summary>
+    private SidebarNavId ResolveRestoreNav()
+    {
+        var desired = _divineAscensionModSystem?.Config.UiPrefs.LastNavId ?? SidebarNavId.PlayerInfo;
+        if (_manager == null) return desired;
+
+        var ctx = SidebarNavMapper.ContextFromManager(_manager, _state.Sidebar);
+        return SidebarNavMapper.ResolveRestoreNav(desired, ctx);
+    }
 
     /// <summary>
     ///     Server-driven open: fires when the player right-clicks a lectern and the
@@ -292,7 +308,7 @@ public partial class GuiDialog
     private void OnOpenMenuRequested(OpenMenuPacket packet)
     {
         if (_state.IsOpen) return;
-        _state.Sidebar.CurrentNav = SidebarNavId.Blessings;
+        _state.Sidebar.CurrentNav = ResolveRestoreNav();
         Open();
     }
 

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarNavMapper.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarNavMapper.cs
@@ -62,6 +62,24 @@ public static class SidebarNavMapper
     }
 
     /// <summary>
+    ///     Resolve the nav id the codex should land on when reopened. Honours the
+    ///     player's last-visited page, but falls back to <see cref="SidebarNavId.PlayerInfo" />
+    ///     when that page is disabled for the current player — e.g. a Civilization
+    ///     page restored after they left the civilization (#474). PlayerInfo is
+    ///     always reachable.
+    /// </summary>
+    public static SidebarNavId ResolveRestoreNav(SidebarNavId desired, Context ctx)
+    {
+        var vm = BuildViewModel(ctx);
+        foreach (var group in vm.Groups)
+        foreach (var item in group.Items)
+            if (item.Id == desired)
+                return item.IsDisabled ? SidebarNavId.PlayerInfo : desired;
+
+        return SidebarNavId.PlayerInfo;
+    }
+
+    /// <summary>
     ///     Convenience adapter — production builds the context off the live
     ///     <c>GuiDialogManager</c>. Kept here so the mapper is the single place
     ///     that knows the manager surface; renderers only see the view model.


### PR DESCRIPTION
Wire UiPrefs.LastNavId end-to-end: persist the current sidebar nav on
Close() and restore it on open instead of hardcoding Blessings. Falls
back to PlayerInfo when the restored page is disabled for the current
player, and changes the first-time default to PlayerInfo.

https://claude.ai/code/session_01TQn4KTmMS3CoyEDfCDoE1w