### PR TITLE
refactor(civilization): split CivilizationManager into focused collaborators

### DIFF
--- a/DivineAscension/Systems/CivilizationManager.cs
+++ b/DivineAscension/Systems/CivilizationManager.cs
@@ -3,33 +3,31 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using DivineAscension.API.Interfaces;
-using DivineAscension.Constants;
 using DivineAscension.Data;
-using DivineAscension.Models;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
+using DivineAscension.Systems.Civilizations;
 using DivineAscension.Systems.Interfaces;
-using Vintagestory.API.Common;
-using Vintagestory.API.Config;
-using Vintagestory.API.Server;
 
 namespace DivineAscension.Systems;
 
 /// <summary>
-///     Manages civilizations - alliances of 1-4 religions with different deities
+///     Manages civilizations - alliances of 1-4 religions with different deities.
+///     This is a thin facade: it owns the world data and the single lock that
+///     serializes all access, and it raises the public events. The actual work is
+///     delegated to lock-free collaborators in <c>Systems/Civilizations/</c>
+///     (membership lifecycle, capital, chronicle, persistence, queries).
 /// </summary>
 public class CivilizationManager : ICivilizationManager
 {
-    private const string DATA_KEY = "divineascension_civilizations";
-    private const int MIN_RELIGIONS = 1;
-    private const int MAX_RELIGIONS = 4;
-    private const int INVITE_EXPIRY_DAYS = 7;
+    private readonly CivilizationCapitalService _capital;
+    private readonly CivilizationChronicler _chronicler;
     private readonly IEventService _eventService;
     private readonly ILoggerWrapper _logger;
-    private readonly IPersistenceService _persistenceService;
-
+    private readonly CivilizationMembershipService _membership;
+    private readonly CivilizationProfileService _profile;
     private readonly IReligionManager _religionManager;
-    private readonly IWorldService _worldService;
+    private readonly CivilizationStore _store;
     private CivilizationWorldData _data = new();
 
     // Optional dependency wired after construction to break the circular init order
@@ -50,9 +48,15 @@ public class CivilizationManager : ICivilizationManager
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
-        _persistenceService = persistenceService ?? throw new ArgumentNullException(nameof(persistenceService));
-        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+        if (persistenceService == null) throw new ArgumentNullException(nameof(persistenceService));
+        if (worldService == null) throw new ArgumentNullException(nameof(worldService));
         _religionManager = religionManager ?? throw new ArgumentNullException(nameof(religionManager));
+
+        _store = new CivilizationStore(persistenceService, logger);
+        _chronicler = new CivilizationChronicler(worldService);
+        _capital = new CivilizationCapitalService(logger);
+        _profile = new CivilizationProfileService(logger);
+        _membership = new CivilizationMembershipService(logger, religionManager, worldService, _chronicler, _capital);
     }
 
     private object Lock
