### PR TITLE
feat(ui): leaderboard slice 4 — glyphs, score bars, tie-breaking (#500)

### DIFF
--- a/DivineAscension/GUI/Managers/CivilizationStateManager.cs
+++ b/DivineAscension/GUI/Managers/CivilizationStateManager.cs
@@ -447,7 +447,43 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
         State.LeaderboardState.IsLoading = true;
         State.LeaderboardState.ErrorMsg = null;
 
+        // Adapter short-circuit: dev fake provider feeds the chapter in-process,
+        // so the boards render (with glyphs/bars) without a server. In Release the
+        // provider is null and the request falls through to the network.
+        if (LeaderboardProvider != null)
+        {
+            State.LeaderboardState.UpdateFromPacket(BuildLeaderboardPacket(LeaderboardProvider.GetLeaderboards()));
+            return;
+        }
+
         _uiService.RequestLeaderboard();
+    }
+
+    /// <summary>
+    ///     Map adapter board VMs → the network response packet so the fake
+    ///     provider and the real server source feed the renderer identically.
+    /// </summary>
+    private static LeaderboardResponsePacket BuildLeaderboardPacket(IReadOnlyList<LeaderboardBoardVM> boards)
+    {
+        var packetBoards = boards.Select(b => new LeaderboardResponsePacket.Board
+        {
+            Metric = (int)b.board,
+            ViewerPosition = b.viewerPosition,
+            Entries = b.entries.Select(e => new LeaderboardResponsePacket.LeaderboardEntry
+            {
+                Position = e.position,
+                CivId = e.civId,
+                Name = e.name,
+                TierLabel = e.tierLabel,
+                Score = (int)e.score,
+                Ethos = (int)e.ethos
+            }).ToList()
+        }).ToList();
+
+        return new LeaderboardResponsePacket(packetBoards)
+        {
+            TotalRealms = boards.FirstOrDefault()?.totalCount ?? 0
+        };
     }
 
     /// <summary>
