### PR TITLE
feat(blessings): implement cropYield and seedDropChance via BlockBehaviorBlessedCrop

### DIFF
--- a/DivineAscension/Blocks/BlockBehaviorBlessedCrop.cs
+++ b/DivineAscension/Blocks/BlockBehaviorBlessedCrop.cs
@@ -1,0 +1,50 @@
+using System;
+using DivineAscension.Constants;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+
+namespace DivineAscension.Blocks;
+
+/// <summary>
+/// Applies Aethra harvest blessings to vanilla crop drops.
+/// Attached to game:crop-* via JSON patch.
+/// </summary>
+public class BlockBehaviorBlessedCrop : BlockBehavior
+{
+    public BlockBehaviorBlessedCrop(Block block) : base(block) { }
+
+    public override ItemStack[] GetDrops(
+        IWorldAccessor world,
+        BlockPos pos,
+        IPlayer byPlayer,
+        ref float dropChanceMultiplier,
+        ref EnumHandling handling)
+    {
+        if (world.Side != EnumAppSide.Server || byPlayer?.Entity?.Stats == null)
+            return base.GetDrops(world, pos, byPlayer, ref dropChanceMultiplier, ref handling);
+
+        var yield = byPlayer.Entity.Stats.GetBlended(VintageStoryStats.CropYield);
+        if (yield > 1.0f)
+            dropChanceMultiplier *= yield;
+
+        var drops = base.GetDrops(world, pos, byPlayer, ref dropChanceMultiplier, ref handling);
+
+        var seedChance = byPlayer.Entity.Stats.GetBlended(VintageStoryStats.SeedDropChance);
+        if (drops == null || seedChance <= 0f || world.Rand.NextDouble() >= seedChance)
+            return drops!;
+
+        for (var i = 0; i < drops.Length; i++)
+        {
+            var path = drops[i]?.Collectible?.Code?.Path;
+            if (path == null || !path.StartsWith("seeds-", StringComparison.Ordinal)) continue;
+
+            var bonus = drops[i].Clone();
+            bonus.StackSize = 1;
+            Array.Resize(ref drops, drops.Length + 1);
+            drops[^1] = bonus;
+            break;
+        }
+
+        return drops;
+    }
+}

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -110,6 +110,7 @@ public class DivineAscensionModSystem : ModSystem
         api.RegisterBlockBehaviorClass("DivineAscensionLectern", typeof(BlockBehaviorLectern));
         api.RegisterBlockBehaviorClass("DivineAscensionStone", typeof(BlockBehaviorStone));
         api.RegisterBlockBehaviorClass("DivineAscensionOre", typeof(BlockBehaviorOre));
+        api.RegisterBlockBehaviorClass("DivineAscensionBlessedCrop", typeof(BlockBehaviorBlessedCrop));
         api.RegisterCollectibleBehaviorClass("ChiselTracking", typeof(CollectibleBehaviorChiselTracking));
         api.Logger.Notification("[DivineAscension] Block and Collectible behavior classes registered");
 

--- a/DivineAscension/assets/divineascension/patches/crop.json
+++ b/DivineAscension/assets/divineascension/patches/crop.json
@@ -1,0 +1,21 @@
+[
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/amaranth.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/cabbage.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/carrot.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/cassava.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/fennel.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/flax.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/licorice.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/onion.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/parsnip.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/peanut.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/pineapple.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/rice.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/rye.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/soybean.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/spelt.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/sunflower.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/turnip.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/pumpkin/motherplant.json", "side": "Server" },
+  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/pumpkin/fruit.json", "side": "Server" }
+]


### PR DESCRIPTION
## Summary
- New `BlockBehaviorBlessedCrop` (pattern mirrors `BlockBehaviorStone` — direct stat read, no emitter).
- Overrides `GetDrops` to scale `dropChanceMultiplier` by the player's `cropYield` blend, then rolls `seedDropChance` to append a single bonus `seeds-*` stack.
- Registered as `"DivineAscensionBlessedCrop"` in `ModSystem.Start`.
- Patched onto vanilla crops via `assets/divineascension/patches/crop.json`:
  - 17 crop files in `plant/crop/`: amaranth, cabbage, carrot, cassava, fennel, flax, licorice, onion, parsnip, peanut, pineapple, rice, rye, soybean, spelt, sunflower, turnip.
  - Plus `plant/pumpkin/motherplant.json` and `plant/pumpkin/fruit.json`.
  - Skipped: `dead.json` (no drops) and `pumpkin/vine.json` (no behaviors array, no relevant drops).

Slice **H1** of the Harvest plan in https://github.com/Quantumheart/DivineAscension/issues/214#issuecomment-4564182097. Depends on #536 only in spirit (both touch the same audit), but no code overlap.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` — clean
- [x] `dotnet test` — 2376 passing
- [x] In-game: equip Aethra blessing with `cropYield` and harvest a mature carrot; confirm increased drops.
- [x] In-game: equip a blessing with `seedDropChance` and harvest crops; confirm occasional bonus seed.
- [x] Confirm no patch warnings at startup for any of the 19 target files.

## Notes
- No tests added — `BlockBehavior` overrides are awkward to mock; the un-tested `BlockBehaviorStone` is the established precedent.
- Wild crops (berries, wildvine) and modded crops are not covered — intentional, those are out of scope for `cropYield`.