@@ -90,11 +94,9 @@ public class CivilizationManager : ICivilizationManager
     {
         _logger.Notification("[DivineAscension] Initializing Civilization Manager...");
 
-        // Register event handlers
         _eventService.OnSaveGameLoaded(OnSaveGameLoaded);
         _eventService.OnGameWorldSave(OnGameWorldSave);
 
-        // Subscribe to religion deletion events
         _religionManager.OnReligionDeleted += HandleReligionDeleted;
 
         _logger.Notification("[DivineAscension] Civilization Manager initialized");
@@ -105,7 +107,6 @@ public class CivilizationManager : ICivilizationManager
     /// </summary>
     public void Dispose()
     {
-        // Unsubscribe from events
         _eventService.UnsubscribeSaveGameLoaded(OnSaveGameLoaded);
         _eventService.UnsubscribeGameWorldSave(OnGameWorldSave);
         _religionManager.OnReligionDeleted -= HandleReligionDeleted;
@@ -121,29 +122,10 @@ public class CivilizationManager : ICivilizationManager
     {
         lock (Lock)
         {
-            _data.Civilizations.GetValueOrDefault(civId)?.AddChronicleEntry(BuildChronicleEntry(kind, line, relatedId));
+            var civ = _data.Civilizations.GetValueOrDefault(civId);
+            if (civ != null)
+                _chronicler.Record(civ, kind, line, relatedId);
         }
-    }
-
-    /// <summary>
-    ///     Builds a chronicle entry, capturing the current in-game day. The calendar
-    ///     may be unavailable during early init (or in tests); day 0 is used then.
-    /// </summary>
-    private ChronicleEntry BuildChronicleEntry(ChronicleKind kind, string line, string? relatedId)
-    {
-        var inGameDay = 0;
-        try
-        {
-            var calendar = _worldService.Calendar;
-            if (calendar != null && calendar.HoursPerDay > 0f)
-                inGameDay = (int)(calendar.TotalHours / calendar.HoursPerDay);
-        }
-        catch
-        {
-            inGameDay = 0;
-        }
-
-        return new ChronicleEntry(kind, line, relatedId, DateTime.UtcNow, inGameDay);
     }
 
     /// <summary>
@@ -153,29 +135,46 @@ public class CivilizationManager : ICivilizationManager
     public void SetHolySiteManager(IHolySiteManager holySiteManager)
     {
         _holySiteManager = holySiteManager ?? throw new ArgumentNullException(nameof(holySiteManager));
+        _capital.SetHolySiteManager(holySiteManager);
         _holySiteManager.OnHolySiteRemoved += HandleHolySiteRemoved;
     }
 
     /// <summary>
-    ///     Cascade hook: when a holy site is removed, null the binding on any civ whose
-    ///     capital points at it. Capital name is preserved.
+    ///     Raises the public event for each recorded side-effect. Invoked while the
+    ///     lock is held so subscribers observe the same serialization as before.
     /// </summary>
-    private void HandleHolySiteRemoved(string religionUID, string siteUID)
+    private void FireEvents(IReadOnlyList<CivEvent> events)
     {
-        lock (Lock)
+        foreach (var ev in events)
         {
-            foreach (var civ in _data.Civilizations.Values)
+            switch (ev.Kind)
             {
-                if (civ.CapitalHolySiteId == siteUID)
-                {
-                    civ.CapitalHolySiteId = null;
-                    _logger.Debug($"[DivineAscension] Cleared capital binding on civ '{civ.Name}' — site {siteUID} removed");
-                }
+                case CivEventKind.Disbanded:
+                    OnCivilizationDisbanded?.Invoke(ev.CivId);
+                    break;
+                case CivEventKind.ReligionAdded:
+                    OnReligionAdded?.Invoke(ev.CivId, ev.ReligionId!);
+                    break;
+                case CivEventKind.ReligionRemoved:
+                    OnReligionRemoved?.Invoke(ev.CivId, ev.ReligionId!);
+                    break;
             }
         }
     }
 
     #region Event Handlers
+
+    /// <summary>
+    ///     Cascade hook: when a holy site is removed, clear the binding on any civ
+    ///     whose capital points at it.
+    /// </summary>
+    private void HandleHolySiteRemoved(string religionUID, string siteUID)
+    {
+        lock (Lock)
+        {
+            _capital.HandleHolySiteRemoved(_data, siteUID);
+        }
+    }
 
     /// <summary>
     ///     Handles religion deletion events from ReligionManager
@@ -184,83 +183,8 @@ public class CivilizationManager : ICivilizationManager
     {
         lock (Lock)
         {
-            try
-            {
-                var civ = _data.GetCivilizationByReligion(religionId);
-                if (civ == null)
-                    // Religion wasn't in a civilization, nothing to do
-                    return;
-
-                _logger.Debug(
-                    $"[DivineAscension] Handling deletion of religion {religionId} from civilization {civ.Name}");
-
-                // Check if the deleted religion was the founder's religion
-                var isFounderReligion = civ.FounderReligionUID == religionId;
-                var civIdForEvent = civ.CivId;
-
-                ClearCapitalIfOwnedByReligion(civ, religionId);
-
-                // Remove religion from civilization
-                _data.RemoveReligionFromCivilization(religionId);
-
-                // Fire event for milestone tracking
-                OnReligionRemoved?.Invoke(civIdForEvent, religionId);
-
-                // Update member count (recalculate from remaining religions)
-                var totalMembers = 0;
-                foreach (var relId in civ.GetMemberReligionIdsSnapshot())
-                {
-                    var religion = _religionManager.GetReligion(relId);
-                    if (religion != null) totalMembers += religion.MemberUIDs.Count;
-                }
-
-                civ.MemberCount = totalMembers;
-
-                // Disband if founder's religion was deleted OR if below minimum religions
-                if (isFounderReligion || civ.MemberReligionIds.Count < MIN_RELIGIONS)
-                {
-                    // Use ForceDisband to bypass permission checks (system cleanup)
-                    ForceDisband_Unlocked(civ.CivId);
-                    if (isFounderReligion)
-                        _logger.Notification(
-                            $"[DivineAscension] Civilization '{civ.Name}' disbanded (founder's religion was deleted)");
-                    else
-                        _logger.Notification(
-                            $"[DivineAscension] Civilization '{civ.Name}' disbanded (religion {religionId} was deleted, below minimum)");
-                }
-                else
-                {
-                    _logger.Notification(
-                        $"[DivineAscension] Removed deleted religion {religionId} from civilization '{civ.Name}'");
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error handling religion deletion: {ex.Message}");
-
-                // If disband failed but religion was removed, manually clean up any orphaned civilizations
-                var orphanedCivs = _data.Civilizations.Values
-                    .Where(c => c.MemberReligionIds.Count == 0)
-                    .ToList();
-
-                if (orphanedCivs.Any())
-                {
-                    _logger.Warning(
-                        $"[DivineAscension] Found {orphanedCivs.Count} orphaned civilization(s) after exception, forcing cleanup");
-                    foreach (var orphan in orphanedCivs)
-                    {
-                        try
-                        {
-                            ForceDisband_Unlocked(orphan.CivId);
-                        }
-                        catch (Exception cleanupEx)
-                        {
-                            _logger.Error(
-                                $"[DivineAscension] Failed to cleanup orphaned civilization {orphan.Name}: {cleanupEx.Message}");
-                        }
-                    }
-                }
-            }
+            var events = _membership.HandleReligionDeleted(_data, religionId);
+            FireEvents(events);
         }
     }
 
@@ -268,707 +192,94 @@ public class CivilizationManager : ICivilizationManager
 
     #region Civilization CRUD
 
-    /// <summary>
-    ///     Creates a new civilization
-    /// </summary>
-    /// <param name="name">Name of the civilization</param>
-    /// <param name="founderUID">Player UID of the founder</param>
-    /// <param name="founderReligionId">Religion ID of the founder</param>
-    /// <param name="icon">Optional icon name for the civilization (defaults to "default")</param>
-    /// <param name="description">Optional description for the civilization</param>
-    /// <returns>The created civilization, or null if creation failed</returns>
+    /// <inheritdoc />
     public Civilization? CreateCivilization(string name, string founderUID, string founderReligionId,
         string icon = "default", string description = "", CivilizationEthos? ethosOverride = null)
     {
         lock (Lock)
         {
-            try
-            {
-                // Validate inputs
-                if (string.IsNullOrWhiteSpace(name))
-                {
-                    _logger.Warning("[DivineAscension] Cannot create civilization with empty name");
-                    return null;
-                }
-
-                if (name.Length < 3 || name.Length > 32)
-                {
-                    _logger.Warning("[DivineAscension] Civilization name must be 3-32 characters");
-                    return null;
-                }
-
-                // Validate description length (max 200 characters)
-                if (description.Length > 200)
-                {
-                    _logger.Warning("[DivineAscension] Description must be 200 characters or less");
-                    return null;
-                }
-
-                // Check if name already exists
-                if (_data.Civilizations.Values.Any(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
-                {
-                    _logger.Warning($"[DivineAscension] Civilization name '{name}' already exists");
-                    return null;
-                }
-
-                // Validate founder's religion exists
-                var founderReligion = _religionManager.GetReligion(founderReligionId);
-                if (founderReligion == null)
-                {
-                    _logger.Warning($"[DivineAscension] Founder religion '{founderReligionId}' not found");
-                    return null;
-                }
-
-                // Check if founder is the religion founder
-                if (founderReligion.FounderUID != founderUID)
-                {
-                    _logger.Warning("[DivineAscension] Only religion founders can create civilizations");
-                    return null;
-                }
-
-                // Check if religion is already in a civilization
-                if (_data.GetCivilizationByReligion(founderReligionId) != null)
-                {
-                    _logger.Warning(
-                        $"[DivineAscension] Religion '{founderReligion.ReligionName}' is already in a civilization");
-                    return null;
-                }
-
-                // Create civilization
-                var civId = Guid.NewGuid().ToString();
-                var (derivedEthos, epithetKey) = CivilizationEthosDeriver.Derive(founderReligion.PatronDomain);
-                var civ = new Civilization(civId, name, founderUID, founderReligionId)
-                {
-                    MemberCount = founderReligion.MemberUIDs.Count,
-                    Icon = icon,
-                    Description = description,
-                    Ethos = ethosOverride ?? derivedEthos,
-                    FounderEpithet = LocalizationService.Instance.Get(epithetKey),
-                    CapitalName = $"{name} Seat"
-                };
-
-                _data.AddCivilization(civ);
-
-                var founderName = founderReligion.GetMemberName(founderUID) ?? founderUID;
-                var foundedLine = string.IsNullOrEmpty(civ.FounderEpithet)
-                    ? LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_FOUNDED, civ.Name, founderName)
-                    : LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_FOUNDED_EPITHET, civ.Name,
-                        founderName, civ.FounderEpithet);
-                civ.AddChronicleEntry(BuildChronicleEntry(ChronicleKind.Founded, foundedLine, null));
-
-                _logger.Notification($"[DivineAscension] Civilization '{name}' created by {founderUID}");
-                return civ;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error creating civilization: {ex.Message}");
-                return null;
-            }
+            return _membership.CreateCivilization(_data, name, founderUID, founderReligionId, icon, description,
+                ethosOverride);
         }
     }
 
-    /// <summary>
-    ///     Invites a religion to join a civilization
-    /// </summary>
+    /// <inheritdoc />
     public bool InviteReligion(string civId, string religionId, string inviterUID)
     {
         lock (Lock)
         {
-            try
-            {
-                var civ = _data.Civilizations.GetValueOrDefault(civId);
-                if (civ == null)
-                {
-                    _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
-                    return false;
-                }
-
-                // Check if inviter is the civilization founder
-                if (!civ.IsFounder(inviterUID))
-                {
-                    _logger.Warning("[DivineAscension] Only civilization founder can invite religions");
-                    return false;
-                }
-
-                // Check if civilization is full
-                if (civ.MemberReligionIds.Count >= MAX_RELIGIONS)
-                {
-                    _logger.Warning("[DivineAscension] Civilization is full (max 4 religions)");
-                    return false;
-                }
-
-                // Validate target religion exists
-                var targetReligion = _religionManager.GetReligion(religionId);
-                if (targetReligion == null)
-                {
-                    _logger.Warning($"[DivineAscension] Target religion '{religionId}' not found");
-                    return false;
-                }
-
-                // Check if religion is already a member
-                if (civ.HasReligion(religionId))
-                {
-                    _logger.Warning($"[DivineAscension] Religion '{targetReligion.ReligionName}' is already a member");
-                    return false;
-                }
-
-                // Check if religion is already in another civilization
-                if (_data.GetCivilizationByReligion(religionId) != null)
-                {
-                    _logger.Warning(
-                        $"[DivineAscension] Religion '{targetReligion.ReligionName}' is already in a civilization");
-                    return false;
-                }
-
-                // Check if invite already exists
-                if (_data.HasPendingInvite(civId, religionId))
-                {
-                    _logger.Warning("[DivineAscension] Invite already sent to this religion");
-                    return false;
-                }
-
-                // Check deity diversity (no duplicate deities)
-                var civDeities = GetCivDeityTypes_Unlocked(civId);
-                if (civDeities.Contains(targetReligion.PatronDomain))
-                {
-                    _logger.Warning($"[DivineAscension] Civilization already has a {targetReligion.PatronDomain} religion");
-                    return false;
-                }
-
-                // Create invite
-                var inviteId = Guid.NewGuid().ToString();
-                var invite = new CivilizationInvite(inviteId, civId, religionId, DateTime.UtcNow);
-                _data.AddInvite(invite);
-
-                _logger.Notification(
-                    $"[DivineAscension] Invited religion '{targetReligion.ReligionName}' to civilization '{civ.Name}'");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error inviting religion: {ex.Message}");
-                return false;
-            }
+            return _membership.InviteReligion(_data, civId, religionId, inviterUID);
         }
     }
 
-    /// <summary>
-    ///     Accepts an invitation to join a civilization
-    /// </summary>
+    /// <inheritdoc />
     public bool AcceptInvite(string inviteId, string accepterUID)
     {
         lock (Lock)
         {
-            try
-            {
-                var invite = _data.GetInvite(inviteId);
-                if (invite == null || !invite.IsValid)
-                {
-                    _logger.Warning("[DivineAscension] Invite not found or expired");
-                    return false;
-                }
-
-                var civ = _data.Civilizations.GetValueOrDefault(invite.CivId);
-                if (civ == null)
-                {
-                    _logger.Warning($"[DivineAscension] Civilization '{invite.CivId}' not found");
-                    _data.RemoveInvite(inviteId);
-                    return false;
-                }
-
-                var religion = _religionManager.GetReligion(invite.ReligionId);
-                if (religion == null)
-                {
-                    _logger.Warning($"[DivineAscension] Religion '{invite.ReligionId}' not found");
-                    _data.RemoveInvite(inviteId);
-                    return false;
-                }
-
-                // Check if accepter is the religion founder
-                if (religion.FounderUID != accepterUID)
-                {
-                    _logger.Warning("[DivineAscension] Only religion founder can accept civilization invites");
-                    return false;
-                }
-
-                // Check if civilization still has space
-                if (civ.MemberReligionIds.Count >= MAX_RELIGIONS)
-                {
-                    _logger.Warning("[DivineAscension] Civilization is now full");
-                    _data.RemoveInvite(inviteId);
-                    return false;
-                }
-
-                // Add religion to civilization
-                if (!_data.AddReligionToCivilization(invite.CivId, invite.ReligionId))
-                {
-                    _logger.Error("[DivineAscension] Failed to add religion to civilization");
-                    return false;
-                }
-
-                // Update member count
-                civ.MemberCount += religion.MemberUIDs.Count;
-
-                // Remove invite
-                _data.RemoveInvite(inviteId);
-
-                _logger.Notification(
-                    $"[DivineAscension] Religion '{religion.ReligionName}' joined civilization '{civ.Name}'");
-
-                civ.AddChronicleEntry(BuildChronicleEntry(ChronicleKind.ReligionJoined,
-                    LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_RELIGION_JOINED, religion.ReligionName),
-                    invite.ReligionId));
-
-                // Fire event for milestone tracking
-                OnReligionAdded?.Invoke(civ.CivId, invite.ReligionId);
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error accepting invite: {ex.Message}");
-                return false;
-            }
+            var result = _membership.AcceptInvite(_data, inviteId, accepterUID);
+            FireEvents(result.Events);
+            return result.Success;
         }
     }
 
-    /// <summary>
-    ///     Declines an invitation to join a civilization
-    /// </summary>
+    /// <inheritdoc />
     public bool DeclineInvite(string inviteId, string declinerUID)
     {
         lock (Lock)
         {
-            try
-            {
-                var invite = _data.GetInvite(inviteId);
-                if (invite == null || !invite.IsValid)
-                {
-                    _logger.Warning("[DivineAscension] Invite not found or expired");
-                    return false;
-                }
-
-                var civ = _data.Civilizations.GetValueOrDefault(invite.CivId);
-                if (civ == null)
-                {
-                    _logger.Warning($"[DivineAscension] Civilization '{invite.CivId}' not found");
-                    _data.RemoveInvite(inviteId);
-                    return false;
-                }
-
-                var religion = _religionManager.GetReligion(invite.ReligionId);
-                if (religion == null)
-                {
-                    _logger.Warning($"[DivineAscension] Religion '{invite.ReligionId}' not found");
-                    _data.RemoveInvite(inviteId);
-                    return false;
-                }
-
-                // Check if decliner is the religion founder
-                if (religion.FounderUID != declinerUID)
-                {
-                    _logger.Warning("[DivineAscension] Only religion founder can decline civilization invites");
-                    return false;
-                }
-
-                // Remove invite
-                _data.RemoveInvite(inviteId);
-
-                // Notify online players in the inviting civilization
-                var civReligions = GetCivReligions_Unlocked(civ.CivId);
-                var message = $"[Civilization] {religion.ReligionName} has declined the invitation to join {civ.Name}.";
-
-                foreach (var civReligion in civReligions)
-                {
-                    foreach (var memberUID in civReligion.MemberUIDs)
-                    {
-                        var player = _worldService.GetPlayerByUID(memberUID) as IServerPlayer;
-                        if (player != null)
-                        {
-                            player.SendMessage(
-                                GlobalConstants.GeneralChatGroup,
-                                message,
-                                EnumChatType.Notification
-                            );
-                        }
-                    }
-                }
-
-                _logger.Notification(
-                    $"[DivineAscension] Religion '{religion.ReligionName}' declined invitation to civilization '{civ.Name}'");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error declining invite: {ex.Message}");
-                return false;
-            }
+            return _membership.DeclineInvite(_data, inviteId, declinerUID);
         }
     }
 
-    /// <summary>
-    ///     A religion leaves a civilization voluntarily
-    /// </summary>
+    /// <inheritdoc />
     public bool LeaveReligion(string religionId, string requesterUID)
     {
         lock (Lock)
         {
-            try
-            {
-                // First, determine if the religion is part of any civilization.
-                // Prefer the fast lookup map, but also fall back to scanning in case
-                // the map is out of sync with in-memory test manipulations.
-                var civ = _data.GetCivilizationByReligion(religionId);
-                if (civ == null)
-                    // Fallback scan for robustness in tests or edge cases
-                    civ = _data.Civilizations.Values.FirstOrDefault(c => c.HasReligion(religionId));
-
-                if (civ == null)
-                {
-                    _logger.Warning("[DivineAscension] Religion is not in a civilization");
-                    return false;
-                }
-
-                // Now ensure the religion itself exists
-                var religion = _religionManager.GetReligion(religionId);
-                if (religion == null)
-                {
-                    _logger.Warning($"[DivineAscension] Religion '{religionId}' not found");
-                    return false;
-                }
-
-                // Check if requester is the religion founder
-                if (religion.FounderUID != requesterUID)
-                {
-                    _logger.Warning("[DivineAscension] Only religion founder can leave civilization");
-                    return false;
-                }
-
-                // If this is the civilization founder's religion, disband instead
-                if (civ.IsFounder(requesterUID))
-                {
-                    _logger.Warning("[DivineAscension] Civilization founder must disband, not leave");
-                    return false;
-                }
-
-                // Remove religion from civilization
-                var civIdForEvent = civ.CivId;
-                ClearCapitalIfOwnedByReligion(civ, religionId);
-                _data.RemoveReligionFromCivilization(religionId);
-                civ.MemberCount -= religion.MemberUIDs.Count;
-
-                // Fire event for milestone tracking (before potential disband)
-                OnReligionRemoved?.Invoke(civIdForEvent, religionId);
-
-                civ.AddChronicleEntry(BuildChronicleEntry(ChronicleKind.ReligionLeft,
-                    LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_RELIGION_LEFT, religion.ReligionName),
-                    religionId));
-
-                // Check if civilization falls below minimum
-                if (civ.MemberReligionIds.Count < MIN_RELIGIONS)
-                {
-                    DisbandCivilization_Unlocked(civ.CivId, civ.FounderUID);
-                    _logger.Notification(
-                        $"[DivineAscension] Civilization '{civ.Name}' disbanded (below minimum religions)");
-                }
-                else
-                {
-                    _logger.Notification(
-                        $"[DivineAscension] Religion '{religion.ReligionName}' left civilization '{civ.Name}'");
-                }
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error leaving civilization: {ex.Message}");
-                return false;
-            }
+            var result = _membership.LeaveReligion(_data, religionId, requesterUID);
+            FireEvents(result.Events);
+            return result.Success;
         }
     }
 
-    /// <summary>
-    ///     Kicks a religion from a civilization
-    /// </summary>
+    /// <inheritdoc />
     public bool KickReligion(string civId, string religionId, string kickerUID)
     {
         lock (Lock)
         {
-            try
-            {
-                var civ = _data.Civilizations.GetValueOrDefault(civId);
-                if (civ == null)
-                {
-                    _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
-                    return false;
-                }
-
-                // Check if kicker is the civilization founder
-                if (!civ.IsFounder(kickerUID))
-                {
-                    _logger.Warning("[DivineAscension] Only civilization founder can kick religions");
-                    return false;
-                }
-
-                // Check if religion is a member
-                if (!civ.HasReligion(religionId))
-                {
-                    _logger.Warning("[DivineAscension] Religion is not a member of this civilization");
-                    return false;
-                }
-
-                var religion = _religionManager.GetReligion(religionId);
-                if (religion == null)
-                {
-                    _logger.Warning($"[DivineAscension] Religion '{religionId}' not found");
-                    return false;
-                }
-
-                // Cannot kick own religion
-                var kickerReligion = _religionManager.GetPlayerReligion(kickerUID);
-                if (kickerReligion?.ReligionUID == religionId)
-                {
-                    _logger.Warning("[DivineAscension] Cannot kick your own religion");
-                    return false;
-                }
-
-                // Remove religion from civilization
-                ClearCapitalIfOwnedByReligion(civ, religionId);
-                _data.RemoveReligionFromCivilization(religionId);
-                civ.MemberCount -= religion.MemberUIDs.Count;
-
-                // Fire event for milestone tracking (before potential disband)
-                OnReligionRemoved?.Invoke(civId, religionId);
-
-                civ.AddChronicleEntry(BuildChronicleEntry(ChronicleKind.ReligionLeft,
-                    LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_RELIGION_LEFT, religion.ReligionName),
-                    religionId));
-
-                // Check if civilization falls below minimum
-                if (civ.MemberReligionIds.Count < MIN_RELIGIONS)
-                {
-                    DisbandCivilization_Unlocked(civ.CivId, civ.FounderUID);
-                    _logger.Notification(
-                        $"[DivineAscension] Civilization '{civ.Name}' disbanded (below minimum religions)");
-                }
-                else
-                {
-                    _logger.Notification(
-                        $"[DivineAscension] Religion '{religion.ReligionName}' kicked from civilization '{civ.Name}'");
-                }
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error kicking religion: {ex.Message}");
-                return false;
-            }
+            var result = _membership.KickReligion(_data, civId, religionId, kickerUID);
+            FireEvents(result.Events);
+            return result.Success;
         }
     }
 
