### PR TITLE
fix(ui): capitalize the chronicle date prefix (#373)

### DIFF
--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -495,7 +495,7 @@
   "divineascension:ui.civilization.chronicle.intro": "The lasting deeds of the realm, set down deed by deed as they came to pass.",
   "divineascension:ui.civilization.chronicle.empty": "No deeds have yet been chronicled for this realm.",
   "divineascension:ui.civilization.chronicle.footer.closing": "Here the chronicle rests, awaiting deeds yet to come.",
-  "divineascension:ui.calendar.chronicle.date": "the {0} of {1}, Year {2}",
+  "divineascension:ui.calendar.chronicle.date": "The {0} of {1}, Year {2}",
   "divineascension:ui.calendar.month.1": "January",
   "divineascension:ui.calendar.month.2": "February",
   "divineascension:ui.calendar.month.3": "March",


### PR DESCRIPTION
The chronicle date label opens each line ("the 1st of July, Year 0 · Thus was..."), so it should be capitalized. Changes the shared `ui.calendar.chronicle.date` template from "the {0} of..." to "The {0} of...". Used by both the religion and civ chronicles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)