### PR TITLE
feat(blessings): apply cookingYield stat to firepit and crock outputs

### DIFF
--- a/DivineAscension/Systems/Patches/CookingPatches.cs
+++ b/DivineAscension/Systems/Patches/CookingPatches.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using DivineAscension.Constants;
 using HarmonyLib;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
@@ -43,6 +44,15 @@ public static class CookingPatches
         {
             /* ignore listener errors */
         }
+    }
+
+    // Scale a cooked output stack by the player's cookingYield blessing stat.
+    // Multiplier is a WeightedSum stat with base 1.0, so >1.0 means a bonus.
+    internal static void ApplyCookingYield(IServerPlayer player, ItemStack stack)
+    {
+        var yield = player.Entity?.Stats?.GetBlended(VintageStoryStats.CookingYield) ?? 1f;
+        if (yield <= 1f || stack.StackSize <= 0) return;
+        stack.StackSize = Math.Max(stack.StackSize, (int)Math.Round(stack.StackSize * yield));
     }
 
     // Track last interacting player via exact decompiled method
@@ -129,7 +139,10 @@ public static class CookingPatches
 
             // Consider it cooked if collectible code changed
             if (before == null || before.Collectible?.Code != after.Collectible?.Code)
+            {
+                ApplyCookingYield(player, after);
                 RaiseMealCooked(player, after.Clone(), __instance.Pos);
+            }
         }
     }
 
@@ -207,7 +220,10 @@ public static class CookingPatches
                     if (afterSlot == null || afterSlot.Empty) continue;
                     var after = afterSlot.Itemstack;
                     if (before == null || before.Collectible?.Code != after.Collectible?.Code)
+                    {
+                        ApplyCookingYield(player, after);
                         RaiseMealCooked(player, after.Clone(), be.Pos);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `CookingPatches.Postfix_Firepit_SmeltItems` and `Postfix_BlockCrock_OnBlockInteractStart` now scale cooked output `StackSize` by the player's `cookingYield` blend before raising `OnMealCooked`.
- New `ApplyCookingYield(player, stack)` helper centralises the math (WeightedSum stat, base 1.0 → multiplier).

Slice **H2** of the Harvest plan in https://github.com/Quantumheart/DivineAscension/issues/214#issuecomment-4564182097.

## Why Harmony (not an entityClass swap)
Considered a `BlockEntityFirepitDA` subclass + JSON `entityClass` replace, but the existing Harmony postfix in `CookingPatches` already attributes the player and detects cooked-output transitions. Extending it is 4 lines vs a new BE subclass + accessor + entityClass patch, and avoids `entityClass`-replace conflicts with other mods that subclass `BlockEntityFirepit`. No *new* Harmony patches introduced.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` — clean
- [x] `dotnet test` — 2395 passing
- [x] In-game: equip Baker's Touch (`cookingYield: 0.25`), cook a meal in a firepit, confirm output stack ~25% larger than baseline.
- [x] In-game: seal a crock with cooked contents, confirm same scaling.