-    /// <summary>
-    ///     Disbands a civilization
-    /// </summary>
+    /// <inheritdoc />
     public bool DisbandCivilization(string civId, string requesterUID)
     {
         lock (Lock)
         {
-            return DisbandCivilization_Unlocked(civId, requesterUID);
+            var result = _membership.DisbandCivilization(_data, civId, requesterUID);
+            FireEvents(result.Events);
+            return result.Success;
         }
     }
 
-    /// <summary>
-    ///     Internal unlocked version of DisbandCivilization (caller must hold lock)
-    /// </summary>
-    private bool DisbandCivilization_Unlocked(string civId, string requesterUID)
-    {
-        try
-        {
-            var civ = _data.Civilizations.GetValueOrDefault(civId);
-            if (civ == null)
-            {
-                _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
-                return false;
-            }
-
-            // Check if requester is the civilization founder
-            if (!civ.IsFounder(requesterUID))
-            {
-                _logger.Warning("[DivineAscension] Only civilization founder can disband");
-                return false;
-            }
-
-            // Mark as disbanded
-            civ.DisbandedDate = DateTime.UtcNow;
-
-            civ.AddChronicleEntry(BuildChronicleEntry(ChronicleKind.Disbanded,
-                LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_DISBANDED, civ.Name), null));
-
-            // Remove all pending invites for this civilization
-            _data.PendingInvites.RemoveAll(i => i.CivId == civId);
-
-            // Remove civilization
-            _data.RemoveCivilization(civId);
-
-            // Fire event to notify other systems
-            OnCivilizationDisbanded?.Invoke(civId);
-
-            _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' disbanded by founder");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.Error($"[DivineAscension] Error disbanding civilization: {ex.Message}");
-            return false;
-        }
-    }
-
-    /// <summary>
-    ///     Force-disbands a civilization without permission checks (for system cleanup)
-    ///     Used when a civilization becomes invalid due to religion deletion or data corruption
-    /// </summary>
-    private void ForceDisband(string civId)
-    {
-        lock (Lock)
-        {
-            ForceDisband_Unlocked(civId);
-        }
-    }
-
-    /// <summary>
-    ///     Internal unlocked version of ForceDisband (caller must hold lock)
-    /// </summary>
-    private void ForceDisband_Unlocked(string civId)
-    {
-        try
-        {
-            var civ = _data.Civilizations.GetValueOrDefault(civId);
-            if (civ == null)
-            {
-                _logger.Debug($"[DivineAscension] Civilization '{civId}' not found for forced disband");
-                return;
-            }
-
-            // Mark as disbanded
-            civ.DisbandedDate = DateTime.UtcNow;
-
-            civ.AddChronicleEntry(BuildChronicleEntry(ChronicleKind.Disbanded,
-                LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_DISBANDED, civ.Name), null));
-
-            // Remove all pending invites for this civilization
-            _data.PendingInvites.RemoveAll(i => i.CivId == civId);
-
-            // Remove civilization
-            _data.RemoveCivilization(civId);
-
-            // Fire event to notify other systems (diplomacy cleanup)
-            OnCivilizationDisbanded?.Invoke(civId);
-
-            _logger.Notification(
-                $"[DivineAscension] Civilization '{civ.Name}' forcibly disbanded (invalid state)");
-        }
-        catch (Exception ex)
-        {
-            _logger.Error($"[DivineAscension] Error force-disbanding civilization {civId}: {ex.Message}");
-            // Do not swallow - let it propagate to alert admins
-            throw;
-        }
-    }
-
-    /// <summary>
-    ///     Updates a civilization's icon
-    /// </summary>
-    /// <param name="civId">ID of the civilization</param>
-    /// <param name="requestorUID">Player UID requesting the update</param>
-    /// <param name="icon">New icon name</param>
-    /// <returns>True if successful, false otherwise</returns>
+    /// <inheritdoc />
     public bool UpdateCivilizationIcon(string civId, string requestorUID, string icon)
     {
         lock (Lock)
         {
-            try
-            {
-                var civ = _data.Civilizations.GetValueOrDefault(civId);
-                if (civ == null)
-                {
-                    _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
-                    return false;
-                }
-
-                // Check if requestor is the civilization founder
-                if (!civ.IsFounder(requestorUID))
-                {
-                    _logger.Warning("[DivineAscension] Only civilization founder can update icon");
-                    return false;
-                }
-
-                // Validate icon name (basic validation)
-                if (string.IsNullOrWhiteSpace(icon))
-                {
-                    _logger.Warning("[DivineAscension] Icon name cannot be empty");
-                    return false;
-                }
-
-                // Update icon
-                civ.UpdateIcon(icon);
-
-                _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' icon updated to '{icon}'");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error updating civilization icon: {ex.Message}");
-                return false;
-            }
+            return _profile.UpdateIcon(_data, civId, requestorUID, icon);
         }
     }
 
