### PR TITLE
feat(ui): DEBUG fake leaderboard provider + adapter seam (#501)

### DIFF
--- a/DivineAscension/GUI/GuiDialogManager.cs
+++ b/DivineAscension/GUI/GuiDialogManager.cs
@@ -82,6 +82,13 @@ public class GuiDialogManager : IBlessingDialogManager
         fakeDiplomacyProvider.ConfigureDevSeed(20260522);
         CivilizationManager.UseDiplomacyProvider(fakeDiplomacyProvider);
         CivilizationManager.RequestDiplomacyInfo();
+
+        // Seeded Standing of Realms leaderboard so the chapter can be styled across
+        // all four boards without a server, with a mid-table highlighted self-row.
+        var fakeLeaderboardProvider = new FakeLeaderboardProvider();
+        fakeLeaderboardProvider.ConfigureDevSeed(12, 20260526);
+        CivilizationManager.UseLeaderboardProvider(fakeLeaderboardProvider);
+        CivilizationManager.RefreshLeaderboardFromProvider();
 #endif
     }
 

--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -50,6 +50,9 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     // UI-only diplomacy adapter (fake in dev). Null in release.
     internal IDiplomacyProvider? DiplomacyProvider { get; private set; }
 
+    // UI-only leaderboard adapter (fake in dev). Null in release.
+    internal ILeaderboardProvider? LeaderboardProvider { get; private set; }
+
     public CivilizationTabState State { get; } = new();
 
     /// <summary>
