### PR TITLE
fix(blessings): drop pumpkin motherplant from BlessedCrop patch

### DIFF
--- a/DivineAscension/assets/divineascension/patches/crop.json
+++ b/DivineAscension/assets/divineascension/patches/crop.json
@@ -16,6 +16,5 @@
   { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/spelt.json", "side": "Server" },
   { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/sunflower.json", "side": "Server" },
   { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/crop/turnip.json", "side": "Server" },
-  { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/pumpkin/motherplant.json", "side": "Server" },
   { "op": "addmerge", "path": "/behaviors/-", "value": { "name": "DivineAscensionBlessedCrop" }, "file": "game:blocktypes/plant/pumpkin/fruit.json", "side": "Server" }
 ]


### PR DESCRIPTION
## Summary
- Removes the `pumpkin/motherplant.json` entry from `divineascension:patches/crop.json`.
- Root cause: that file's only \`behaviors\` key is nested inside \`attributes\` — there's no root-level array, so \`addmerge /behaviors/-\` fails at load with:
  > Patch 17 ... failed because supplied path /behaviors/- is invalid: The json path /behaviors/- was not found. No such element 'behaviors' at the root path
- The harvestable pumpkin block is `pumpkin/fruit.json` (still patched), so `cropYield` / `seedDropChance` still apply where they matter.

## Test plan
- [x] `dotnet build` clean
- [ ] Reload world — no patch error on `crop.json`