-    /// <summary>
-    ///     Updates a civilization's description
-    /// </summary>
-    /// <param name="civId">ID of the civilization</param>
-    /// <param name="requestorUID">Player UID requesting the update</param>
-    /// <param name="description">New description text</param>
-    /// <returns>True if successful, false otherwise</returns>
+    /// <inheritdoc />
     public bool UpdateCivilizationDescription(string civId, string requestorUID, string description)
     {
         lock (Lock)
         {
-            try
-            {
-                var civ = _data.Civilizations.GetValueOrDefault(civId);
-                if (civ == null)
-                {
-                    _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
-                    return false;
-                }
-
-                // Check if requestor is the civilization founder
-                if (!civ.IsFounder(requestorUID))
-                {
-                    _logger.Warning("[DivineAscension] Only civilization founder can update description");
-                    return false;
-                }
-
-                // Validate description length (max 200 characters, matching religion pattern)
-                if (description.Length > 200)
-                {
-                    _logger.Warning("[DivineAscension] Description must be 200 characters or less");
-                    return false;
-                }
-
-                // Update description (profanity check is done at command/network handler level)
-                civ.UpdateDescription(description);
-
-                _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' description updated");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error updating civilization description: {ex.Message}");
-                return false;
-            }
+            return _profile.UpdateDescription(_data, civId, requestorUID, description);
         }
     }
 
@@ -977,70 +288,7 @@ public class CivilizationManager : ICivilizationManager
     {
         lock (Lock)
         {
-            try
-            {
-                var civ = _data.Civilizations.GetValueOrDefault(civId);
-                if (civ == null)
-                {
-                    _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
-                    return false;
-                }
-
-                if (!civ.IsFounder(requestorUID))
-                {
-                    _logger.Warning("[DivineAscension] Only civilization founder can set capital");
-                    return false;
-                }
-
-                var trimmed = (capitalName ?? string.Empty).Trim();
-                if (trimmed.Length == 0 || trimmed.Length > 64)
-                {
-                    _logger.Warning("[DivineAscension] Capital name must be 1-64 characters");
-                    return false;
-                }
-
-                if (!string.IsNullOrEmpty(holySiteId))
-                {
-                    var site = _holySiteManager?.GetHolySite(holySiteId);
-                    if (site == null)
-                    {
-                        _logger.Warning($"[DivineAscension] Holy site '{holySiteId}' not found");
-                        return false;
-                    }
-
-                    if (!civ.HasReligion(site.ReligionUID))
-                    {
-                        _logger.Warning("[DivineAscension] Holy site does not belong to a member religion");
-                        return false;
-                    }
-                }
-
-                civ.CapitalName = trimmed;
-                civ.CapitalHolySiteId = string.IsNullOrEmpty(holySiteId) ? null : holySiteId;
-
-                _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' capital set to '{trimmed}'");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Error setting capital: {ex.Message}");
-                return false;
-            }
-        }
-    }
-
-    /// <summary>
-    ///     Cascade: when a religion leaves a civ, if it owned the civ's bound capital
-    ///     site, null the binding. Capital name is preserved. Must be called inside Lock.
-    /// </summary>
-    private void ClearCapitalIfOwnedByReligion(Civilization civ, string religionId)
-    {
-        if (civ.CapitalHolySiteId == null) return;
-        var site = _holySiteManager?.GetHolySite(civ.CapitalHolySiteId);
-        if (site != null && site.ReligionUID == religionId)
-        {
-            civ.CapitalHolySiteId = null;
-            _logger.Debug($"[DivineAscension] Cleared capital binding on civ '{civ.Name}' — religion {religionId} left");
+            return _capital.SetCapital(_data, civId, requestorUID, capitalName, holySiteId);
         }
     }
 
@@ -1048,9 +296,7 @@ public class CivilizationManager : ICivilizationManager
 
     #region Query Methods
 
-    /// <summary>
-    ///     Gets a civilization by ID
-    /// </summary>
+    /// <inheritdoc />
     public Civilization? GetCivilization(string civId)
     {
         lock (Lock)
@@ -1059,9 +305,7 @@ public class CivilizationManager : ICivilizationManager
         }
     }
 
-    /// <summary>
-    ///     Gets the civilization a religion belongs to
-    /// </summary>
+    /// <inheritdoc />
     public Civilization? GetCivilizationByReligion(string religionId)
     {
         lock (Lock)
@@ -1070,9 +314,7 @@ public class CivilizationManager : ICivilizationManager
         }
     }
 
-    /// <summary>
-    ///     Gets the civilization a player belongs to (via their religion)
-    /// </summary>
+    /// <inheritdoc />
     public Civilization? GetCivilizationByPlayer(string playerUID)
     {
         var religion = _religionManager.GetPlayerReligion(playerUID);
@@ -1085,9 +327,7 @@ public class CivilizationManager : ICivilizationManager
         }
     }
 
-    /// <summary>
-    ///     Gets all civilizations (returns a snapshot for safe iteration)
-    /// </summary>
+    /// <inheritdoc />
     public IEnumerable<Civilization> GetAllCivilizations()
     {
         lock (Lock)
@@ -1096,69 +336,25 @@ public class CivilizationManager : ICivilizationManager
         }
     }
 
-    /// <summary>
-    ///     Gets all deity types in a civilization
-    /// </summary>
+    /// <inheritdoc />
     public HashSet<DeityDomain> GetCivDeityTypes(string civId)
     {
         lock (Lock)
         {
-            return GetCivDeityTypes_Unlocked(civId);
+            return CivilizationQueries.GetDeityTypes(_data, _religionManager, civId);
         }
     }
 
-    /// <summary>
-    ///     Internal unlocked version of GetCivDeityTypes (caller must hold lock)
-    /// </summary>
-    private HashSet<DeityDomain> GetCivDeityTypes_Unlocked(string civId)
-    {
-        var civ = _data.Civilizations.GetValueOrDefault(civId);
-        if (civ == null)
-            return new HashSet<DeityDomain>();
-
-        var deities = new HashSet<DeityDomain>();
-        foreach (var religionId in civ.GetMemberReligionIdsSnapshot())
-        {
-            var religion = _religionManager.GetReligion(religionId);
-            if (religion != null) deities.Add(religion.PatronDomain);
-        }
-
-        return deities;
-    }
-
-    /// <summary>
-    ///     Gets all religions in a civilization
-    /// </summary>
+    /// <inheritdoc />
     public List<ReligionData> GetCivReligions(string civId)
     {
         lock (Lock)
         {
-            return GetCivReligions_Unlocked(civId);
+            return CivilizationQueries.GetReligions(_data, _religionManager, civId);
         }
     }
 
