### PR TITLE
feat(civ): Founding Day annual holiday

### DIFF
--- a/DivineAscension.Tests/Systems/CivilizationFoundingDayTests.cs
+++ b/DivineAscension.Tests/Systems/CivilizationFoundingDayTests.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Data;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Tests.Helpers;
+using Moq;
+
+namespace DivineAscension.Tests.Systems;
+
+/// <summary>
+///     Tests for the civilization annual Founding Day holiday. The full
+///     ticker pipeline is integration-level (needs an IGameCalendar fake),
+///     so these cover the load-bearing data + manager pieces: founding
+///     date capture, first-year suppression stamp, and the idempotency
+///     accessor used by the ticker.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class CivilizationFoundingDayTests
+{
+    private readonly CivilizationManager _civ;
+    private readonly Mock<IReligionManager> _religions = new();
+    private readonly Mock<ILoggerWrapper> _logger = new();
+    private readonly FakeEventService _events = new();
+    private readonly FakePersistenceService _persistence = new();
+    private readonly FakeWorldService _world = new();
+
+    public CivilizationFoundingDayTests()
+    {
+        _civ = new CivilizationManager(_logger.Object, _events, _persistence, _world, _religions.Object);
+    }
+
+    private Civilization CreateCiv(string founderUid = "founder", string religionId = "religion")
+    {
+        var religion = TestFixtures.CreateTestReligion(religionId, "R", DeityDomain.Craft, "D", founderUid);
+        _religions.Setup(r => r.GetReligion(religionId)).Returns(religion);
+        return _civ.CreateCivilization("Test Realm", founderUid, religionId)!;
+    }
+
+    [Fact]
+    public void CreateCivilization_WithoutCalendar_LeavesFoundingDateUncaptured()
+    {
+        // FakeWorldService throws on Calendar when unset — the membership
+        // service must swallow that and leave FoundingMonth/Day at 0 so the
+        // ticker simply skips this civ.
+        var civ = CreateCiv();
+
+        Assert.Equal(0, civ.FoundingMonth);
+        Assert.Equal(0, civ.FoundingDay);
+    }
+
+    [Fact]
+    public void TryMarkFoundingDayFired_FiresOncePerYear()
+    {
+        var civ = CreateCiv();
+        // Simulate a captured date + clean stamp so the first call succeeds.
+        civ.FoundingMonth = 3;
+        civ.FoundingDay = 7;
+        civ.FoundingDayLastFiredYear = 0;
+
+        Assert.True(_civ.TryMarkFoundingDayFired(civ.CivId, 1387));
+        Assert.False(_civ.TryMarkFoundingDayFired(civ.CivId, 1387));
+        Assert.True(_civ.TryMarkFoundingDayFired(civ.CivId, 1388));
+    }
+
+    [Fact]
+    public void TryMarkFoundingDayFired_RespectsFirstYearSuppressionStamp()
+    {
+        // A civ founded in year Y has FoundingDayLastFiredYear stamped to Y,
+        // so any attempt to fire in Y must be rejected.
+        var civ = CreateCiv();
+        civ.FoundingDayLastFiredYear = 1387;
+
+        Assert.False(_civ.TryMarkFoundingDayFired(civ.CivId, 1387));
+        Assert.True(_civ.TryMarkFoundingDayFired(civ.CivId, 1388));
+    }
+
+    [Fact]
+    public void TryMarkFoundingDayFired_UnknownCiv_ReturnsFalse()
+    {
+        Assert.False(_civ.TryMarkFoundingDayFired("nonexistent-civ", 1387));
+    }
+}

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -833,6 +833,10 @@ public static class LocalizationKeys
     public const string CHRONICLE_ALLIANCE_FORMED = "divineascension:chronicle.alliance_formed";
     public const string CHRONICLE_DISBANDED = "divineascension:chronicle.disbanded";
 
