### PR TITLE
fix(ui): wrap religion tooltip description at its draw size

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Components/ReligionListRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/ReligionListRenderer.cs
@@ -296,8 +296,9 @@ public static class ReligionListRenderer
             lines.Add(""); // Empty line for spacing
             lines.Add(LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_LIST_DESCRIPTION_LABEL));
 
-            // Wrap description text
-            var wrappedDesc = WrapText(religion.Description, tooltipMaxWidth - tooltipPadding * 2, 13f);
+            // Wrap description text at the same size it is drawn (Body); a
+            // smaller measure size lets lines overflow and clip at the edge.
+            var wrappedDesc = WrapText(religion.Description, tooltipMaxWidth - tooltipPadding * 2, Body);
             lines.AddRange(wrappedDesc);
         }
 


### PR DESCRIPTION
## Problem

The religion browse tooltip clipped long descriptions at the right edge instead of wrapping to the popup width.

## Cause

`ReligionListRenderer.DrawTooltip` wrapped the description with a hardcoded **13f** measure font (`ReligionListRenderer.cs:300`) but drew the body lines at **`Body` (15f)**. Lines measured to fit the 276px inner width at 13f render ~15% wider at 15f (~318px), overflowing the 300px tooltip. The draw uses raw `drawList.AddText` with no wrap width, so the overflow clips rather than wraps.

## Fix

Measure the wrap at `Body` — the same size the description is drawn at — so each pre-wrapped line actually fits. One-line change; this is the only `WrapText` call in the file and it feeds only the description.

## Testing

- `dotnet build` clean.
- `dotnet test` — 2353 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)