### PR TITLE
feat(ui): show civic boon values on Milestones page (#493)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
@@ -33,6 +33,7 @@ internal static class CivilizationMilestoneRenderer
     private const float StatRowHeight = 22f;
     private const float ProseBottomSpacing = 12f;
     private const float BoonLineHeight = 22f;
+    private const float BoonProseHeight = 20f;
     private const float DeedNameHeight = 22f;
     private const float DeedProgressRowHeight = 22f;
     private const float DeedItemSpacing = 10f;
@@ -215,14 +216,20 @@ internal static class CivilizationMilestoneRenderer
             return currentY + BoonLineHeight + 6f;
         }
 
-        foreach (var phrase in phrases)
+        foreach (var boon in phrases)
         {
             DrawDiamondBullet(drawList, x + 4f, currentY + Body / 2f - 1f);
             drawList.AddText(ImGui.GetFont(), Body,
                 new Vector2(x + ProgressBarIndent, currentY),
-                ImGui.ColorConvertFloat4ToU32(ColorPalette.White),
-                phrase);
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold),
+                boon.Value);
             currentY += BoonLineHeight;
+
+            drawList.AddText(ImGui.GetFont(), Secondary,
+                new Vector2(x + ProgressBarIndent, currentY),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey),
+                boon.Prose);
+            currentY += BoonProseHeight;
         }
 
         return currentY + 6f;
@@ -351,7 +358,9 @@ internal static class CivilizationMilestoneRenderer
         // Boons: heading + N lines (or empty single line)
         h += DividerHeight;
         var boonCount = MilestonePhrases.ActiveBonusPhrases(viewModel.Bonuses).Count();
-        h += SectionLabelHeight + (boonCount > 0 ? boonCount * BoonLineHeight : BoonLineHeight) + 6f;
+        h += SectionLabelHeight + (boonCount > 0
+            ? boonCount * (BoonLineHeight + BoonProseHeight)
+            : BoonLineHeight) + 6f;
 
         // Deeds: heading + per-item (name + progress/set-down row + spacing)
         h += DividerHeight;

--- a/DivineAscension/GUI/UI/Renderers/Civilization/MilestonePhrases.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/MilestonePhrases.cs
@@ -1,7 +1,15 @@
 using System.Collections.Generic;
+using System.Globalization;
 using DivineAscension.Network;
 
 namespace DivineAscension.GUI.UI.Renderers.Civilization;
+
+/// <summary>
+///     One active boon as shown under "Boons of Standing": a concrete value
+///     lead-in (e.g. "+15% favor") paired with the manuscript prose that
+///     describes it.
+/// </summary>
+internal readonly record struct BoonPhrase(string Value, string Prose);
 
 /// <summary>
 ///     Manuscript phrasing tables for the Chronicles ledger chapter. Verb
@@ -38,19 +46,34 @@ internal static class MilestonePhrases
     }
 
     /// <summary>
-    ///     Walks the bonus DTO and returns one manuscript sentence per active
-    ///     bonus, in display order. Inactive bonuses (multiplier == 1.0,
-    ///     slot count 0) are skipped.
+    ///     Walks the bonus DTO and returns one boon per active bonus, in
+    ///     display order, each carrying its concrete value alongside the
+    ///     manuscript prose. Inactive bonuses (multiplier == 1.0, slot count
+    ///     0) are skipped. Multipliers render as percentages to match the PvP
+    ///     chat convention ("[CIV +X%]"); holy-site slots as a flat count.
     /// </summary>
-    public static IEnumerable<string> ActiveBonusPhrases(CivilizationBonusesDto bonuses)
+    public static IEnumerable<BoonPhrase> ActiveBonusPhrases(CivilizationBonusesDto bonuses)
     {
         if (bonuses.PrestigeMultiplier > 1f)
-            yield return "Deeds are remembered in greater measure.";
+            yield return new BoonPhrase(
+                $"+{Percent(bonuses.PrestigeMultiplier)} prestige",
+                "Deeds are remembered in greater measure.");
         if (bonuses.FavorMultiplier > 1f)
-            yield return "Devotion is reckoned more keenly.";
+            yield return new BoonPhrase(
+                $"+{Percent(bonuses.FavorMultiplier)} favor",
+                "Devotion is reckoned more keenly.");
         if (bonuses.ConquestMultiplier > 1f)
-            yield return "The Realm's banners strike with greater wrath in war.";
+            yield return new BoonPhrase(
+                $"+{Percent(bonuses.ConquestMultiplier)} conquest (in war)",
+                "The Realm's banners strike with greater wrath in war.");
         if (bonuses.BonusHolySiteSlots > 0)
-            yield return "Hallows beyond the common count may be raised.";
+            yield return new BoonPhrase(
+                $"+{bonuses.BonusHolySiteSlots} {(bonuses.BonusHolySiteSlots == 1 ? "hallow" : "hallows")}",
+                "Hallows beyond the common count may be raised.");
+    }
+
+    private static string Percent(float multiplier)
+    {
+        return ((multiplier - 1f) * 100f).ToString("F0", CultureInfo.InvariantCulture) + "%";
     }
 }


### PR DESCRIPTION
Surface the concrete civilization bonus magnitudes alongside the
existing narrative prose in the Boons of Standing section. Each active
boon now renders its value as a gold lead-in stat (e.g. "+15% favor",
"+20% conquest (in war)", "+2 hallows") with the prose as a grey
subtitle. Multipliers format as percentages to match the PvP chat
convention; holy-site slots as a flat count. The "None yet" empty state
is preserved.

https://claude.ai/code/session_0118HkidHGR8QDvGJtS35jqN