+    // Civ Founding Day annual holiday
+    public const string CIV_FOUNDING_DAY_CHRONICLE = "divineascension:civ.foundingday.chronicle";
+    public const string CIV_FOUNDING_DAY_BROADCAST = "divineascension:civ.foundingday.broadcast";
+
     // Religion chronicle (#373)
     public const string UI_RELIGION_INFO_CHRONICLE_HEADING =
         "divineascension:ui.religion.info.chronicle.heading";

--- a/DivineAscension/Data/CivilizationData.cs
+++ b/DivineAscension/Data/CivilizationData.cs
@@ -151,6 +151,27 @@ public class Civilization
     public int WarKillCount { get; set; } = 0;
 
     /// <summary>
+    ///     In-game month captured at civ creation; drives the annual
+    ///     Founding Day holiday. 0 for pre-feature civilizations (no migration).
+    /// </summary>
+    [ProtoMember(20)]
+    public int FoundingMonth { get; set; }
+
+    /// <summary>In-game day-of-month captured at civ creation.</summary>
+    [ProtoMember(21)]
+    public int FoundingDay { get; set; }
+
+    /// <summary>
+    ///     Last in-game year the Founding Day fired. The ticker only fires
+    ///     when <c>calendar.Year &gt; FoundingDayLastFiredYear</c>, which
+    ///     makes the day-rollover idempotent across save/reload. Stamped to
+    ///     the founding year at creation so the first-year "anniversary on
+    ///     the day of founding" doesn't fire.
+    /// </summary>
+    [ProtoMember(22)]
+    public int FoundingDayLastFiredYear { get; set; }
+
+    /// <summary>
     ///     Civilization-wide blessings unlocked via milestones
     /// </summary>
     [ProtoMember(14)]

--- a/DivineAscension/Systems/CivilizationCalendarTicker.cs
+++ b/DivineAscension/Systems/CivilizationCalendarTicker.cs
@@ -1,0 +1,77 @@
+using System;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Services;
+
+namespace DivineAscension.Systems;
+
+/// <summary>
+///     Polls the in-game calendar each minute, firing a chronicle entry and
+///     member broadcast for each civilization's annual Founding Day.
+///     Idempotency stamp lives on the civ itself
+///     (<c>Civilization.FoundingDayLastFiredYear</c>) and persists in the
+///     save, so reload on the same day does not re-fire. Mirrors the
+///     religion <c>ReligionCalendarTicker</c>; per the design discussion,
+///     civilizations have a single auto holiday and no custom calendar.
+/// </summary>
+public sealed class CivilizationCalendarTicker
+{
+    private const int TickIntervalMs = 60_000;
+
+    private readonly IEventService _eventService;
+    private readonly ILoggerWrapper _logger;
+    private readonly IPlayerMessengerService _messengerService;
+    private readonly CivilizationManager _civilizationManager;
+    private readonly IWorldService _worldService;
+
+    public CivilizationCalendarTicker(
+        ILoggerWrapper logger,
+        IEventService eventService,
+        IWorldService worldService,
+        CivilizationManager civilizationManager,
+        IPlayerMessengerService messengerService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+        _civilizationManager = civilizationManager ?? throw new ArgumentNullException(nameof(civilizationManager));
+        _messengerService = messengerService ?? throw new ArgumentNullException(nameof(messengerService));
+    }
+
+    public void Initialize()
+    {
+        _eventService.RegisterGameTickListener(OnTick, TickIntervalMs);
+        _logger.Notification("[DivineAscension] CivilizationCalendarTicker initialized");
+    }
+
+    /// <summary>Internal so tests can drive the tick deterministically.</summary>
+    internal void OnTick(float _)
+    {
+        var (month, day) = SacredCalendar.GetCurrentMonthDay(_worldService);
+        var year = SacredCalendar.GetCurrentYear(_worldService);
+        if (month <= 0 || day <= 0 || year <= 0) return;
+
+        var daysPerMonth = 0;
+        try { daysPerMonth = _worldService.Calendar?.DaysPerMonth ?? 0; }
+        catch { return; }
+        if (daysPerMonth <= 0) return;
+
+        foreach (var civ in _civilizationManager.GetAllCivilizations())
+        {
+            if (civ.FoundingMonth <= 0 || civ.FoundingDay <= 0) continue;
+            if (civ.FoundingMonth != month) continue;
+            // Clamp Founding Day down to DaysPerMonth — captured value can be
+            // valid for the world's calendar at creation but become unreachable
+            // if a server later shrinks DaysPerMonth. The feast then fires on
+            // the last day of the month, same convention as religion feasts.
+            var effectiveDay = Math.Min(civ.FoundingDay, daysPerMonth);
+            if (effectiveDay != day) continue;
+            if (civ.FoundingDayLastFiredYear >= year) continue;
+            if (!_civilizationManager.TryMarkFoundingDayFired(civ.CivId, year)) continue;
+
+            _civilizationManager.RecordFoundingDay(civ.CivId);
+            _messengerService.BroadcastToCivilization(civ.CivId,
+                Services.LocalizationService.Instance.Get(LocalizationKeys.CIV_FOUNDING_DAY_BROADCAST));
+        }
+    }
+}