-    /// <summary>
-    ///     Internal unlocked version of GetCivReligions (caller must hold lock)
-    /// </summary>
-    private List<ReligionData> GetCivReligions_Unlocked(string civId)
-    {
-        var civ = _data.Civilizations.GetValueOrDefault(civId);
-        if (civ == null)
-            return new List<ReligionData>();
-
-        var religions = new List<ReligionData>();
-        foreach (var religionId in civ.GetMemberReligionIdsSnapshot())
-        {
-            var religion = _religionManager.GetReligion(religionId);
-            if (religion != null) religions.Add(religion);
-        }
-
-        return religions;
-    }
-
-    /// <summary>
-    ///     Gets all pending invites for a religion
-    /// </summary>
+    /// <inheritdoc />
     public List<CivilizationInvite> GetInvitesForReligion(string religionId)
     {
         lock (Lock)
@@ -1167,9 +363,7 @@ public class CivilizationManager : ICivilizationManager
         }
     }
 
-    /// <summary>
-    ///     Gets all pending invites for a civilization
-    /// </summary>
+    /// <inheritdoc />
     public List<CivilizationInvite> GetInvitesForCiv(string civId)
     {
         lock (Lock)
@@ -1178,9 +372,7 @@ public class CivilizationManager : ICivilizationManager
         }
     }
 
-    /// <summary>
-    ///     Updates member counts for all civilizations (should be called when religion membership changes)
-    /// </summary>
+    /// <inheritdoc />
     public void UpdateMemberCounts()
     {
         lock (Lock)
@@ -1205,58 +397,17 @@ public class CivilizationManager : ICivilizationManager
 
     private void OnSaveGameLoaded()
     {
-        LoadCivilizations();
+        lock (Lock)
+        {
+            _data = _store.Load();
+        }
     }
 
     private void OnGameWorldSave()
     {
-        SaveCivilizations();
-    }
-
-    private void LoadCivilizations()
-    {
         lock (Lock)
         {
-            try
-            {
-                var loadedData = _persistenceService.Load<CivilizationWorldData>(DATA_KEY);
-                if (loadedData != null)
-                {
-                    _data = loadedData;
-                    foreach (var civ in _data.Civilizations.Values)
-                    {
-                        if (string.IsNullOrEmpty(civ.CapitalName))
-                            civ.CapitalName = $"{civ.Name} Seat";
-                    }
-                    _logger.Notification($"[DivineAscension] Loaded {_data.Civilizations.Count} civilizations");
-                }
-                else
-                {
-                    _logger.Debug("[DivineAscension] No civilization data found, starting fresh");
-                    _data = new CivilizationWorldData();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Failed to load civilizations: {ex.Message}");
-                _data = new CivilizationWorldData();
-            }
-        }
-    }
-
-    private void SaveCivilizations()
-    {
-        lock (Lock)
-        {
-            try
-            {
-                _persistenceService.Save(DATA_KEY, _data);
-                _logger.Debug($"[DivineAscension] Saved {_data.Civilizations.Count} civilizations");
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"[DivineAscension] Failed to save civilizations: {ex.Message}");
-            }
+            _store.Save(_data);
         }
     }
 

--- a/DivineAscension/Systems/Civilizations/CivilizationCapitalService.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationCapitalService.cs
@@ -1,0 +1,117 @@
+using System;
+using DivineAscension.Data;
+using DivineAscension.Services;
+using DivineAscension.Systems.Interfaces;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     Owns the civilization capital: the founder-set display name plus the optional
+///     binding to a member religion's holy site, and the cascades that null that
+///     binding when the site is removed or its owning religion leaves the civ.
+///     Lock-free — the facade serializes all access.
+/// </summary>
+internal sealed class CivilizationCapitalService
+{
+    private readonly ILoggerWrapper _logger;
+
+    // Wired after construction to break the HolySiteManager <-> CivilizationManager
+    // circular init order. Used only for capital binding validation and cascades.
+    private IHolySiteManager? _holySiteManager;
+
+    public CivilizationCapitalService(ILoggerWrapper logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void SetHolySiteManager(IHolySiteManager holySiteManager)
+    {
+        _holySiteManager = holySiteManager ?? throw new ArgumentNullException(nameof(holySiteManager));
+    }
+
+    public bool SetCapital(CivilizationWorldData data, string civId, string requestorUID, string capitalName,
+        string? holySiteId)
+    {
+        try
+        {
+            var civ = data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
+                return false;
+            }
+
+            if (!civ.IsFounder(requestorUID))
+            {
+                _logger.Warning("[DivineAscension] Only civilization founder can set capital");
+                return false;
+            }
+
+            if (!CivilizationValidator.TryNormalizeCapitalName(capitalName, out var trimmed))
+            {
+                _logger.Warning("[DivineAscension] Capital name must be 1-64 characters");
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(holySiteId))
+            {
+                var site = _holySiteManager?.GetHolySite(holySiteId);
+                if (site == null)
+                {
+                    _logger.Warning($"[DivineAscension] Holy site '{holySiteId}' not found");
+                    return false;
+                }
+
+                if (!civ.HasReligion(site.ReligionUID))
+                {
+                    _logger.Warning("[DivineAscension] Holy site does not belong to a member religion");
+                    return false;
+                }
+            }
+
+            civ.CapitalName = trimmed;
+            civ.CapitalHolySiteId = string.IsNullOrEmpty(holySiteId) ? null : holySiteId;
+
+            _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' capital set to '{trimmed}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error setting capital: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     Cascade: when a religion leaves a civ, if it owned the civ's bound capital
+    ///     site, null the binding. Capital name is preserved.
+    /// </summary>
+    public void ClearCapitalIfOwnedByReligion(Civilization civ, string religionId)
+    {
+        if (civ.CapitalHolySiteId == null) return;
+        var site = _holySiteManager?.GetHolySite(civ.CapitalHolySiteId);
+        if (site != null && site.ReligionUID == religionId)
+        {
+            civ.CapitalHolySiteId = null;
+            _logger.Debug(
+                $"[DivineAscension] Cleared capital binding on civ '{civ.Name}' — religion {religionId} left");
+        }
+    }
+
+    /// <summary>
+    ///     Cascade hook: when a holy site is removed, null the binding on any civ whose
+    ///     capital points at it. Capital name is preserved.
+    /// </summary>
+    public void HandleHolySiteRemoved(CivilizationWorldData data, string siteUID)
+    {
+        foreach (var civ in data.Civilizations.Values)
+        {
+            if (civ.CapitalHolySiteId == siteUID)
+            {
+                civ.CapitalHolySiteId = null;
+                _logger.Debug(
+                    $"[DivineAscension] Cleared capital binding on civ '{civ.Name}' — site {siteUID} removed");
+            }
+        }
+    }
+}

--- a/DivineAscension/Systems/Civilizations/CivilizationCapitalService.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationCapitalService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using DivineAscension.Data;
 using DivineAscension.Services;
 using DivineAscension.Systems.Interfaces;

--- a/DivineAscension/Systems/Civilizations/CivilizationChronicler.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationChronicler.cs
@@ -1,0 +1,82 @@
+using System;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Data;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     Builds and appends chronicle entries for a civilization, owning the in-game
+///     day capture and the localized chronicle-voice wording. Keeps calendar and
+///     localization concerns out of the manager and membership logic.
+/// </summary>
+internal sealed class CivilizationChronicler
+{
+    private readonly IWorldService _worldService;
+
+    public CivilizationChronicler(IWorldService worldService)
+    {
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+    }
+
+    /// <summary>
+    ///     Builds a chronicle entry, capturing the current in-game day. The calendar
+    ///     may be unavailable during early init (or in tests); day 0 is used then.
+    /// </summary>
+    public ChronicleEntry BuildEntry(ChronicleKind kind, string line, string? relatedId)
+    {
+        var inGameDay = 0;
+        try
+        {
+            var calendar = _worldService.Calendar;
+            if (calendar != null && calendar.HoursPerDay > 0f)
+                inGameDay = (int)(calendar.TotalHours / calendar.HoursPerDay);
+        }
+        catch
+        {
+            inGameDay = 0;
+        }
+
+        return new ChronicleEntry(kind, line, relatedId, DateTime.UtcNow, inGameDay);
+    }
+
+    /// <summary>
+    ///     Appends a pre-built chronicle line. Used by collaborating systems that
+    ///     supply their own wording (milestones, diplomacy).
+    /// </summary>
+    public void Record(Civilization civ, ChronicleKind kind, string line, string? relatedId)
+    {
+        civ.AddChronicleEntry(BuildEntry(kind, line, relatedId));
+    }
+
+    public void RecordFounded(Civilization civ, string founderName)
+    {
+        var line = string.IsNullOrEmpty(civ.FounderEpithet)
+            ? LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_FOUNDED, civ.Name, founderName)
+            : LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_FOUNDED_EPITHET, civ.Name,
+                founderName, civ.FounderEpithet);
+        civ.AddChronicleEntry(BuildEntry(ChronicleKind.Founded, line, null));
+    }
+
+    public void RecordReligionJoined(Civilization civ, string religionName, string religionId)
+    {
+        civ.AddChronicleEntry(BuildEntry(ChronicleKind.ReligionJoined,
+            LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_RELIGION_JOINED, religionName),
+            religionId));
+    }
+
+    public void RecordReligionLeft(Civilization civ, string religionName, string religionId)
+    {
+        civ.AddChronicleEntry(BuildEntry(ChronicleKind.ReligionLeft,
+            LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_RELIGION_LEFT, religionName),
+            religionId));
+    }
+
+    public void RecordDisbanded(Civilization civ)
+    {
+        civ.AddChronicleEntry(BuildEntry(ChronicleKind.Disbanded,
+            LocalizationService.Instance.Get(LocalizationKeys.CHRONICLE_DISBANDED, civ.Name), null));
+    }
+}

