### PR TITLE
feat(progression): persist DiscoveredChunks for Caravan Wayfaring

### DIFF
--- a/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
@@ -744,7 +744,7 @@ public class PlayerProgressionDataManagerTests
         Assert.Equal(150, loadedData.GetFavor(DeityDomain.Craft));
         Assert.Equal(200, loadedData.GetTotalFavorEarned(DeityDomain.Craft));
         _mockLogger.Verify(
-            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v6"))),
+            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v7"))),
             Times.Once()
         );
     }

--- a/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
@@ -34,7 +34,8 @@ public class PlayerProgressionDataTests
         Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
         Assert.Equal(0, data.GetTotalFavorEarned(DeityDomain.Craft));
         Assert.Equal(0f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft));
-        Assert.Equal(6, data.DataVersion); // v6: per-deity favor (Pantheon 2.0)
+        Assert.Equal(7, data.DataVersion); // v7: DiscoveredChunks (Caravan / Wayfaring)
+        Assert.Equal(0, data.DiscoveredChunkCount);
         Assert.Empty(data.UnlockedBlessings);
     }
 
@@ -382,6 +383,64 @@ public class PlayerProgressionDataTests
         Assert.Equal(789, roundTripped.GetFavor(DeityDomain.Conquest));
         Assert.Equal(123, roundTripped.GetTotalFavorEarned(DeityDomain.Craft));
         Assert.InRange(roundTripped.GetAccumulatedFractionalFavor(DeityDomain.Wild), 0.299f, 0.301f);
+    }
+
+    #endregion
+
+    #region DiscoveredChunks Tests
+
+    [Fact]
+    public void TryAddDiscoveredChunk_NewChunk_ReturnsTrueAndStores()
+    {
+        var data = new PlayerProgressionData("player-123");
+
+        Assert.True(data.TryAddDiscoveredChunk(42L));
+        Assert.True(data.HasDiscoveredChunk(42L));
+        Assert.Equal(1, data.DiscoveredChunkCount);
+    }
+
+    [Fact]
+    public void TryAddDiscoveredChunk_Duplicate_ReturnsFalse()
+    {
+        var data = new PlayerProgressionData("player-123");
+        data.TryAddDiscoveredChunk(42L);
+
+        Assert.False(data.TryAddDiscoveredChunk(42L));
+        Assert.Equal(1, data.DiscoveredChunkCount);
+    }
+
+    [Fact]
+    public void TryAddDiscoveredChunk_AtSoftCap_StopsAwarding()
+    {
+        var data = new PlayerProgressionData("player-123");
+        for (long i = 0; i < PlayerProgressionData.DiscoveredChunksSoftCap; i++)
+        {
+            data.TryAddDiscoveredChunk(i);
+        }
+
+        Assert.Equal(PlayerProgressionData.DiscoveredChunksSoftCap, data.DiscoveredChunkCount);
+        Assert.False(data.TryAddDiscoveredChunk(long.MaxValue));
+        Assert.False(data.HasDiscoveredChunk(long.MaxValue));
+        Assert.Equal(PlayerProgressionData.DiscoveredChunksSoftCap, data.DiscoveredChunkCount);
+    }
+
+    [Fact]
+    public void ProtoBuf_RoundTrip_PreservesDiscoveredChunks()
+    {
+        var data = new PlayerProgressionData("player-chunks");
+        data.TryAddDiscoveredChunk(1L);
+        data.TryAddDiscoveredChunk(1_000_000L);
+        data.TryAddDiscoveredChunk(-7L);
+
+        using var ms = new System.IO.MemoryStream();
+        ProtoBuf.Serializer.Serialize(ms, data);
+        ms.Position = 0;
+        var roundTripped = ProtoBuf.Serializer.Deserialize<PlayerProgressionData>(ms);
+
+        Assert.Equal(3, roundTripped.DiscoveredChunkCount);
+        Assert.True(roundTripped.HasDiscoveredChunk(1L));
+        Assert.True(roundTripped.HasDiscoveredChunk(1_000_000L));
+        Assert.True(roundTripped.HasDiscoveredChunk(-7L));
     }
 
     #endregion