--- a/DivineAscension/Systems/CivilizationManager.cs
+++ b/DivineAscension/Systems/CivilizationManager.cs
@@ -129,6 +129,38 @@ public class CivilizationManager : ICivilizationManager
     }
 
     /// <summary>
+    ///     Appends a Founding Day chronicle entry and persists. Used by the
+    ///     <see cref="CivilizationCalendarTicker"/>.
+    /// </summary>
+    public void RecordFoundingDay(string civId)
+    {
+        lock (Lock)
+        {
+            var civ = _data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null) return;
+            _chronicler.RecordFoundingDay(civ);
+            _store.Save(_data);
+        }
+    }
+
+    /// <summary>
+    ///     Stamps the in-game year on the civ's Founding-Day idempotency
+    ///     stamp. Returns false if the stamp is already at or beyond
+    ///     <paramref name="year"/> (don't fire), true if newly stamped (fire).
+    /// </summary>
+    public bool TryMarkFoundingDayFired(string civId, int year)
+    {
+        lock (Lock)
+        {
+            var civ = _data.Civilizations.GetValueOrDefault(civId);
+            if (civ == null) return false;
+            if (civ.FoundingDayLastFiredYear >= year) return false;
+            civ.FoundingDayLastFiredYear = year;
+            return true;
+        }
+    }
+
+    /// <summary>
     ///     Wires the holy-site manager dependency after construction so capital cascades
     ///     can fire. Called from the system initializer once both managers exist.
     /// </summary>

--- a/DivineAscension/Systems/Civilizations/CivilizationChronicler.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationChronicler.cs
@@ -83,6 +83,17 @@ internal sealed class CivilizationChronicler
             religionId));
     }
 