--- a/DivineAscension/Systems/Civilizations/CivilizationEvents.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationEvents.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     The kinds of side-effect events a civilization mutation can produce.
+///     Collaborators record these; <see cref="CivilizationManager" /> (the facade)
+///     is the sole place that raises the corresponding public events.
+/// </summary>
+internal enum CivEventKind
+{
+    Disbanded,
+    ReligionAdded,
+    ReligionRemoved
+}
+
+/// <summary>
+///     A deferred civilization event. Lock-free collaborators append these to a
+///     result; the facade replays them onto its public event delegates.
+/// </summary>
+internal readonly record struct CivEvent(CivEventKind Kind, string CivId, string? ReligionId)
+{
+    public static CivEvent Disbanded(string civId) => new(CivEventKind.Disbanded, civId, null);
+
+    public static CivEvent ReligionAdded(string civId, string religionId) =>
+        new(CivEventKind.ReligionAdded, civId, religionId);
+
+    public static CivEvent ReligionRemoved(string civId, string religionId) =>
+        new(CivEventKind.ReligionRemoved, civId, religionId);
+}
+
+/// <summary>
+///     Outcome of a membership mutation: whether it succeeded and the ordered list
+///     of events the facade should raise afterwards.
+/// </summary>
+internal readonly struct MembershipResult
+{
+    public MembershipResult(bool success, List<CivEvent> events)
+    {
+        Success = success;
+        Events = events;
+    }
+
+    public bool Success { get; }
+    public List<CivEvent> Events { get; }
+
+    public static MembershipResult Failed() => new(false, new List<CivEvent>());
+    public static MembershipResult Ok(List<CivEvent> events) => new(true, events);
+}

