### PR TITLE
fix(ui): don't treat chronicle year 0 as uncaptured (#373)

### DIFF
--- a/DivineAscension/GUI/UI/Utilities/ChronicleDateFormatter.cs
+++ b/DivineAscension/GUI/UI/Utilities/ChronicleDateFormatter.cs
@@ -18,7 +18,10 @@ public static class ChronicleDateFormatter
     public static string Format(int year, int month, int dayOfMonth, int inGameDay, string dayFallbackKey)
     {
         var loc = LocalizationService.Instance;
-        if (year <= 0 || month is < 1 or > 12 || dayOfMonth < 1)
+        // Month is the capture sentinel: valid months are 1..12, so 0 means the entry
+        // predates calendar capture. Year is NOT a sentinel — year 0 is a valid first
+        // year in some world configs and must still render.
+        if (month is < 1 or > 12 || dayOfMonth < 1)
             return loc.Get(dayFallbackKey, inGameDay);
 
         var monthName = loc.Get(LocalizationKeys.CalendarMonth(month));


### PR DESCRIPTION
## Summary
`ChronicleDateFormatter.Format` used `year <= 0` as the sentinel for "this entry predates calendar capture, fall back to Day N". But **year 0 is a valid first year** in some world configs, so a freshly-written chronicle entry in such a world fell back to "Day N" instead of showing its calendar date.

Fix: use `Month` as the sole capture sentinel. Valid months are 1–12, so `Month == 0` unambiguously means "not captured" (pre-capture entries default year/month/day all to 0). `Year` is no longer gated and renders correctly even when 0.

## Impact
- Worlds whose calendar starts at year 0: newly-recorded chronicle entries now show "the Nth of <Month>, Year 0" instead of "Day N".
- Pre-capture entries (Month 0) still correctly fall back to "Day N".

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug`
- [x] `dotnet test` — 2370 passed
- [ ] In a year-0 world: found an order, confirm the Founded entry shows a calendar date

🤖 Generated with [Claude Code](https://claude.com/claude-code)