### PR TITLE
feat(ui): show in-game calendar dates in the religion chronicle (#373)

### DIFF
--- a/DivineAscension.Tests/Systems/ReligionChronicleTests.cs
+++ b/DivineAscension.Tests/Systems/ReligionChronicleTests.cs
@@ -117,7 +117,7 @@ public class ReligionChronicleTests
         religion.AddChronicleEntry(new ChronicleEntry(ChronicleKind.Founded, "Founded.", null,
             new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), 3));
         religion.AddChronicleEntry(new ChronicleEntry(ChronicleKind.FirstHolySite, "Consecrated.", "site-2",
-            new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc), 7));
+            new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc), 7, year: 1387, month: 3, dayOfMonth: 12));
 
         using var ms = new MemoryStream();
         Serializer.Serialize(ms, religion);
@@ -129,6 +129,10 @@ public class ReligionChronicleTests
         Assert.Equal("Consecrated.", restored.Chronicle[1].Line);
         Assert.Equal("site-2", restored.Chronicle[1].RelatedId);
         Assert.Equal(7, restored.Chronicle[1].InGameDay);
+        // Calendar date persists across the round-trip.
+        Assert.Equal(1387, restored.Chronicle[1].Year);
+        Assert.Equal(3, restored.Chronicle[1].Month);
+        Assert.Equal(12, restored.Chronicle[1].DayOfMonth);
     }
 
     [Fact]

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionChronicleRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionChronicleRenderer.cs
@@ -186,9 +186,9 @@ internal static class ReligionChronicleRenderer
 
     private static string ComposeLine(PlayerReligionInfoResponsePacket.ChronicleEntryDto entry)
     {
-        var day = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INFO_CHRONICLE_DAY,
-            entry.InGameDay);
-        return $"{day} · {entry.Line}";
+        var date = ChronicleDateFormatter.Format(entry.Year, entry.Month, entry.DayOfMonth, entry.InGameDay,
+            LocalizationKeys.UI_RELIGION_INFO_CHRONICLE_DAY);
+        return $"{date} · {entry.Line}";
     }
 
     private static void DrawCentered(ImDrawListPtr drawList, string text, float x, float y, float width, float height)

--- a/DivineAscension/Network/PlayerReligionInfoResponsePacket.cs
+++ b/DivineAscension/Network/PlayerReligionInfoResponsePacket.cs
@@ -76,6 +76,15 @@ public class PlayerReligionInfoResponsePacket
 
         /// <summary>The chronicle voice line, already resolved server-side.</summary>
         [ProtoMember(3)] public string Line { get; set; } = string.Empty;
+
+        /// <summary>In-game calendar year; 0 for pre-capture entries (fall back to "Day N").</summary>
+        [ProtoMember(4)] public int Year { get; set; }
+
+        /// <summary>In-game month (1..12); 0 when unknown.</summary>
+        [ProtoMember(5)] public int Month { get; set; }
+
+        /// <summary>In-game day of month (1-based); 0 when unknown.</summary>
+        [ProtoMember(6)] public int DayOfMonth { get; set; }
     }
 
     [ProtoContract]

--- a/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
@@ -146,7 +146,10 @@ public class ReligionNetworkHandler : IServerNetworkHandler
                 {
                     InGameDay = e.InGameDay,
                     Kind = (int)e.Kind,
-                    Line = e.Line
+                    Line = e.Line,
+                    Year = e.Year,
+                    Month = e.Month,
+                    DayOfMonth = e.DayOfMonth
                 })
                 .ToList();
 

--- a/DivineAscension/Systems/ReligionChronicler.cs
+++ b/DivineAscension/Systems/ReligionChronicler.cs
@@ -30,18 +30,27 @@ internal sealed class ReligionChronicler
     public ChronicleEntry BuildEntry(ChronicleKind kind, string line, string? relatedId)
     {
         var inGameDay = 0;
+        var year = 0;
+        var month = 0;
+        var dayOfMonth = 0;
         try
         {
             var calendar = _worldService.Calendar;
             if (calendar != null && calendar.HoursPerDay > 0f)
+            {
                 inGameDay = (int)(calendar.TotalHours / calendar.HoursPerDay);
+                year = calendar.Year;
+                month = calendar.Month;
+                if (calendar.DaysPerMonth > 0)
+                    dayOfMonth = calendar.DayOfYear % calendar.DaysPerMonth + 1;
+            }
         }
         catch
         {
             inGameDay = 0;
         }
 
-        return new ChronicleEntry(kind, line, relatedId, DateTime.UtcNow, inGameDay);
+        return new ChronicleEntry(kind, line, relatedId, DateTime.UtcNow, inGameDay, year, month, dayOfMonth);
     }
 
     public void RecordFounded(ReligionData religion)


### PR DESCRIPTION
## Summary
Brings the **religion** chronicle to parity with the civ chronicle (#369, merged), which already renders dates like "the 3rd of January, Year 1387". The religion chronicle still showed "Day N".

The shared infrastructure — `ChronicleEntry` year/month/day fields, `ChronicleDateFormatter`, the `UI_CALENDAR_*` keys and 12 month names — already landed on master via #527. This PR only wires the religion side.

## Changes
- `ReligionChronicler.BuildEntry` — capture `Year`, `Month`, `DayOfMonth` from `IGameCalendar`.
- `PlayerReligionInfoResponsePacket.ChronicleEntryDto` + `ReligionNetworkHandler` — carry the fields to the client.
- `ReligionChronicleRenderer.ComposeLine` — format via `ChronicleDateFormatter`; pre-capture entries (year 0) fall back to "Day N".
- Test: religion chronicle calendar date round-trips through ProtoBuf.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug`
- [x] `dotnet test` — 2370 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)