@@ -1721,6 +1724,36 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     {
         CivilizationProvider?.Refresh();
         RequestCivilizationList(State.BrowseState.DeityFilter);
+    }
+
+    /// <summary>
+    ///     Configure a UI-only leaderboard data provider (fake in dev). When set,
+    ///     the leaderboard draw path reads from it instead of the network. In Release
+    ///     it stays null and the real server/network branch (slice 1) is used.
+    /// </summary>
+    internal void UseLeaderboardProvider(ILeaderboardProvider provider)
+    {
+        LeaderboardProvider = provider;
+    }
+
+    /// <summary>
+    ///     Refresh the leaderboard from the configured provider (if any).
+    /// </summary>
+    internal void RefreshLeaderboardFromProvider()
+    {
+        LeaderboardProvider?.Refresh();
+    }
+
+    /// <summary>
+    ///     Source the Standing of Realms boards for the leaderboard chapter. The
+    ///     adapter seam: the dev fake provides seeded data; in Release the provider
+    ///     is null and slice 1's network-backed source plugs into the else branch.
+    /// </summary>
+    internal IReadOnlyList<LeaderboardBoardVM> GetLeaderboards()
+    {
+        return LeaderboardProvider != null
+            ? LeaderboardProvider.GetLeaderboards()
+            : Array.Empty<LeaderboardBoardVM>();
     }
 
     private static IReadOnlyList<CivilizationListResponsePacket.CivilizationInfo> ApplyBrowseFilters(

--- a/DivineAscension/GUI/UI/Adapters/Civilizations/FakeLeaderboardProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/Civilizations/FakeLeaderboardProvider.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.GUI.UI.Adapters.Civilizations;
+
+/// <summary>
+///     Dev-only, UI-only leaderboard provider that generates synthetic realm standings
+///     deterministically across all four boards. Uses the adapter pattern via
+///     <see cref="ILeaderboardProvider" /> so the chapter can be styled against seeded,
+///     representative data without the server/network plumbing (epic #496, slice 5).
+///     The viewer's own realm is seeded to land mid-table so the pin/highlight (slice 2)
+///     is exercisable.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class FakeLeaderboardProvider : ILeaderboardProvider
+{
+    private static readonly string[] RealmNames =
+    {
+        "Northwind Pact", "The Sunken Marches", "Long-Row Covenant", "The Gilded Reach",
+        "Hollowmere Concord", "Ashfell Dominion", "The Iron Tessellate", "Greyfen Union",
+        "The Amber League", "Stormhold Accord", "The Verdant Assembly", "Duskwater Realm",
+        "The Bronze Confederacy", "Whitethorn Order", "The Cinder Reaches", "Saltmarch Coalition",
+        "The Pale Covenant", "Highreach Federation", "The Drowned Kingdom", "Emberfall Concord"
+    };
+
+    private static readonly CivilizationEthos[] EthosPool =
+    {
+        CivilizationEthos.Sovereign, CivilizationEthos.Mercantile, CivilizationEthos.Martial,
+        CivilizationEthos.Mystic, CivilizationEthos.Ascetic
+    };
+
+    private readonly List<LeaderboardBoardVM> _boards = new();
+    private int _count = 12;
+    private int _seed = 20260526;
+
+    public LeaderboardBoardVM GetLeaderboard(LeaderboardBoard board)
+    {
+        if (_boards.Count == 0) Regenerate();
+        return _boards.First(b => b.board == board);
+    }
+
+    public IReadOnlyList<LeaderboardBoardVM> GetLeaderboards()
+    {
+        if (_boards.Count == 0) Regenerate();
+        return _boards;
+    }
+
+    public void ConfigureDevSeed(int count, int seed)
+    {
+        _count = Math.Max(1, count);
+        _seed = seed;
+        Regenerate();
+    }
+
+    public void Refresh()
+    {
+        Regenerate();
+    }
+
+    private void Regenerate()
+    {
+        var rnd = new Random(_seed);
+
+        // Generate the "other" realms with random metrics across all boards.
+        var realms = new List<Realm>(_count);
+        for (var i = 0; i < _count - 1; i++)
+        {
+            var name = RealmNames[i % RealmNames.Length];
+            if (i >= RealmNames.Length) name = $"{name} {i / RealmNames.Length + 1}";
+
+            realms.Add(new Realm(
+                GenerateGuid(rnd).ToString("N"),
+                name,
+                EthosPool[rnd.Next(EthosPool.Length)],
+                rnd.Next(0, 5),       // CivilizationRank value
+                rnd.Next(0, 400),     // war kills
+                rnd.Next(1, 2000),    // age in days
+                rnd.Next(0, 13),      // milestones completed
+                false));
+        }
+
+        // Seed the viewer's realm with the median of each metric so it lands
+        // mid-table on every board (exercises the self-pin/highlight in slice 2).
+        var viewer = new Realm(
+            GenerateGuid(rnd).ToString("N"),
+            "Ashfell",
+            CivilizationEthos.Martial,
+            Median(realms.Select(r => r.RankValue)),
+            Median(realms.Select(r => r.ConquestKills)),
+            Median(realms.Select(r => r.EnduranceDays)),
+            Median(realms.Select(r => r.DeedsCount)),
+            true);
+        realms.Add(viewer);
+
+        _boards.Clear();
+        _boards.Add(BuildBoard(LeaderboardBoard.Standing, realms, r => r.RankValue));
+        _boards.Add(BuildBoard(LeaderboardBoard.Conquest, realms, r => r.ConquestKills));
+        _boards.Add(BuildBoard(LeaderboardBoard.Endurance, realms, r => r.EnduranceDays));
+        _boards.Add(BuildBoard(LeaderboardBoard.Deeds, realms, r => r.DeedsCount));
+    }
+
+    private static LeaderboardBoardVM BuildBoard(
+        LeaderboardBoard board, IReadOnlyList<Realm> realms, Func<Realm, long> score)
+    {
+        // Older realm wins score ties (tie-breaking is finalised in slice 4).
+        var ordered = realms
+            .OrderByDescending(score)
+            .ThenByDescending(r => r.EnduranceDays)
+            .ToList();
+
+        var entries = new List<LeaderboardEntryVM>(ordered.Count);
+        var viewerPosition = 0;
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            var realm = ordered[i];
+            var position = i + 1;
+            if (realm.IsViewer) viewerPosition = position;
+
+            entries.Add(new LeaderboardEntryVM(
+                position,
+                realm.CivId,
+                realm.Name,
+                realm.Ethos,
+                ((CivilizationRank)realm.RankValue).ToString(),
+                score(realm),
+                realm.IsViewer));
+        }
+
+        return new LeaderboardBoardVM(board, entries, viewerPosition, ordered.Count);
+    }
+
+    private static int Median(IEnumerable<int> values)
+    {
+        var sorted = values.OrderBy(v => v).ToArray();
+        return sorted.Length == 0 ? 0 : sorted[sorted.Length / 2];
+    }
+
+    private static Guid GenerateGuid(Random rnd)
+    {
+        var bytes = new byte[16];
+        rnd.NextBytes(bytes);
+        return new Guid(bytes);
+    }
+
+    private sealed record Realm(
+        string CivId,
+        string Name,
+        CivilizationEthos Ethos,
+        int RankValue,
+        int ConquestKills,
+        int EnduranceDays,
+        int DeedsCount,
+        bool IsViewer);
+}