@@ -1819,6 +1855,7 @@ public class CivilizationStateManager(ICoreClientAPI coreClientApi, IUiService u
     internal void RefreshLeaderboardFromProvider()
     {
         LeaderboardProvider?.Refresh();
+        RequestLeaderboard();
     }
 
     /// <summary>

--- a/DivineAscension/GUI/UI/Adapters/Civilizations/FakeLeaderboardProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/Civilizations/FakeLeaderboardProvider.cs
@@ -105,7 +105,8 @@ internal sealed class FakeLeaderboardProvider : ILeaderboardProvider
     private static LeaderboardBoardVM BuildBoard(
         LeaderboardBoard board, IReadOnlyList<Realm> realms, Func<Realm, long> score)
     {
-        // Older realm wins score ties (tie-breaking is finalised in slice 4).
+        // Older realm wins score ties — matches the server rule (ThenBy CreatedDate
+        // ascending); here more EnduranceDays == older.
         var ordered = realms
             .OrderByDescending(score)
             .ThenByDescending(r => r.EnduranceDays)

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
@@ -213,8 +213,10 @@ internal static class CivilizationLeaderboardRenderer
             : entry.Name;
         drawList.AddText(font, Body, new Vector2(nameX, textY), nameColor, name);
 
-        // Right block: score (right-aligned), bar, then tier label.
-        var rightEdge = x + width - (isViewer ? RowMarkerWidth : 0f);
+        // Right block: score (right-aligned), bar, then tier label. The pin
+        // gutter is reserved on every row so the columns line up whether or not
+        // the row is the viewer's.
+        var rightEdge = x + width - RowMarkerWidth;
         var scoreText = entry.Score.ToString();
         var scoreSize = ImGui.CalcTextSize(scoreText);
         var scoreX = rightEdge - scoreSize.X;

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
@@ -18,11 +18,12 @@ using static DivineAscension.GUI.UI.Utilities.FontSizes;
 namespace DivineAscension.GUI.UI.Renderers.Civilization;
 
 /// <summary>
-///     Pure renderer for the Standing of Realms leaderboard chapter (#497,
-///     #498). Title strip + refresh glyph, prose intro, then every realm
-///     ranked by Standing as a plain row: position, name, tier label, score.
-///     The viewer's own realm is pinned/highlighted, and a closing summary
-///     line states where they stand among the rest.
+///     Pure renderer for the Standing of Realms leaderboard chapter (#497–#500).
+///     Title strip + refresh glyph, prose intro, board selector, then every realm
+///     as a ranked row: Roman rank, heraldic ethos glyph, name, tier label, a
+///     proportional score bar, and the score. The viewer's own realm is pinned
+///     (<c>▸ … ◂</c>) and highlighted in gold in its true ranked position, and a
+///     closing summary line states where they stand among the rest.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal static class CivilizationLeaderboardRenderer
@@ -38,6 +39,13 @@ internal static class CivilizationLeaderboardRenderer
     private const float SelectorRowBottomSpacing = 6f;
     private const float SelectorChipGap = 18f;
     private const float SelectorChipPaddingX = 8f;
+    private const float RowMarkerWidth = 16f; // ▸/◂ pin gutter on the viewer row
+    private const float RowRankWidth = 46f;    // "VIII." rank column
+    private const float RowGlyphSize = 16f;    // heraldic ethos mark
+    private const float RowGlyphGap = 8f;
+    private const float RowBarWidth = 72f;
+    private const float RowBarHeight = 8f;
+    private const float RowColumnGap = 12f;
 
     public static CivilizationLeaderboardRenderResult Draw(
         CivilizationLeaderboardViewModel viewModel,
@@ -108,28 +116,17 @@ internal static class CivilizationLeaderboardRenderer
             return new CivilizationLeaderboardRenderResult(events, height);
         }
 
+        // Score bars are proportional to the board's top score. Entries arrive
+        // sorted highest-first, but guard against an empty/zero top all the same.
+        var maxScore = 0;
+        foreach (var e in viewModel.Entries)
+            if (e.Score > maxScore)
+                maxScore = e.Score;
+
         foreach (var entry in viewModel.Entries)
         {
             var isViewer = viewModel.ViewerPosition > 0 && entry.Position == viewModel.ViewerPosition;
-            var value = LocalizationService.Instance.Get(
-                LocalizationKeys.UI_CIVILIZATION_LEADERBOARD_ROW_VALUE, entry.TierLabel, entry.Score);
-
-            if (isViewer)
-            {
-                // Pin and highlight the viewer's own realm so it's always findable.
-                var name = LocalizationService.Instance.Get(
-                    LocalizationKeys.UI_CIVILIZATION_LEADERBOARD_SELF_ROW, entry.Name);
-                var label = $"▸ {entry.Position}.  {name}";
-                ChromeRenderer.DrawLeader(drawList, label, $"{value}  ◂", x, currentY, contentWidth,
-                    labelColor: ColorPalette.Gold, valueColor: ColorPalette.Gold);
-            }
-            else
-            {
-                var label = $"{entry.Position}.  {entry.Name}";
-                ChromeRenderer.DrawLeader(drawList, label, value, x, currentY, contentWidth,
-                    valueColor: ColorPalette.Gold);
-            }
-
+            DrawRow(drawList, entry, isViewer, maxScore, x, currentY, contentWidth);
             currentY += RowHeight;
         }
 
@@ -165,6 +162,86 @@ internal static class CivilizationLeaderboardRenderer
             by + RefreshGlyphSize / 2f,
             RefreshGlyphSize - 6f,
             ColorPalette.LightText);
+    }
+
+    /// <summary>
+    ///     One ranked row: pin gutter, Roman rank, ethos glyph, realm name on the
+    ///     left; tier label, proportional score bar, and score on the right. The
+    ///     viewer's own realm is bracketed (<c>▸ … ◂</c>), uppercased, and gold so
+    ///     it stays findable in its true ranked position.
+    /// </summary>
+    private static void DrawRow(
+        ImDrawListPtr drawList,
+        Network.Civilization.LeaderboardResponsePacket.LeaderboardEntry entry,
+        bool isViewer, int maxScore,
+        float x, float y, float width)
+    {
+        var font = ImGui.GetFont();
+        var rowMidY = y + RowHeight / 2f;
+        var textY = rowMidY - Body / 2f;
+        var nameColor = ImGui.ColorConvertFloat4ToU32(isViewer ? ColorPalette.Gold : ColorPalette.White);
+        var glyphColor = isViewer ? ColorPalette.Gold : ColorPalette.Grey;
+
+        // Pin gutter — bracket the viewer's realm so it reads as "you are here".
+        if (isViewer)
+        {
+            drawList.AddText(font, Body, new Vector2(x, textY), nameColor, "▸"); // ▸
+            drawList.AddText(font, Body, new Vector2(x + width - ImGui.CalcTextSize("◂").X, textY),
+                nameColor, "◂"); // ◂
+        }
+
+        var leftX = x + RowMarkerWidth;
+
+        // Roman rank.
+        drawList.AddText(font, Body, new Vector2(leftX, textY),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), $"{ToRoman(entry.Position)}.");
+
+        // Ethos glyph.
+        var glyphX = leftX + RowRankWidth;
+        EthosGlyphRenderer.Draw(drawList, (CivilizationEthos)entry.Ethos,
+            new Vector2(glyphX, rowMidY - RowGlyphSize / 2f),
+            new Vector2(glyphX + RowGlyphSize, rowMidY + RowGlyphSize / 2f),
+            glyphColor);
+
+        // Realm name (uppercased + prefixed for the viewer).
+        var nameX = glyphX + RowGlyphSize + RowGlyphGap;
+        var name = isViewer
+            ? LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_LEADERBOARD_SELF_ROW, entry.Name)
+            : entry.Name;
+        drawList.AddText(font, Body, new Vector2(nameX, textY), nameColor, name);
+
+        // Right block: score (right-aligned), bar, then tier label.
+        var rightEdge = x + width - (isViewer ? RowMarkerWidth : 0f);
+        var scoreText = entry.Score.ToString();
+        var scoreSize = ImGui.CalcTextSize(scoreText);
+        var scoreX = rightEdge - scoreSize.X;
+        drawList.AddText(font, Body, new Vector2(scoreX, textY),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), scoreText);
+
+        var barRight = scoreX - RowColumnGap;
+        var barLeft = barRight - RowBarWidth;
+        DrawScoreBar(drawList, barLeft, rowMidY - RowBarHeight / 2f, RowBarWidth, RowBarHeight,
+            maxScore <= 0 ? 0f : (float)entry.Score / maxScore, isViewer);
+
+        // Tier label, right-aligned against the bar.
+        var tierSize = ImGui.CalcTextSize(entry.TierLabel);
+        drawList.AddText(font, Body, new Vector2(barLeft - RowColumnGap - tierSize.X, textY),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), entry.TierLabel);
+    }
+
+    /// <summary>A proportional score bar: faint track with a filled gold portion.</summary>
+    private static void DrawScoreBar(
+        ImDrawListPtr drawList, float x, float y, float width, float height, float fraction, bool isViewer)
+    {
+        fraction = Math.Clamp(fraction, 0f, 1f);
+        var trackCol = ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor);
+        var fillCol = ImGui.ColorConvertFloat4ToU32(isViewer ? ColorPalette.Gold : ColorPalette.Grey);
+
+        drawList.AddRectFilled(new Vector2(x, y), new Vector2(x + width, y + height),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor * 0.4f), 2f);
+        drawList.AddRect(new Vector2(x, y), new Vector2(x + width, y + height), trackCol, 2f);
+        if (fraction > 0f)
+            drawList.AddRectFilled(new Vector2(x, y), new Vector2(x + width * fraction, y + height), fillCol, 2f);
     }
 
     private static float DrawProseIntro(

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
@@ -183,11 +183,14 @@ internal static class CivilizationLeaderboardRenderer
         var glyphColor = isViewer ? ColorPalette.Gold : ColorPalette.Grey;
 
         // Pin gutter — bracket the viewer's realm so it reads as "you are here".
+        // Drawn as chevrons rather than glyphs: ▸/◂ aren't in the ImGui font.
         if (isViewer)
         {
-            drawList.AddText(font, Body, new Vector2(x, textY), nameColor, "▸"); // ▸
-            drawList.AddText(font, Body, new Vector2(x + width - ImGui.CalcTextSize("◂").X, textY),
-                nameColor, "◂"); // ◂
+            const float pinSize = 9f;
+            ChromeRenderer.DrawChevron(drawList, x + pinSize * 0.6f, rowMidY, pinSize,
+                ChromeRenderer.ChevronDirection.Right, ColorPalette.Gold);
+            ChromeRenderer.DrawChevron(drawList, x + width - pinSize * 0.6f, rowMidY, pinSize,
+                ChromeRenderer.ChevronDirection.Left, ColorPalette.Gold);
         }
 
         var leftX = x + RowMarkerWidth;

--- a/DivineAscension/GUI/UI/Renderers/Utilities/EthosGlyphRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/EthosGlyphRenderer.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
+using ImGuiNET;
+
+namespace DivineAscension.GUI.UI.Renderers.Utilities;
+
+/// <summary>
+///     Paint a realm's heraldic mark inside the rect <c>(min, max)</c> using
+///     drawList primitives only — crown (Sovereign), scales (Mercantile),
+///     crossed swords (Martial), sparkle (Mystic), sun (Ascetic). Reuses the
+///     ink-on-vellum vocabulary of <see cref="DomainGlyphRenderer" /> so the
+///     Standing of Realms rows read as a manuscript ledger (#500).
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class EthosGlyphRenderer
+{
+    public static void Draw(ImDrawListPtr drawList, CivilizationEthos ethos,
+        Vector2 min, Vector2 max, Vector4? colorOverride = null)
+    {
+        var color = ImGui.ColorConvertFloat4ToU32(colorOverride ?? ColorPalette.Grey);
+        var w = max.X - min.X;
+        var h = max.Y - min.Y;
+        if (w <= 2f || h <= 2f) return;
+
+        var cx = (min.X + max.X) * 0.5f;
+        var cy = (min.Y + max.Y) * 0.5f;
+        var s = MathF.Min(w, h);
+
+        switch (ethos)
+        {
+            case CivilizationEthos.Sovereign:
+                DrawCrown(drawList, cx, cy, s, color);
+                return;
+            case CivilizationEthos.Mercantile:
+                DrawScales(drawList, cx, cy, s, color);
+                return;
+            case CivilizationEthos.Martial:
+                DrawCrossedSwords(drawList, cx, cy, s, color);
+                return;
+            case CivilizationEthos.Mystic:
+                DrawSparkle(drawList, cx, cy, s, color);
+                return;
+            case CivilizationEthos.Ascetic:
+                DrawSun(drawList, cx, cy, s, color);
+                return;
+            default:
+                drawList.AddCircle(new Vector2(cx, cy), s * 0.3f, color, 16, 1.5f);
+                return;
+        }
+    }
+
+    private static void DrawCrown(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
+    {
+        var halfW = s * 0.38f;
+        var baseY = cy + s * 0.22f;
+        var topY = cy - s * 0.26f;
+        var bandH = MathF.Max(2f, s * 0.10f);
+
+        // Three points rising to a band.
+        for (var i = -1; i <= 1; i++)
+        {
+            var px = cx + i * halfW;
+            drawList.AddTriangleFilled(
+                new Vector2(px - halfW * 0.5f, baseY),
+                new Vector2(px + halfW * 0.5f, baseY),
+                new Vector2(px, topY),
+                color);
+        }
+
+        drawList.AddRectFilled(
+            new Vector2(cx - halfW, baseY - bandH * 0.5f),
+            new Vector2(cx + halfW, baseY + bandH * 0.5f),
+            color, 1f);
+    }
+
+    private static void DrawScales(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
+    {
+        var beam = MathF.Max(1.5f, s * 0.05f);
+        var armX = s * 0.34f;
+        var beamY = cy - s * 0.22f;
+
+        // Central post + crossbeam.
+        drawList.AddLine(new Vector2(cx, beamY - s * 0.12f), new Vector2(cx, cy + s * 0.28f), color, beam);
+        drawList.AddLine(new Vector2(cx - armX, beamY), new Vector2(cx + armX, beamY), color, beam);
+
+        // Two pans hanging from the beam ends.
+        var panY = beamY + s * 0.22f;
+        var panR = s * 0.13f;
+        for (var side = -1; side <= 1; side += 2)
+        {
+            var ex = cx + side * armX;
+            drawList.AddLine(new Vector2(ex, beamY), new Vector2(ex, panY), color, MathF.Max(1f, s * 0.03f));
+            drawList.AddCircle(new Vector2(ex, panY + panR * 0.4f), panR, color, 16, MathF.Max(1.2f, s * 0.035f));
+        }
+    }
+
+    private static void DrawCrossedSwords(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
+    {
+        var thick = MathF.Max(1.8f, s * 0.06f);
+        var arm = s * 0.40f;
+        const float k = 0.70710677f;
+
+        // Two blades crossing through the centre.
+        drawList.AddLine(new Vector2(cx - k * arm, cy + k * arm), new Vector2(cx + k * arm, cy - k * arm), color, thick);
+        drawList.AddLine(new Vector2(cx + k * arm, cy + k * arm), new Vector2(cx - k * arm, cy - k * arm), color, thick);
+
+        // Short crossguards near the hilts (bottom corners).
+        var g = s * 0.12f;
+        drawList.AddLine(new Vector2(cx - k * arm - g, cy + k * arm - g),
+            new Vector2(cx - k * arm + g, cy + k * arm + g), color, MathF.Max(1.2f, s * 0.035f));
+        drawList.AddLine(new Vector2(cx + k * arm - g, cy + k * arm + g),
+            new Vector2(cx + k * arm + g, cy + k * arm - g), color, MathF.Max(1.2f, s * 0.035f));
+    }
+
+    private static void DrawSparkle(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
+    {
+        // Four tapered spikes from the centre — a heraldic mullet/sparkle (✦).
+        var tip = s * 0.42f;
+        var waist = s * 0.12f;
+        var c = new Vector2(cx, cy);
+
+        // N, E, S, W spikes, each a kite split into two triangles via the waist.
+        DrawSpike(drawList, c, new Vector2(cx, cy - tip), waist, color, vertical: true);
+        DrawSpike(drawList, c, new Vector2(cx, cy + tip), waist, color, vertical: true);
+        DrawSpike(drawList, c, new Vector2(cx - tip, cy), waist, color, vertical: false);
+        DrawSpike(drawList, c, new Vector2(cx + tip, cy), waist, color, vertical: false);
+    }
+
+    private static void DrawSpike(ImDrawListPtr drawList, Vector2 center, Vector2 tip, float waist, uint color,
+        bool vertical)
+    {
+        var left = vertical
+            ? new Vector2(center.X - waist, center.Y)
+            : new Vector2(center.X, center.Y - waist);
+        var right = vertical
+            ? new Vector2(center.X + waist, center.Y)
+            : new Vector2(center.X, center.Y + waist);
+        drawList.AddTriangleFilled(left, right, tip, color);
+    }
+
+    private static void DrawSun(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
+    {
+        var coreR = s * 0.16f;
+        var center = new Vector2(cx, cy);
+        drawList.AddCircleFilled(center, coreR, color);
+
+        // Eight rays around the disc.
+        var inner = coreR + s * 0.05f;
+        var outer = s * 0.42f;
+        var rayW = MathF.Max(1.2f, s * 0.035f);
+        for (var i = 0; i < 8; i++)
+        {
+            var a = i * (MathF.PI / 4f);
+            var dx = MathF.Cos(a);
+            var dy = MathF.Sin(a);
+            drawList.AddLine(
+                new Vector2(cx + dx * inner, cy + dy * inner),
+                new Vector2(cx + dx * outer, cy + dy * outer),
+                color, rayW);
+        }
+    }
+}

--- a/DivineAscension/Network/Civilization/LeaderboardResponsePacket.cs
+++ b/DivineAscension/Network/Civilization/LeaderboardResponsePacket.cs
@@ -51,5 +51,8 @@ public class LeaderboardResponsePacket
         [ProtoMember(3)] public string Name { get; set; } = string.Empty;
         [ProtoMember(4)] public string TierLabel { get; set; } = string.Empty;
         [ProtoMember(5)] public int Score { get; set; }
+
+        /// <summary>The realm's <see cref="DivineAscension.Models.Enum.CivilizationEthos" />, drives the per-realm heraldic glyph.</summary>
+        [ProtoMember(6)] public int Ethos { get; set; }
     }
 }

--- a/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
@@ -148,8 +148,10 @@ public class CivilizationNetworkHandler(
 
     /// <summary>
     ///     Build one ranked board: orders all realms by <paramref name="scoreOf" />
-    ///     (highest first), labels each row with the realm's standing tier, and
-    ///     records the viewer's own position within the ordering.
+    ///     (highest first), breaking score ties in favour of the older realm
+    ///     (earlier <see cref="Data.Civilization.CreatedDate" />) so the ordering
+    ///     is deterministic. Labels each row with the realm's standing tier and
+    ///     ethos glyph, and records the viewer's own position within the ordering.
     /// </summary>
     private static LeaderboardResponsePacket.Board BuildBoard(
         LeaderboardMetric metric,
@@ -157,7 +159,11 @@ public class CivilizationNetworkHandler(
         string? viewerCivId,
         System.Func<Data.Civilization, int> scoreOf)
     {
-        var ranked = civilizations.OrderByDescending(scoreOf).ToList();
+        // Tie-break: older realm (earlier CreatedDate) wins equal scores.
+        var ranked = civilizations
+            .OrderByDescending(scoreOf)
+            .ThenBy(c => c.CreatedDate)
+            .ToList();
         var entries = new List<LeaderboardResponsePacket.LeaderboardEntry>(ranked.Count);
         var viewerPosition = 0;
 
@@ -170,7 +176,8 @@ public class CivilizationNetworkHandler(
                 CivId = civ.CivId,
                 Name = civ.Name,
                 TierLabel = RankRequirements.GetCivilizationRankName((int)civ.Rank),
-                Score = scoreOf(civ)
+                Score = scoreOf(civ),
+                Ethos = (int)civ.Ethos
             });
 
             if (viewerCivId != null && civ.CivId == viewerCivId)

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -356,7 +356,7 @@
   "divineascension:ui.civilization.leaderboard.error": "Error loading the standing: {0}",
   "divineascension:ui.civilization.leaderboard.empty": "No Realms have yet risen to be measured.",
   "divineascension:ui.civilization.leaderboard.row_value": "{0}  ({1})",
-  "divineascension:ui.civilization.leaderboard.self_row": "YOUR REALM — {0}",
+  "divineascension:ui.civilization.leaderboard.self_row": "YOUR REALM - {0}",
   "divineascension:ui.civilization.leaderboard.summary": "Your Realm stands {0} among {1}. Greater deeds would see you rise.",
   "divineascension:ui.civilization.leaderboard.summary_none": "You belong to no Realm, and so stand apart from this reckoning.",
   "divineascension:ui.civilization.leaderboard.board.standing": "Standing",


### PR DESCRIPTION
Closes #500. Vertical slice 4 of the Standing of Realms leaderboard (#496) — visual polish + edge cases.

## What changed

- **Heraldic ethos glyphs** per realm via new `EthosGlyphRenderer` (crown / scales / crossed swords / sparkle / sun), mirroring `DomainGlyphRenderer`'s ink-on-vellum primitives. Ethos now rides the packet (`LeaderboardEntry.Ethos`).
- **Proportional score bars** — faint track + gold fill scaled to the board's top score.
- **Deterministic tie-breaking** — older realm (earlier `CreatedDate`) wins equal scores, applied server-side in `BuildBoard`; the fake provider matches.
- **Rows redrawn** — pin gutter, Roman rank, glyph, name on the left; tier label, score bar, score on the right. Viewer row is uppercased, gold, and bracketed with drawn chevrons, kept in its **true ranked position** (honest ranking; the highlight + pins + summary line keep it findable).
- **Adapter seam hooked up** — slice 5's `ILeaderboardProvider` was wired but never bridged into `LeaderboardState`, so the dev fake never rendered. `RequestLeaderboard` now maps the provider's boards into the response packet (`BuildLeaderboardPacket`) and `RefreshLeaderboardFromProvider` seeds it on startup. Release stays on the network path.

## Fixes from local testing

- `▸`/`◂` pins and the `—` em-dash rendered as `?` (not in the ImGui font) — pins now drawn as chevrons, dash replaced with a hyphen.
- Right column on the viewer row was shifted vs. other rows — pin gutter now reserved on every row so columns align.

## Empty / sparse

0 realms → empty-state text; 1 realm → single row renders cleanly; no-realm viewer → "stand apart from this reckoning" summary.

## Testing

- `dotnet build` clean; `dotnet test` — 2353 passing.
- Verified visually in-game (see screenshots in the issue thread): all four boards, glyphs, bars, pinned/highlighted self-row.