--- a/DivineAscension/Systems/Civilizations/CivilizationMembershipService.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationMembershipService.cs
@@ -1,0 +1,615 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Data;
+using DivineAscension.Models;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems.Interfaces;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     The civilization membership lifecycle: create, invite/accept/decline, leave,
+///     kick, disband and the cascade triggered by religion deletion. Lock-free — the
+///     <see cref="CivilizationManager" /> facade serializes every call and raises the
+///     events recorded in the returned <see cref="MembershipResult" />.
+/// </summary>
+internal sealed class CivilizationMembershipService
+{
+    private readonly CivilizationCapitalService _capital;
+    private readonly CivilizationChronicler _chronicler;
+    private readonly ILoggerWrapper _logger;
+    private readonly IReligionManager _religionManager;
+    private readonly IWorldService _worldService;
+
+    public CivilizationMembershipService(
+        ILoggerWrapper logger,
+        IReligionManager religionManager,
+        IWorldService worldService,
+        CivilizationChronicler chronicler,
+        CivilizationCapitalService capital)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _religionManager = religionManager ?? throw new ArgumentNullException(nameof(religionManager));
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+        _chronicler = chronicler ?? throw new ArgumentNullException(nameof(chronicler));
+        _capital = capital ?? throw new ArgumentNullException(nameof(capital));
+    }
+
+    public Civilization? CreateCivilization(CivilizationWorldData data, string name, string founderUID,
+        string founderReligionId, string icon, string description, CivilizationEthos? ethosOverride)
+    {
+        try
+        {
+            if (!CivilizationValidator.IsNameNonEmpty(name))
+            {
+                _logger.Warning("[DivineAscension] Cannot create civilization with empty name");
+                return null;
+            }
+
+            if (!CivilizationValidator.IsNameLengthValid(name))
+            {
+                _logger.Warning("[DivineAscension] Civilization name must be 3-32 characters");
+                return null;
+            }
+
+            if (!CivilizationValidator.IsDescriptionLengthValid(description))
+            {
+                _logger.Warning("[DivineAscension] Description must be 200 characters or less");
+                return null;
+            }
+
+            if (CivilizationValidator.IsNameTaken(data, name))
+            {
+                _logger.Warning($"[DivineAscension] Civilization name '{name}' already exists");
+                return null;
+            }
+
+            var founderReligion = _religionManager.GetReligion(founderReligionId);
+            if (founderReligion == null)
+            {
+                _logger.Warning($"[DivineAscension] Founder religion '{founderReligionId}' not found");
+                return null;
+            }
+
+            if (founderReligion.FounderUID != founderUID)
+            {
+                _logger.Warning("[DivineAscension] Only religion founders can create civilizations");
+                return null;
+            }
+
+            if (data.GetCivilizationByReligion(founderReligionId) != null)
+            {
+                _logger.Warning(
+                    $"[DivineAscension] Religion '{founderReligion.ReligionName}' is already in a civilization");
+                return null;
+            }
+
+            var civId = Guid.NewGuid().ToString();
+            var (derivedEthos, epithetKey) = CivilizationEthosDeriver.Derive(founderReligion.PatronDomain);
+            var civ = new Civilization(civId, name, founderUID, founderReligionId)
+            {
+                MemberCount = founderReligion.MemberUIDs.Count,
+                Icon = icon,
+                Description = description,
+                Ethos = ethosOverride ?? derivedEthos,
+                FounderEpithet = LocalizationService.Instance.Get(epithetKey),
+                CapitalName = $"{name} Seat"
+            };
+
+            data.AddCivilization(civ);
+
+            var founderName = founderReligion.GetMemberName(founderUID) ?? founderUID;
+            _chronicler.RecordFounded(civ, founderName);
+
+            _logger.Notification($"[DivineAscension] Civilization '{name}' created by {founderUID}");
+            return civ;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error creating civilization: {ex.Message}");
+            return null;
+        }
+    }
+
+    public bool InviteReligion(CivilizationWorldData data, string civId, string religionId, string inviterUID)
+    {
+        try
+        {
+            var civ = data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
+                return false;
+            }
+
+            if (!civ.IsFounder(inviterUID))
+            {
+                _logger.Warning("[DivineAscension] Only civilization founder can invite religions");
+                return false;
+            }
+
+            if (civ.MemberReligionIds.Count >= CivilizationValidator.MaxReligions)
+            {
+                _logger.Warning("[DivineAscension] Civilization is full (max 4 religions)");
+                return false;
+            }
+
+            var targetReligion = _religionManager.GetReligion(religionId);
+            if (targetReligion == null)
+            {
+                _logger.Warning($"[DivineAscension] Target religion '{religionId}' not found");
+                return false;
+            }
+
+            if (civ.HasReligion(religionId))
+            {
+                _logger.Warning($"[DivineAscension] Religion '{targetReligion.ReligionName}' is already a member");
+                return false;
+            }
+
+            if (data.GetCivilizationByReligion(religionId) != null)
+            {
+                _logger.Warning(
+                    $"[DivineAscension] Religion '{targetReligion.ReligionName}' is already in a civilization");
+                return false;
+            }
+
+            if (data.HasPendingInvite(civId, religionId))
+            {
+                _logger.Warning("[DivineAscension] Invite already sent to this religion");
+                return false;
+            }
+
+            var civDeities = CivilizationQueries.GetDeityTypes(data, _religionManager, civId);
+            if (civDeities.Contains(targetReligion.PatronDomain))
+            {
+                _logger.Warning(
+                    $"[DivineAscension] Civilization already has a {targetReligion.PatronDomain} religion");
+                return false;
+            }
+
+            var inviteId = Guid.NewGuid().ToString();
+            var invite = new CivilizationInvite(inviteId, civId, religionId, DateTime.UtcNow);
+            data.AddInvite(invite);
+
+            _logger.Notification(
+                $"[DivineAscension] Invited religion '{targetReligion.ReligionName}' to civilization '{civ.Name}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error inviting religion: {ex.Message}");
+            return false;
+        }
+    }
+
+    public MembershipResult AcceptInvite(CivilizationWorldData data, string inviteId, string accepterUID)
+    {
+        try
+        {
+            var invite = data.GetInvite(inviteId);
+            if (invite == null || !invite.IsValid)
+            {
+                _logger.Warning("[DivineAscension] Invite not found or expired");
+                return MembershipResult.Failed();
+            }
+
+            var civ = data.Civilizations.GetValueOrDefault(invite.CivId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{invite.CivId}' not found");
+                data.RemoveInvite(inviteId);
+                return MembershipResult.Failed();
+            }
+
+            var religion = _religionManager.GetReligion(invite.ReligionId);
+            if (religion == null)
+            {
+                _logger.Warning($"[DivineAscension] Religion '{invite.ReligionId}' not found");
+                data.RemoveInvite(inviteId);
+                return MembershipResult.Failed();
+            }
+
+            if (religion.FounderUID != accepterUID)
+            {
+                _logger.Warning("[DivineAscension] Only religion founder can accept civilization invites");
+                return MembershipResult.Failed();
+            }
+
+            if (civ.MemberReligionIds.Count >= CivilizationValidator.MaxReligions)
+            {
+                _logger.Warning("[DivineAscension] Civilization is now full");
+                data.RemoveInvite(inviteId);
+                return MembershipResult.Failed();
+            }
+
+            if (!data.AddReligionToCivilization(invite.CivId, invite.ReligionId))
+            {
+                _logger.Error("[DivineAscension] Failed to add religion to civilization");
+                return MembershipResult.Failed();
+            }
+
+            civ.MemberCount += religion.MemberUIDs.Count;
+            data.RemoveInvite(inviteId);
+
+            _logger.Notification(
+                $"[DivineAscension] Religion '{religion.ReligionName}' joined civilization '{civ.Name}'");
+
+            _chronicler.RecordReligionJoined(civ, religion.ReligionName, invite.ReligionId);
+
+            var events = new List<CivEvent> { CivEvent.ReligionAdded(civ.CivId, invite.ReligionId) };
+            return MembershipResult.Ok(events);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error accepting invite: {ex.Message}");
+            return MembershipResult.Failed();
+        }
+    }
+
+    public bool DeclineInvite(CivilizationWorldData data, string inviteId, string declinerUID)
+    {
+        try
+        {
+            var invite = data.GetInvite(inviteId);
+            if (invite == null || !invite.IsValid)
+            {
+                _logger.Warning("[DivineAscension] Invite not found or expired");
+                return false;
+            }
+
+            var civ = data.Civilizations.GetValueOrDefault(invite.CivId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{invite.CivId}' not found");
+                data.RemoveInvite(inviteId);
+                return false;
+            }
+
+            var religion = _religionManager.GetReligion(invite.ReligionId);
+            if (religion == null)
+            {
+                _logger.Warning($"[DivineAscension] Religion '{invite.ReligionId}' not found");
+                data.RemoveInvite(inviteId);
+                return false;
+            }
+
+            if (religion.FounderUID != declinerUID)
+            {
+                _logger.Warning("[DivineAscension] Only religion founder can decline civilization invites");
+                return false;
+            }
+
+            data.RemoveInvite(inviteId);
+
+            var civReligions = CivilizationQueries.GetReligions(data, _religionManager, civ.CivId);
+            var message = $"[Civilization] {religion.ReligionName} has declined the invitation to join {civ.Name}.";
+
+            foreach (var civReligion in civReligions)
+            {
+                foreach (var memberUID in civReligion.MemberUIDs)
+                {
+                    var player = _worldService.GetPlayerByUID(memberUID) as IServerPlayer;
+                    if (player != null)
+                    {
+                        player.SendMessage(
+                            GlobalConstants.GeneralChatGroup,
+                            message,
+                            EnumChatType.Notification
+                        );
+                    }
+                }
+            }
+
+            _logger.Notification(
+                $"[DivineAscension] Religion '{religion.ReligionName}' declined invitation to civilization '{civ.Name}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error declining invite: {ex.Message}");
+            return false;
+        }
+    }
+
+    public MembershipResult LeaveReligion(CivilizationWorldData data, string religionId, string requesterUID)
+    {
+        var events = new List<CivEvent>();
+        try
+        {
+            // Prefer the fast lookup map, but fall back to scanning in case the map is
+            // out of sync with in-memory test manipulations.
+            var civ = data.GetCivilizationByReligion(religionId)
+                      ?? data.Civilizations.Values.FirstOrDefault(c => c.HasReligion(religionId));
+
+            if (civ == null)
+            {
+                _logger.Warning("[DivineAscension] Religion is not in a civilization");
+                return MembershipResult.Failed();
+            }
+
+            var religion = _religionManager.GetReligion(religionId);
+            if (religion == null)
+            {
+                _logger.Warning($"[DivineAscension] Religion '{religionId}' not found");
+                return MembershipResult.Failed();
+            }
+
+            if (religion.FounderUID != requesterUID)
+            {
+                _logger.Warning("[DivineAscension] Only religion founder can leave civilization");
+                return MembershipResult.Failed();
+            }
+
+            if (civ.IsFounder(requesterUID))
+            {
+                _logger.Warning("[DivineAscension] Civilization founder must disband, not leave");
+                return MembershipResult.Failed();
+            }
+
+            var civIdForEvent = civ.CivId;
+            _capital.ClearCapitalIfOwnedByReligion(civ, religionId);
+            data.RemoveReligionFromCivilization(religionId);
+            civ.MemberCount -= religion.MemberUIDs.Count;
+
+            events.Add(CivEvent.ReligionRemoved(civIdForEvent, religionId));
+
+            _chronicler.RecordReligionLeft(civ, religion.ReligionName, religionId);
+
+            if (civ.MemberReligionIds.Count < CivilizationValidator.MinReligions)
+            {
+                Disband(data, civ.CivId, civ.FounderUID, events);
+                _logger.Notification(
+                    $"[DivineAscension] Civilization '{civ.Name}' disbanded (below minimum religions)");
+            }
+            else
+            {
+                _logger.Notification(
+                    $"[DivineAscension] Religion '{religion.ReligionName}' left civilization '{civ.Name}'");
+            }
+
+            return MembershipResult.Ok(events);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error leaving civilization: {ex.Message}");
+            return MembershipResult.Failed();
+        }
+    }
+
+    public MembershipResult KickReligion(CivilizationWorldData data, string civId, string religionId, string kickerUID)
+    {
+        var events = new List<CivEvent>();
+        try
+        {
+            var civ = data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
+                return MembershipResult.Failed();
+            }
+
+            if (!civ.IsFounder(kickerUID))
+            {
+                _logger.Warning("[DivineAscension] Only civilization founder can kick religions");
+                return MembershipResult.Failed();
+            }
+
+            if (!civ.HasReligion(religionId))
+            {
+                _logger.Warning("[DivineAscension] Religion is not a member of this civilization");
+                return MembershipResult.Failed();
+            }
+
+            var religion = _religionManager.GetReligion(religionId);
+            if (religion == null)
+            {
+                _logger.Warning($"[DivineAscension] Religion '{religionId}' not found");
+                return MembershipResult.Failed();
+            }
+
+            var kickerReligion = _religionManager.GetPlayerReligion(kickerUID);
+            if (kickerReligion?.ReligionUID == religionId)
+            {
+                _logger.Warning("[DivineAscension] Cannot kick your own religion");
+                return MembershipResult.Failed();
+            }
+
+            _capital.ClearCapitalIfOwnedByReligion(civ, religionId);
+            data.RemoveReligionFromCivilization(religionId);
+            civ.MemberCount -= religion.MemberUIDs.Count;
+
+            events.Add(CivEvent.ReligionRemoved(civId, religionId));
+
+            _chronicler.RecordReligionLeft(civ, religion.ReligionName, religionId);
+
+            if (civ.MemberReligionIds.Count < CivilizationValidator.MinReligions)
+            {
+                Disband(data, civ.CivId, civ.FounderUID, events);
+                _logger.Notification(
+                    $"[DivineAscension] Civilization '{civ.Name}' disbanded (below minimum religions)");
+            }
+            else
+            {
+                _logger.Notification(
+                    $"[DivineAscension] Religion '{religion.ReligionName}' kicked from civilization '{civ.Name}'");
+            }
+
+            return MembershipResult.Ok(events);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error kicking religion: {ex.Message}");
+            return MembershipResult.Failed();
+        }
+    }
+
+    public MembershipResult DisbandCivilization(CivilizationWorldData data, string civId, string requesterUID)
+    {
+        var events = new List<CivEvent>();
+        var success = Disband(data, civId, requesterUID, events);
+        return new MembershipResult(success, events);
+    }
+
+    /// <summary>
+    ///     Disbands a civilization after verifying the requester is its founder.
+    ///     Appends an <see cref="CivEventKind.Disbanded" /> event on success.
+    /// </summary>
+    private bool Disband(CivilizationWorldData data, string civId, string requesterUID, List<CivEvent> events)
+    {
+        try
+        {
+            var civ = data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
+                return false;
+            }
+
+            if (!civ.IsFounder(requesterUID))
+            {
+                _logger.Warning("[DivineAscension] Only civilization founder can disband");
+                return false;
+            }
+
+            civ.DisbandedDate = DateTime.UtcNow;
+            _chronicler.RecordDisbanded(civ);
+
+            data.PendingInvites.RemoveAll(i => i.CivId == civId);
+            data.RemoveCivilization(civId);
+
+            events.Add(CivEvent.Disbanded(civId));
+
+            _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' disbanded by founder");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error disbanding civilization: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     Force-disbands a civilization without permission checks (system cleanup).
+    ///     Rethrows on failure to surface corruption to admins.
+    /// </summary>
+    private void ForceDisband(CivilizationWorldData data, string civId, List<CivEvent> events)
+    {
+        try
+        {
+            var civ = data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null)
+            {
+                _logger.Debug($"[DivineAscension] Civilization '{civId}' not found for forced disband");
+                return;
+            }
+
+            civ.DisbandedDate = DateTime.UtcNow;
+            _chronicler.RecordDisbanded(civ);
+
+            data.PendingInvites.RemoveAll(i => i.CivId == civId);
+            data.RemoveCivilization(civId);
+
+            events.Add(CivEvent.Disbanded(civId));
+
+            _logger.Notification(
+                $"[DivineAscension] Civilization '{civ.Name}' forcibly disbanded (invalid state)");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error force-disbanding civilization {civId}: {ex.Message}");
+            // Do not swallow - let it propagate to alert admins
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///     Cascade triggered by religion deletion: removes the religion from its civ
+    ///     and disbands the civ if it was the founder's religion or drops below the
+    ///     minimum. Returns the ordered events for the facade to raise.
+    /// </summary>
+    public List<CivEvent> HandleReligionDeleted(CivilizationWorldData data, string religionId)
+    {
+        var events = new List<CivEvent>();
+        try
+        {
+            var civ = data.GetCivilizationByReligion(religionId);
+            if (civ == null)
+                // Religion wasn't in a civilization, nothing to do
+                return events;
+
+            _logger.Debug(
+                $"[DivineAscension] Handling deletion of religion {religionId} from civilization {civ.Name}");
+
+            var isFounderReligion = civ.FounderReligionUID == religionId;
+            var civIdForEvent = civ.CivId;
+
+            _capital.ClearCapitalIfOwnedByReligion(civ, religionId);
+
+            data.RemoveReligionFromCivilization(religionId);
+
+            events.Add(CivEvent.ReligionRemoved(civIdForEvent, religionId));
+
+            var totalMembers = 0;
+            foreach (var relId in civ.GetMemberReligionIdsSnapshot())
+            {
+                var religion = _religionManager.GetReligion(relId);
+                if (religion != null) totalMembers += religion.MemberUIDs.Count;
+            }
+
+            civ.MemberCount = totalMembers;
+
+            if (isFounderReligion || civ.MemberReligionIds.Count < CivilizationValidator.MinReligions)
+            {
+                ForceDisband(data, civ.CivId, events);
+                if (isFounderReligion)
+                    _logger.Notification(
+                        $"[DivineAscension] Civilization '{civ.Name}' disbanded (founder's religion was deleted)");
+                else
+                    _logger.Notification(
+                        $"[DivineAscension] Civilization '{civ.Name}' disbanded (religion {religionId} was deleted, below minimum)");
+            }
+            else
+            {
+                _logger.Notification(
+                    $"[DivineAscension] Removed deleted religion {religionId} from civilization '{civ.Name}'");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error handling religion deletion: {ex.Message}");
+
+            // If disband failed but religion was removed, manually clean up orphaned civilizations
+            var orphanedCivs = data.Civilizations.Values
+                .Where(c => c.MemberReligionIds.Count == 0)
+                .ToList();
+
+            if (orphanedCivs.Any())
+            {
+                _logger.Warning(
+                    $"[DivineAscension] Found {orphanedCivs.Count} orphaned civilization(s) after exception, forcing cleanup");
+                foreach (var orphan in orphanedCivs)
+                {
+                    try
+                    {
+                        ForceDisband(data, orphan.CivId, events);
+                    }
+                    catch (Exception cleanupEx)
+                    {
+                        _logger.Error(
+                            $"[DivineAscension] Failed to cleanup orphaned civilization {orphan.Name}: {cleanupEx.Message}");
+                    }
+                }
+            }
+        }
+
+        return events;
+    }
+}

--- a/DivineAscension/Systems/Civilizations/CivilizationProfileService.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationProfileService.cs
@@ -1,0 +1,90 @@
+using System;
+using DivineAscension.Data;
+using DivineAscension.Services;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     Founder-gated edits to a civilization's presentation (icon, description).
+///     Lock-free — the <see cref="CivilizationManager" /> facade serializes access.
+///     Profanity checks for the description happen at the command/network layer.
+/// </summary>
+internal sealed class CivilizationProfileService
+{
+    private readonly ILoggerWrapper _logger;
+
+    public CivilizationProfileService(ILoggerWrapper logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public bool UpdateIcon(CivilizationWorldData data, string civId, string requestorUID, string icon)
+    {
+        try
+        {
+            var civ = data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
+                return false;
+            }
+
+            if (!civ.IsFounder(requestorUID))
+            {
+                _logger.Warning("[DivineAscension] Only civilization founder can update icon");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(icon))
+            {
+                _logger.Warning("[DivineAscension] Icon name cannot be empty");
+                return false;
+            }
+
+            civ.UpdateIcon(icon);
+
+            _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' icon updated to '{icon}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error updating civilization icon: {ex.Message}");
+            return false;
+        }
+    }
+
+    public bool UpdateDescription(CivilizationWorldData data, string civId, string requestorUID, string description)
+    {
+        try
+        {
+            var civ = data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null)
+            {
+                _logger.Warning($"[DivineAscension] Civilization '{civId}' not found");
+                return false;
+            }
+
+            if (!civ.IsFounder(requestorUID))
+            {
+                _logger.Warning("[DivineAscension] Only civilization founder can update description");
+                return false;
+            }
+
+            if (!CivilizationValidator.IsDescriptionLengthValid(description))
+            {
+                _logger.Warning("[DivineAscension] Description must be 200 characters or less");
+                return false;
+            }
+
+            civ.UpdateDescription(description);
+
+            _logger.Notification($"[DivineAscension] Civilization '{civ.Name}' description updated");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Error updating civilization description: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/DivineAscension/Systems/Civilizations/CivilizationProfileService.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationProfileService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using DivineAscension.Data;
 using DivineAscension.Services;
 

--- a/DivineAscension/Systems/Civilizations/CivilizationQueries.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationQueries.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using DivineAscension.Data;
+using DivineAscension.Models.Enum;
+using DivineAscension.Systems.Interfaces;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     Lock-free read helpers over <see cref="CivilizationWorldData" />. Shared by
+///     the facade's query methods and the membership service so the previous
+///     "_Unlocked" method pairs are no longer needed — the facade owns the lock.
+/// </summary>
+internal static class CivilizationQueries
+{
+    public static HashSet<DeityDomain> GetDeityTypes(CivilizationWorldData data,
+        IReligionManager religionManager, string civId)
+    {
+        var civ = data.Civilizations.GetValueOrDefault(civId);
+        if (civ == null)
+            return new HashSet<DeityDomain>();
+
+        var deities = new HashSet<DeityDomain>();
+        foreach (var religionId in civ.GetMemberReligionIdsSnapshot())
+        {
+            var religion = religionManager.GetReligion(religionId);
+            if (religion != null) deities.Add(religion.PatronDomain);
+        }
+
+        return deities;
+    }
+
+    public static List<ReligionData> GetReligions(CivilizationWorldData data,
+        IReligionManager religionManager, string civId)
+    {
+        var civ = data.Civilizations.GetValueOrDefault(civId);
+        if (civ == null)
+            return new List<ReligionData>();
+
+        var religions = new List<ReligionData>();
+        foreach (var religionId in civ.GetMemberReligionIdsSnapshot())
+        {
+            var religion = religionManager.GetReligion(religionId);
+            if (religion != null) religions.Add(religion);
+        }
+
+        return religions;
+    }
+}

--- a/DivineAscension/Systems/Civilizations/CivilizationStore.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationStore.cs
@@ -1,0 +1,67 @@
+using System;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Data;
+using DivineAscension.Services;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     Persistence boundary for civilization world data. Owns the save key and the
+///     legacy capital-name backfill performed on load.
+/// </summary>
+internal sealed class CivilizationStore
+{
+    private const string DATA_KEY = "divineascension_civilizations";
+    private readonly ILoggerWrapper _logger;
+    private readonly IPersistenceService _persistenceService;
+
+    public CivilizationStore(IPersistenceService persistenceService, ILoggerWrapper logger)
+    {
+        _persistenceService = persistenceService ?? throw new ArgumentNullException(nameof(persistenceService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    ///     Loads persisted data, repairing legacy saves with empty capital names.
+    ///     Never throws — returns a fresh container on any failure.
+    /// </summary>
+    public CivilizationWorldData Load()
+    {
+        try
+        {
+            var loadedData = _persistenceService.Load<CivilizationWorldData>(DATA_KEY);
+            if (loadedData != null)
+            {
+                foreach (var civ in loadedData.Civilizations.Values)
+                {
+                    if (string.IsNullOrEmpty(civ.CapitalName))
+                        civ.CapitalName = $"{civ.Name} Seat";
+                }
+
+                _logger.Notification($"[DivineAscension] Loaded {loadedData.Civilizations.Count} civilizations");
+                return loadedData;
+            }
+
+            _logger.Debug("[DivineAscension] No civilization data found, starting fresh");
+            return new CivilizationWorldData();
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Failed to load civilizations: {ex.Message}");
+            return new CivilizationWorldData();
+        }
+    }
+
+    public void Save(CivilizationWorldData data)
+    {
+        try
+        {
+            _persistenceService.Save(DATA_KEY, data);
+            _logger.Debug($"[DivineAscension] Saved {data.Civilizations.Count} civilizations");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Failed to save civilizations: {ex.Message}");
+        }
+    }
+}

--- a/DivineAscension/Systems/Civilizations/CivilizationValidator.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationValidator.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using DivineAscension.Data;
+
+namespace DivineAscension.Systems.Civilizations;
+
+/// <summary>
+///     Pure, lock-free validation rules for civilizations. No side effects and no
+///     logging — callers decide what to log on failure, preserving their messages.
+/// </summary>
+internal static class CivilizationValidator
+{
+    public const int MinReligions = 1;
+    public const int MaxReligions = 4;
+    public const int MaxDescriptionLength = 200;
+    public const int MinCapitalNameLength = 1;
+    public const int MaxCapitalNameLength = 64;
+
+    public static bool IsNameNonEmpty(string name) => !string.IsNullOrWhiteSpace(name);
+
+    public static bool IsNameLengthValid(string name) => name.Length >= 3 && name.Length <= 32;
+
+    public static bool IsDescriptionLengthValid(string description) =>
+        description.Length <= MaxDescriptionLength;
+
+    public static bool IsNameTaken(CivilizationWorldData data, string name) =>
+        data.Civilizations.Values.Any(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    ///     Trims the candidate capital name and reports whether it falls within the
+    ///     allowed 1-64 character range.
+    /// </summary>
+    public static bool TryNormalizeCapitalName(string? capitalName, out string trimmed)
+    {
+        trimmed = (capitalName ?? string.Empty).Trim();
+        return trimmed.Length >= MinCapitalNameLength && trimmed.Length <= MaxCapitalNameLength;
+    }
+}


### PR DESCRIPTION
Decompose the 1263-line CivilizationManager god class into a thin facade
over lock-free collaborators in Systems/Civilizations/. The facade owns the
world data and the single serializing lock and raises the public events;
all logic moves out:

- CivilizationMembershipService: create/invite/accept/decline/leave/kick/
  disband and the religion-deletion cascade
- CivilizationCapitalService: capital name/holy-site binding + cascades
- CivilizationProfileService: founder-gated icon/description edits
- CivilizationChronicler: chronicle entry building, in-game-day capture,
  localized wording
- CivilizationStore: persistence + legacy capital-name backfill
- CivilizationValidator / CivilizationQueries: pure rules and read helpers

Collaborators return recorded events; the facade replays them onto its
public delegates, eliminating the duplicated "_Unlocked" method pairs. The
ICivilizationManager surface and all behavior/log messages are unchanged.

https://claude.ai/code/session_01Q3vtqrGg2D2BgfC39dWcF5