--- a/DivineAscension/GUI/UI/Adapters/Civilizations/ILeaderboardProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/Civilizations/ILeaderboardProvider.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.GUI.UI.Adapters.Civilizations;
+
+/// <summary>
+///     The four themed boards of the Standing of Realms leaderboard (epic #496).
+///     Each ranks civilizations by a different metric the civ systems already track.
+/// </summary>
+internal enum LeaderboardBoard
+{
+    Standing,  // Civilization rank (Nascent → Eternal)
+    Conquest,  // War kill count
+    Endurance, // Age since founding
+    Deeds      // Milestones completed
+}
+
+/// <summary>
+///     One ranked realm within a board.
+/// </summary>
+internal sealed record LeaderboardEntryVM(
+    int position,        // 1-based rank within the board
+    string civId,
+    string name,
+    CivilizationEthos ethos, // drives the per-realm glyph
+    string tierLabel,    // the realm's standing, e.g. "Eternal" / "Dominant"
+    long score,          // the board's metric for this realm
+    bool isViewer        // the viewer's own realm (pinned/highlighted in slice 2)
+);
+
+/// <summary>
+///     One board's ordered entries plus the viewer's own position and the total
+///     number of ranked realms (for the "stands IV among XII" summary line).
+/// </summary>
+internal sealed record LeaderboardBoardVM(
+    LeaderboardBoard board,
+    IReadOnlyList<LeaderboardEntryVM> entries,
+    int viewerPosition,  // 1-based; 0 when the viewer has no ranked realm
+    int totalCount
+);
+
+/// <summary>
+///     UI-only data source for the Standing of Realms leaderboard. Intended for swapping
+///     between a real (network-backed) provider and a dev-only fake provider without
+///     touching systems/persistence — mirrors <see cref="ICivilizationProvider" />.
+/// </summary>
+internal interface ILeaderboardProvider
+{
+    LeaderboardBoardVM GetLeaderboard(LeaderboardBoard board);
+    IReadOnlyList<LeaderboardBoardVM> GetLeaderboards();
+    void ConfigureDevSeed(int count, int seed);
+    void Refresh();
+}


### PR DESCRIPTION
Add ILeaderboardProvider seam and a deterministic FakeLeaderboardProvider
so the Standing of Realms chapter can be styled against seeded data across
all four boards (Standing/Conquest/Endurance/Deeds) without server plumbing.
The viewer's realm is seeded mid-table to exercise the self-pin/highlight.
Wired in GuiDialogManager under the existing DEBUG block; in Release the
provider stays null and slice 1's network branch plugs into the seam.

https://claude.ai/code/session_016iBMgLyq72nN9phcyw2Q1Q