--- a/DivineAscension/Systems/PlayerProgressionData.cs
+++ b/DivineAscension/Systems/PlayerProgressionData.cs
@@ -90,7 +90,13 @@ public class PlayerProgressionData
     ///     Data version (internal bookkeeping only — Pantheon 2.0 no longer carries cross-version save migrations).
     /// </summary>
     [ProtoMember(104)]
-    public int DataVersion { get; set; } = 6;
+    public int DataVersion { get; set; } = 7;
+
+    /// <summary>
+    ///     Soft cap on tracked discovered chunks per player. Past this, <see cref="TryAddDiscoveredChunk"/>
+    ///     stops awarding to bound memory growth for explorers who roam tens of thousands of chunks.
+    /// </summary>
+    public const int DiscoveredChunksSoftCap = 1_000_000;
 
     /// <summary>
     ///     Accumulated fractional favor per deity domain (not yet awarded) for passive generation.
@@ -375,6 +381,54 @@ public class PlayerProgressionData
     /// </summary>
     [ProtoMember(115)]
     public DateTime? LastPatrolCompletionTimeUtc { get; set; }
+
+    /// <summary>
+    ///     Set of chunk keys the player has visited (packed long form from <c>ChunkPos.ToChunkIndex3D</c>).
+    ///     Drives the Wayfaring favor source for the Caravan domain. v6 saves load with an empty set
+    ///     (no retroactive rewards).
+    /// </summary>
+    [ProtoMember(116)] private HashSet<long> _discoveredChunks = new();
+
+    /// <summary>
+    ///     Count of discovered chunks (thread-safe).
+    /// </summary>
+    public int DiscoveredChunkCount
+    {
+        get
+        {
+            lock (Lock)
+            {
+                return _discoveredChunks.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Checks if the player has already visited a chunk (thread-safe).
+    /// </summary>
+    public bool HasDiscoveredChunk(long chunkKey)
+    {
+        lock (Lock)
+        {
+            return _discoveredChunks.Contains(chunkKey);
+        }
+    }
+
+    /// <summary>
+    ///     Records a chunk visit. Returns <c>true</c> if the chunk was newly added and the caller
+    ///     should award favor. Returns <c>false</c> if the chunk was already known, or if the soft
+    ///     cap (<see cref="DiscoveredChunksSoftCap"/>) has been reached. Thread-safe.
+    /// </summary>
+    public bool TryAddDiscoveredChunk(long chunkKey)
+    {
+        lock (Lock)
+        {
+            if (_discoveredChunks.Count >= DiscoveredChunksSoftCap)
+                return false;
+
+            return _discoveredChunks.Add(chunkKey);
+        }
+    }
 
     /// <summary>
     ///     Gets the committed branch for a domain (thread-safe).

--- a/DivineAscension/Systems/PlayerProgressionData.cs
+++ b/DivineAscension/Systems/PlayerProgressionData.cs
@@ -96,7 +96,7 @@ public class PlayerProgressionData
     ///     Soft cap on tracked discovered chunks per player. Past this, <see cref="TryAddDiscoveredChunk"/>
     ///     stops awarding to bound memory growth for explorers who roam tens of thousands of chunks.
     /// </summary>
-    public const int DiscoveredChunksSoftCap = 1_000_000;
+    public const int DiscoveredChunksSoftCap = 100_000;
 
     /// <summary>
     ///     Accumulated fractional favor per deity domain (not yet awarded) for passive generation.


### PR DESCRIPTION
## Summary
- Add `HashSet<long> _discoveredChunks` (`ProtoMember(116)`) to `PlayerProgressionData` with thread-safe `TryAddDiscoveredChunk` / `HasDiscoveredChunk` / `DiscoveredChunkCount`.
- Soft cap `DiscoveredChunksSoftCap = 100_000` — past this, new chunks stop being recorded so Wayfaring favor stops awarding. Cap is a memory ceiling; rate/award balance lives in #437.
- Bump `DataVersion` 6 → 7. v6 saves deserialize with an empty set (no retroactive rewards) — protobuf-default-value migration, no manual code path needed.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` clean
- [x] `dotnet test` — 2399/2399 pass
- [x] New unit tests: add/dedupe/soft-cap/protobuf roundtrip
- [x] Updated existing log-assertion (`v6` → `v7`) in PlayerProgressionDataManagerTests

Closes #430