+    /// <summary>
+    ///     Records the annual Founding Day "kept by the realm" entry. Fired
+    ///     by <see cref="CivilizationCalendarTicker"/> on the day each year.
+    /// </summary>
+    public void RecordFoundingDay(Civilization civ)
+    {
+        civ.AddChronicleEntry(BuildEntry(ChronicleKind.FeastDay,
+            LocalizationService.Instance.Get(LocalizationKeys.CIV_FOUNDING_DAY_CHRONICLE, civ.Name),
+            null));
+    }
+
     public void RecordDisbanded(Civilization civ)
     {
         civ.AddChronicleEntry(BuildEntry(ChronicleKind.Disbanded,

--- a/DivineAscension/Systems/Civilizations/CivilizationMembershipService.cs
+++ b/DivineAscension/Systems/Civilizations/CivilizationMembershipService.cs
@@ -92,6 +92,8 @@ internal sealed class CivilizationMembershipService
 
             var civId = Guid.NewGuid().ToString();
             var (derivedEthos, epithetKey) = CivilizationEthosDeriver.Derive(founderReligion.PatronDomain);
+            var (foundingMonth, foundingDay) = SacredCalendar.GetCurrentMonthDay(_worldService);
+            var foundingYear = SacredCalendar.GetCurrentYear(_worldService);
             var civ = new Civilization(civId, name, founderUID, founderReligionId)
             {
                 MemberCount = founderReligion.MemberUIDs.Count,
@@ -99,7 +101,13 @@ internal sealed class CivilizationMembershipService
                 Description = description,
                 Ethos = ethosOverride ?? derivedEthos,
                 FounderEpithet = LocalizationService.Instance.Get(epithetKey),
-                CapitalName = $"{name} Seat"
+                CapitalName = $"{name} Seat",
+                FoundingMonth = foundingMonth,
+                FoundingDay = foundingDay,
+                // Suppress the first-year Founding Day fire — "anniversary on
+                // the day of founding" is awkward, and the ticker condition
+                // `Year > FoundingDayLastFiredYear` makes this just a stamp.
+                FoundingDayLastFiredYear = foundingYear
             };
 
             data.AddCivilization(civ);

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -106,6 +106,13 @@ public static class DivineAscensionSystemInitializer
             eventService, worldService, religionManager, messengerService);
         religionCalendarTicker.Initialize();
 
+        // Civilization Founding Day holiday — single annual auto-feast per civ,
+        // no custom calendar. Mirrors the religion ticker pattern.
+        var civilizationCalendarTicker = new CivilizationCalendarTicker(
+            LoggingService.Instance.CreateLogger("CivilizationCalendarTicker"),
+            eventService, worldService, civilizationManager, messengerService);
+        civilizationCalendarTicker.Initialize();
+
         var playerReligionDataManager = new PlayerProgressionDataManager(
             LoggingService.Instance.CreateLogger("PlayerProgressionDataManager")
             , eventService, persistenceService,

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -518,6 +518,8 @@
   "divineascension:chronicle.peace_signed": "Peace was made with {0}.",
   "divineascension:chronicle.alliance_formed": "An alliance was forged with {0}.",
   "divineascension:chronicle.disbanded": "And so {0} passed into memory.",
+  "divineascension:civ.foundingday.chronicle": "The realm of {0} kept its Founding Day, marking another year of the banner.",
+  "divineascension:civ.foundingday.broadcast": "Today the realm keeps its Founding Day.",
   "divineascension:ui.religion.info.chronicle.heading": "Chronicle of the Order",
   "divineascension:ui.religion.info.chronicle.day": "Day {0}",
   "divineascension:ui.religion.chronicle.empty": "No deeds have yet been chronicled for this order.",


### PR DESCRIPTION
## Summary
- Each new civilization captures its in-game `(Month, Day)` at creation and gets an annual **Founding Day**, mirroring the religion Founding feast shipped in #535.
- A `CivilizationCalendarTicker` polls the in-game calendar each minute. On the matching day each year, for every civ:
  - writes a Founded-kind chronicle entry via `CivilizationChronicler.RecordFoundingDay`
  - broadcasts a localized line to civ members via `IPlayerMessengerService.BroadcastToCivilization`
- Idempotent per in-game year via `Civilization.FoundingDayLastFiredYear`, which persists in the save so reload on the same day does not re-fire.
- Founding year is stamped at creation so the first-year "anniversary on the day of founding" is suppressed.
- Day captured at creation is clamped to `DaysPerMonth` at fire time, so a server that later shrinks the calendar still fires the holiday on the last day of the founding month.

### Design note
By intent, civilizations get *only* this single auto holiday — no custom calendar surface, no per-civ "Add feast day" flow. The per-religion Sacred Calendar (#375 + #422) covers founder-curated holidays. This keeps the total visible holiday density bounded: a player in a civ of 4 religions sees at most 1 civ + 2 religion-auto + religion-custom days per year.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` clean
- [x] `dotnet test` — 2380/2380 pass, including 4 new `CivilizationFoundingDayTests` (no-calendar path, idempotency, first-year suppression stamp, unknown-civ guard)
- [ ] In-game: create a civ → confirm Founding Day does **not** fire in the founding year
- [ ] In-game: tick into the next year's founding date → confirm chronicle entry + civ broadcast fire exactly once; save/reload on the same day does not re-fire
- [ ] In-game: shrink the world's `daysPerMonth` config such that the captured Founding Day exceeds it → confirm the holiday still fires on the last day of that month