### PR TITLE
feat(domain): Caravan content + stat keys (Slice 2) + slice 1 hardcoded-array fix-up

### DIFF
--- a/DivineAscension.Tests/GUI/Managers/BlessingStateManagerPantheonTests.cs
+++ b/DivineAscension.Tests/GUI/Managers/BlessingStateManagerPantheonTests.cs
@@ -41,7 +41,7 @@ public class BlessingStateManagerPantheonTests
     }
 
     [Fact]
-    public void LoadBlessingStates_PopulatesAllFiveDeityBuckets()
+    public void LoadBlessingStates_PopulatesAllSixDeityBuckets()
     {
         var players = new List<Blessing>
         {
@@ -49,7 +49,8 @@ public class BlessingStateManagerPantheonTests
             B("w1", DeityDomain.Wild),
             B("q1", DeityDomain.Conquest),
             B("h1", DeityDomain.Harvest),
-            B("s1", DeityDomain.Stone)
+            B("s1", DeityDomain.Stone),
+            B("k1", DeityDomain.Caravan)
         };
         var religion = new List<Blessing>
         {
@@ -59,12 +60,17 @@ public class BlessingStateManagerPantheonTests
 
         _sut.LoadBlessingStates(players, religion);
 
-        Assert.Equal(5, _sut.State.PlayerBlessingStatesByDeity.Count);
-        foreach (var domain in new[] { DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone })
+        Assert.Equal(6, _sut.State.PlayerBlessingStatesByDeity.Count);
+        foreach (var domain in new[]
+                 {
+                     DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest,
+                     DeityDomain.Stone, DeityDomain.Caravan
+                 })
             Assert.Single(_sut.State.PlayerBlessingStatesByDeity[domain]);
         Assert.Single(_sut.State.ReligionBlessingStatesByDeity[DeityDomain.Craft]);
         Assert.Single(_sut.State.ReligionBlessingStatesByDeity[DeityDomain.Wild]);
         Assert.Empty(_sut.State.ReligionBlessingStatesByDeity[DeityDomain.Stone]);
+        Assert.Empty(_sut.State.ReligionBlessingStatesByDeity[DeityDomain.Caravan]);
     }
 
     [Fact]

--- a/DivineAscension/Commands/FavorCommands.cs
+++ b/DivineAscension/Commands/FavorCommands.cs
@@ -348,7 +348,7 @@ public class FavorCommands
     private static readonly DeityDomain[] AllDeities =
     {
         DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
-        DeityDomain.Harvest, DeityDomain.Stone
+        DeityDomain.Harvest, DeityDomain.Stone, DeityDomain.Caravan
     };
 
     /// <summary>

--- a/DivineAscension/Constants/VintageStoryStats.cs
+++ b/DivineAscension/Constants/VintageStoryStats.cs
@@ -90,10 +90,10 @@ public static class VintageStoryStats
     public const string ChunkDiscoveryFavorMultiplier = "chunkDiscoveryFavorMultiplier";
 
     // Caravan (Trade & Wayfaring) Stats — DA-specific, consumed by
-    // TraderTransactionFavorTracker (#429) and ExplorationFavorTracker (#431).
+    // TraderTransactionFavorTracker (#429). ChunkDiscoveryFavorMultiplier
+    // already declared above (consumed by ExplorationFavorTracker, #431).
     public const string TraderBuyPriceMultiplier = "traderBuyPriceMultiplier";
     public const string TraderSellPriceMultiplier = "traderSellPriceMultiplier";
-    public const string ChunkDiscoveryFavorMultiplier = "chunkDiscoveryFavorMultiplier";
 
     #region CombatOverhaul Compatible Stats
 

--- a/DivineAscension/Constants/VintageStoryStats.cs
+++ b/DivineAscension/Constants/VintageStoryStats.cs
@@ -89,6 +89,12 @@ public static class VintageStoryStats
     public const string HolySitePrestigeMultiplier = "holySitePrestigeMultiplier";
     public const string ChunkDiscoveryFavorMultiplier = "chunkDiscoveryFavorMultiplier";
 
+    // Caravan (Trade & Wayfaring) Stats — DA-specific, consumed by
+    // TraderTransactionFavorTracker (#429) and ExplorationFavorTracker (#431).
+    public const string TraderBuyPriceMultiplier = "traderBuyPriceMultiplier";
+    public const string TraderSellPriceMultiplier = "traderSellPriceMultiplier";
+    public const string ChunkDiscoveryFavorMultiplier = "chunkDiscoveryFavorMultiplier";
+
     #region CombatOverhaul Compatible Stats
 
     // CombatOverhaul-compatible tier bonus stats

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -155,11 +155,15 @@ public partial class GuiDialog
 
         // Preload blessing textures for every deity to prevent stuttering when switching tabs.
         var allBlessings = playerBlessings.Concat(religionBlessings).ToList();
-        foreach (var domain in new[] { DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone })
+        foreach (var domain in new[]
+                 {
+                     DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
+                     DeityDomain.Caravan
+                 })
             BlessingIconLoader.PreloadDeityTextures(
                 allBlessings.Where(b => b.Domain == domain).ToList(), domain);
         _logger?.Debug(
-            $"[DivineAscension] Preloaded blessing textures for all five deities ({allBlessings.Count} blessings total).");
+            $"[DivineAscension] Preloaded blessing textures for all six deities ({allBlessings.Count} blessings total).");
 
         // Mark unlocked blessings
         foreach (var blessingId in packet.UnlockedPlayerBlessings)

--- a/DivineAscension/GUI/Managers/BlessingStateManager.cs
+++ b/DivineAscension/GUI/Managers/BlessingStateManager.cs
@@ -22,7 +22,8 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
 {
     private static readonly DeityDomain[] AllDeities =
     {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone
+        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
+        DeityDomain.Caravan
     };
 
     private readonly ICoreClientAPI _coreClientApi = api ?? throw new ArgumentNullException(nameof(api));

--- a/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
@@ -72,6 +72,7 @@ internal static class CrossDeitySummaryRenderer
         DeityDomain.Conquest => "Q",
         DeityDomain.Harvest => "H",
         DeityDomain.Stone => "S",
+        DeityDomain.Caravan => "R",
         _ => "?"
     };
 }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
@@ -20,12 +20,13 @@ internal static class DeitySelectorRenderer
     private const float PatronBorderThickness = 2.5f;
     private const float ActiveBorderThickness = 2f;
     public const float Height = TabSize + 4f;
-    public const int TabCount = 5;
+    public const int TabCount = 6;
     public const float StripWidth = TabCount * TabSize + (TabCount - 1) * TabSpacing;
 
     private static readonly DeityDomain[] Order =
     {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone
+        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
+        DeityDomain.Caravan
     };
 
     /// <summary>

--- a/DivineAscension/Services/BlessingLoader.cs
+++ b/DivineAscension/Services/BlessingLoader.cs
@@ -17,7 +17,7 @@ namespace DivineAscension.Services;
 /// </summary>
 public class BlessingLoader : IBlessingLoader
 {
-    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone" };
+    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone", "caravan" };
 
     private readonly ICoreAPI _api;
     private readonly List<Blessing> _loadedBlessings = new();
@@ -348,6 +348,11 @@ public class BlessingLoader : IBlessingLoader
         VintageStoryStats.QuarterstaffProficiency,
         VintageStoryStats.SlingsProficiency,
         VintageStoryStats.SecondChanceCooldown,
-        VintageStoryStats.SecondChanceGracePeriod
+        VintageStoryStats.SecondChanceGracePeriod,
+
+        // Caravan Stats
+        VintageStoryStats.TraderBuyPriceMultiplier,
+        VintageStoryStats.TraderSellPriceMultiplier,
+        VintageStoryStats.ChunkDiscoveryFavorMultiplier
     };
 }

--- a/DivineAscension/Services/OfferingLoader.cs
+++ b/DivineAscension/Services/OfferingLoader.cs
@@ -15,7 +15,7 @@ namespace DivineAscension.Services;
 /// </summary>
 public class OfferingLoader(ILoggerWrapper logger, IAssetManager assetManager) : IOfferingLoader
 {
-    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone" };
+    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone", "caravan" };
 
     private readonly IAssetManager
         _assetManager = assetManager ?? throw new ArgumentNullException(nameof(assetManager));

--- a/DivineAscension/Services/RitualLoader.cs
+++ b/DivineAscension/Services/RitualLoader.cs
@@ -16,7 +16,7 @@ namespace DivineAscension.Services;
 /// </summary>
 public class RitualLoader(ILoggerWrapper logger, IAssetManager assetManager) : IRitualLoader
 {
-    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone" };
+    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone", "caravan" };
 
     private readonly IAssetManager
         _assetManager = assetManager ?? throw new ArgumentNullException(nameof(assetManager));

--- a/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
@@ -25,7 +25,7 @@ public class BlessingNetworkHandler : IServerNetworkHandler
     private static readonly DeityDomain[] AllDeities =
     {
         DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
-        DeityDomain.Harvest, DeityDomain.Stone
+        DeityDomain.Harvest, DeityDomain.Stone, DeityDomain.Caravan
     };
 
     private readonly ILogger _logger;

--- a/DivineAscension/assets/divineascension/config/blessings/caravan.json
+++ b/DivineAscension/assets/divineascension/config/blessings/caravan.json
@@ -1,0 +1,206 @@
+{
+  "domain": "Caravan",
+  "version": 1,
+  "blessings": [
+    {
+      "blessingId": "caravan_first_step",
+      "name": "First Step",
+      "description": "Foundation for trade and wayfaring. -5% trader buy price, +5% trader sell price, +5% chunk-discovery favor.",
+      "kind": "Player",
+      "category": "Utility",
+      "iconName": "footprint",
+      "requiredFavorRank": 0,
+      "requiredPrestigeRank": 0,
+      "prerequisiteBlessings": [],
+      "statModifiers": {
+        "traderBuyPriceMultiplier": -0.05,
+        "traderSellPriceMultiplier": 0.05,
+        "chunkDiscoveryFavorMultiplier": 0.05
+      },
+      "specialEffects": [],
+      "cost": 50,
+      "branch": null,
+      "exclusiveBranches": null
+    },
+    {
+      "blessingId": "caravan_haggler",
+      "name": "Haggler",
+      "description": "Sharpen your tongue at the stall. -10% trader buy price, +10% trader sell price. Trade path. Requires First Step.",
+      "kind": "Player",
+      "category": "Utility",
+      "iconName": "coin",
+      "requiredFavorRank": 1,
+      "requiredPrestigeRank": 0,
+      "prerequisiteBlessings": ["caravan_first_step"],
+      "statModifiers": {
+        "traderBuyPriceMultiplier": -0.10,
+        "traderSellPriceMultiplier": 0.10
+      },
+      "specialEffects": [],
+      "cost": 150,
+      "branch": "Trade",
+      "exclusiveBranches": ["Wayfaring"]
+    },
+    {
+      "blessingId": "caravan_pathfinder",
+      "name": "Pathfinder",
+      "description": "Mile after mile, the road steadies your step. +5% movement speed, +15% chunk-discovery favor. Wayfaring path. Requires First Step.",
+      "kind": "Player",
+      "category": "Utility",
+      "iconName": "compass",
+      "requiredFavorRank": 1,
+      "requiredPrestigeRank": 0,
+      "prerequisiteBlessings": ["caravan_first_step"],
+      "statModifiers": {
+        "walkspeed": 0.05,
+        "chunkDiscoveryFavorMultiplier": 0.15
+      },
+      "specialEffects": [],
+      "cost": 150,
+      "branch": "Wayfaring",
+      "exclusiveBranches": ["Trade"]
+    },
+    {
+      "blessingId": "caravan_master_trader",
+      "name": "Master Trader",
+      "description": "The markets know your seal. -20% trader buy price (total: -35%), +20% trader sell price (total: +35%). Requires Haggler.",
+      "kind": "Player",
+      "category": "Utility",
+      "iconName": "coin-stack",
+      "requiredFavorRank": 2,
+      "requiredPrestigeRank": 0,
+      "prerequisiteBlessings": ["caravan_haggler"],
+      "statModifiers": {
+        "traderBuyPriceMultiplier": -0.20,
+        "traderSellPriceMultiplier": 0.20
+      },
+      "specialEffects": [],
+      "cost": 400,
+      "branch": "Trade",
+      "exclusiveBranches": ["Wayfaring"]
+    },
+    {
+      "blessingId": "caravan_pathwarden",
+      "name": "Pathwarden",
+      "description": "Cold winds and long marches no longer cost you. +10% movement speed (total: +15%), +15% temperature resistance, +20% chunk-discovery favor (total: +40%). Requires Pathfinder.",
+      "kind": "Player",
+      "category": "Utility",
+      "iconName": "wayfarer",
+      "requiredFavorRank": 2,
+      "requiredPrestigeRank": 0,
+      "prerequisiteBlessings": ["caravan_pathfinder"],
+      "statModifiers": {
+        "walkspeed": 0.10,
+        "temperatureResistance": 0.15,
+        "chunkDiscoveryFavorMultiplier": 0.20
+      },
+      "specialEffects": [],
+      "cost": 400,
+      "branch": "Wayfaring",
+      "exclusiveBranches": ["Trade"]
+    },
+    {
+      "blessingId": "caravan_avatar_road",
+      "name": "Avatar of the Road",
+      "description": "Bear the open sky as a hearth. Grants a placeable Caravan Shrine that acts as a tier-1 altar. +5% movement speed, +10% chunk-discovery favor, -5% trader buy price. Requires Master Trader or Pathwarden.",
+      "kind": "Player",
+      "category": "Utility",
+      "iconName": "wagon",
+      "requiredFavorRank": 3,
+      "requiredPrestigeRank": 0,
+      "prerequisiteBlessings": ["caravan_master_trader", "caravan_pathwarden"],
+      "statModifiers": {
+        "walkspeed": 0.05,
+        "chunkDiscoveryFavorMultiplier": 0.10,
+        "traderBuyPriceMultiplier": -0.05
+      },
+      "specialEffects": ["grants_caravan_shrine"],
+      "cost": 800,
+      "branch": null,
+      "exclusiveBranches": null,
+      "requiresPatron": true
+    },
+    {
+      "blessingId": "caravan_guild_circle",
+      "name": "Caravan Guild",
+      "description": "Your congregation walks together. -5% trader buy price, +5% trader sell price, +5% chunk-discovery favor for all members.",
+      "kind": "Religion",
+      "category": "Utility",
+      "iconName": "cycle",
+      "requiredFavorRank": 0,
+      "requiredPrestigeRank": 0,
+      "prerequisiteBlessings": [],
+      "statModifiers": {
+        "traderBuyPriceMultiplier": -0.05,
+        "traderSellPriceMultiplier": 0.05,
+        "chunkDiscoveryFavorMultiplier": 0.05
+      },
+      "specialEffects": [],
+      "cost": 500,
+      "branch": null,
+      "exclusiveBranches": null
+    },
+    {
+      "blessingId": "caravan_trade_league",
+      "name": "Trade League",
+      "description": "Sealed letters open every gate. -10% trader buy price, +10% trader sell price, +10% chunk-discovery favor for all. Requires Caravan Guild.",
+      "kind": "Religion",
+      "category": "Utility",
+      "iconName": "team-upgrade",
+      "requiredFavorRank": 0,
+      "requiredPrestigeRank": 1,
+      "prerequisiteBlessings": ["caravan_guild_circle"],
+      "statModifiers": {
+        "traderBuyPriceMultiplier": -0.10,
+        "traderSellPriceMultiplier": 0.10,
+        "chunkDiscoveryFavorMultiplier": 0.10
+      },
+      "specialEffects": [],
+      "cost": 1500,
+      "branch": null,
+      "exclusiveBranches": null
+    },
+    {
+      "blessingId": "caravan_road_hegemony",
+      "name": "Road Hegemony",
+      "description": "Every road bears your standard. -15% trader buy price, +15% trader sell price, +20% chunk-discovery favor, +5% movement speed for all. Requires Trade League.",
+      "kind": "Religion",
+      "category": "Utility",
+      "iconName": "wayfarer",
+      "requiredFavorRank": 0,
+      "requiredPrestigeRank": 2,
+      "prerequisiteBlessings": ["caravan_trade_league"],
+      "statModifiers": {
+        "traderBuyPriceMultiplier": -0.15,
+        "traderSellPriceMultiplier": 0.15,
+        "chunkDiscoveryFavorMultiplier": 0.20,
+        "walkspeed": 0.05
+      },
+      "specialEffects": [],
+      "cost": 4000,
+      "branch": null,
+      "exclusiveBranches": null
+    },
+    {
+      "blessingId": "caravan_pantheon_road",
+      "name": "Pantheon of the Road",
+      "description": "Your faith becomes the route between worlds. +5% movement speed, +10% chunk-discovery favor, +10% trader sell price for all. Requires Road Hegemony.",
+      "kind": "Religion",
+      "category": "Utility",
+      "iconName": "wagon",
+      "requiredFavorRank": 0,
+      "requiredPrestigeRank": 3,
+      "prerequisiteBlessings": ["caravan_road_hegemony"],
+      "statModifiers": {
+        "walkspeed": 0.05,
+        "chunkDiscoveryFavorMultiplier": 0.10,
+        "traderSellPriceMultiplier": 0.10
+      },
+      "specialEffects": [],
+      "cost": 8000,
+      "branch": null,
+      "exclusiveBranches": null,
+      "requiresPatron": true
+    }
+  ]
+}

--- a/DivineAscension/assets/divineascension/config/offerings/caravan.json
+++ b/DivineAscension/assets/divineascension/config/offerings/caravan.json
@@ -3,15 +3,10 @@
   "version": 1,
   "offerings": [
     {
-      "name": "Travel Rations",
+      "name": "Travel Pemmican",
       "itemCodes": [
-        "game:driedfruit-blueberry",
-        "game:driedfruit-cherry",
-        "game:driedfruit-cranberry",
-        "game:driedfruit-pinkapple",
-        "game:driedfruit-redapple",
-        "game:driedfruit-yellowapple",
-        "game:curedmeat-vegetable"
+        "game:pemmican-dried-basic",
+        "game:pemmican-dried-salted"
       ],
       "tier": 1,
       "value": 2,
@@ -19,15 +14,28 @@
       "description": "Trail-keeping food for the road"
     },
     {
-      "name": "Coarse Cordage",
+      "name": "Cured Trail Meat",
       "itemCodes": [
-        "game:flaxtwine",
-        "game:cloth-linen"
+        "game:redmeat-cured",
+        "game:bushmeat-cured",
+        "game:poultry-cured",
+        "game:fish-cured"
       ],
       "tier": 1,
       "value": 2,
       "minHolySiteTier": 1,
-      "description": "Basic caravan gear — rope, cloth, packs"
+      "description": "Salt-cured meat traded along the road"
+    },
+    {
+      "name": "Coarse Cordage",
+      "itemCodes": [
+        "game:flaxtwine",
+        "game:cloth-plain"
+      ],
+      "tier": 1,
+      "value": 2,
+      "minHolySiteTier": 1,
+      "description": "Basic caravan gear — rope and undyed cloth"
     },
     {
       "name": "Rusty Gear",
@@ -54,18 +62,27 @@
       "description": "The currency of long routes"
     },
     {
-      "name": "Wool Yarn",
-      "itemCodes": ["game:wool"],
+      "name": "Pickled Provisions",
+      "itemCodes": [
+        "game:pickledlegume",
+        "game:pickledvegetable"
+      ],
       "tier": 2,
       "value": 5,
       "minHolySiteTier": 2,
-      "description": "Caravan trade staple"
+      "description": "Long-keeping caravan rations"
     },
     {
-      "name": "Cheese",
+      "name": "Aged Cheese",
       "itemCodes": [
-        "game:cheese-blue",
-        "game:cheese-cheddar"
+        "game:cheese-blue-1slice",
+        "game:cheese-blue-2slice",
+        "game:cheese-blue-3slice",
+        "game:cheese-blue-4slice",
+        "game:cheese-cheddar-1slice",
+        "game:cheese-cheddar-2slice",
+        "game:cheese-cheddar-3slice",
+        "game:cheese-cheddar-4slice"
       ],
       "tier": 2,
       "value": 5,
@@ -73,19 +90,20 @@
       "description": "Cellared trade good"
     },
     {
-      "name": "Honeyed Comb Loaf",
+      "name": "Road Bread",
       "itemCodes": [
-        "game:bread-rye",
-        "game:bread-spelt",
-        "game:bread-flax",
-        "game:bread-rice",
-        "game:bread-sunflower",
-        "game:bread-cassava"
+        "game:bread-spelt-perfect",
+        "game:bread-rye-perfect",
+        "game:bread-flax-perfect",
+        "game:bread-rice-perfect",
+        "game:bread-cassava-perfect",
+        "game:bread-amaranth-perfect",
+        "game:bread-sunflower-perfect"
       ],
       "tier": 2,
       "value": 5,
       "minHolySiteTier": 2,
-      "description": "Hardened road bread"
+      "description": "Trail bread baked for the long haul"
     },
     {
       "name": "Temporal Gear",
@@ -96,12 +114,17 @@
       "description": "Trader currency — exotic"
     },
     {
-      "name": "Linen Bolt",
-      "itemCodes": ["game:linen-normal"],
+      "name": "Waxed Cheese",
+      "itemCodes": [
+        "game:cheese-waxedcheddar-1slice",
+        "game:cheese-waxedcheddar-2slice",
+        "game:cheese-waxedcheddar-3slice",
+        "game:cheese-waxedcheddar-4slice"
+      ],
       "tier": 3,
       "value": 10,
       "minHolySiteTier": 2,
-      "description": "Bolt of fine linen — exotic trade good"
+      "description": "Far-traded wheel of cheese"
     },
     {
       "name": "Resin",

--- a/DivineAscension/assets/divineascension/config/offerings/caravan.json
+++ b/DivineAscension/assets/divineascension/config/offerings/caravan.json
@@ -1,0 +1,115 @@
+{
+  "domain": "Caravan",
+  "version": 1,
+  "offerings": [
+    {
+      "name": "Travel Rations",
+      "itemCodes": [
+        "game:driedfruit-blueberry",
+        "game:driedfruit-cherry",
+        "game:driedfruit-cranberry",
+        "game:driedfruit-pinkapple",
+        "game:driedfruit-redapple",
+        "game:driedfruit-yellowapple",
+        "game:curedmeat-vegetable"
+      ],
+      "tier": 1,
+      "value": 2,
+      "minHolySiteTier": 1,
+      "description": "Trail-keeping food for the road"
+    },
+    {
+      "name": "Coarse Cordage",
+      "itemCodes": [
+        "game:flaxtwine",
+        "game:cloth-linen"
+      ],
+      "tier": 1,
+      "value": 2,
+      "minHolySiteTier": 1,
+      "description": "Basic caravan gear — rope, cloth, packs"
+    },
+    {
+      "name": "Rusty Gear",
+      "itemCodes": ["game:gear-rusty"],
+      "tier": 1,
+      "value": 2,
+      "minHolySiteTier": 1,
+      "description": "Trader currency — base"
+    },
+    {
+      "name": "Honeycomb",
+      "itemCodes": ["game:honeycomb"],
+      "tier": 1,
+      "value": 2,
+      "minHolySiteTier": 1,
+      "description": "Sweet barter good favored on the road"
+    },
+    {
+      "name": "Salt",
+      "itemCodes": ["game:salt"],
+      "tier": 2,
+      "value": 5,
+      "minHolySiteTier": 2,
+      "description": "The currency of long routes"
+    },
+    {
+      "name": "Wool Yarn",
+      "itemCodes": ["game:wool"],
+      "tier": 2,
+      "value": 5,
+      "minHolySiteTier": 2,
+      "description": "Caravan trade staple"
+    },
+    {
+      "name": "Cheese",
+      "itemCodes": [
+        "game:cheese-blue",
+        "game:cheese-cheddar"
+      ],
+      "tier": 2,
+      "value": 5,
+      "minHolySiteTier": 2,
+      "description": "Cellared trade good"
+    },
+    {
+      "name": "Honeyed Comb Loaf",
+      "itemCodes": [
+        "game:bread-rye",
+        "game:bread-spelt",
+        "game:bread-flax",
+        "game:bread-rice",
+        "game:bread-sunflower",
+        "game:bread-cassava"
+      ],
+      "tier": 2,
+      "value": 5,
+      "minHolySiteTier": 2,
+      "description": "Hardened road bread"
+    },
+    {
+      "name": "Temporal Gear",
+      "itemCodes": ["game:gear-temporal"],
+      "tier": 3,
+      "value": 10,
+      "minHolySiteTier": 2,
+      "description": "Trader currency — exotic"
+    },
+    {
+      "name": "Linen Bolt",
+      "itemCodes": ["game:linen-normal"],
+      "tier": 3,
+      "value": 10,
+      "minHolySiteTier": 2,
+      "description": "Bolt of fine linen — exotic trade good"
+    },
+    {
+      "name": "Resin",
+      "itemCodes": ["game:resin"],
+      "tier": 3,
+      "value": 10,
+      "minHolySiteTier": 3,
+      "description": "Caravan caulking — far-traded"
+    }
+  ]
+}

--- a/DivineAscension/assets/divineascension/config/rituals/caravan.json
+++ b/DivineAscension/assets/divineascension/config/rituals/caravan.json
@@ -34,11 +34,11 @@
               "itemCodes": ["game:salt"]
             },
             {
-              "requirementId": "linen_cloth",
-              "displayName": "Linen Cloth",
+              "requirementId": "plain_cloth",
+              "displayName": "Plain Cloth",
               "quantity": 30,
               "type": "Exact",
-              "itemCodes": ["game:cloth-linen"]
+              "itemCodes": ["game:cloth-plain"]
             }
           ]
         },
@@ -47,7 +47,7 @@
           "stepName": "Barter Goods",
           "requirements": [
             {
-              "requirementId": "trade_breads",
+              "requirementId": "trail_breads",
               "displayName": "Trail Breads (Any Type)",
               "quantity": 80,
               "type": "Category",
@@ -89,11 +89,11 @@
               "itemCodes": ["game:resin"]
             },
             {
-              "requirementId": "wool",
-              "displayName": "Wool",
+              "requirementId": "pemmican",
+              "displayName": "Pemmican (Any Type)",
               "quantity": 60,
-              "type": "Exact",
-              "itemCodes": ["game:wool"]
+              "type": "Category",
+              "itemCodes": ["game:pemmican-*"]
             }
           ]
         },
@@ -103,17 +103,17 @@
           "requirements": [
             {
               "requirementId": "cheeses",
-              "displayName": "Aged Cheeses",
+              "displayName": "Aged Cheeses (Any Type)",
               "quantity": 30,
               "type": "Category",
               "itemCodes": ["game:cheese-*"]
             },
             {
-              "requirementId": "dried_fruits",
-              "displayName": "Dried Fruits (Any Type)",
+              "requirementId": "cured_meats",
+              "displayName": "Cured Meats (Any Type)",
               "quantity": 80,
               "type": "Category",
-              "itemCodes": ["game:driedfruit-*"]
+              "itemCodes": ["game:redmeat-cured", "game:bushmeat-cured", "game:poultry-cured", "game:fish-cured"]
             }
           ]
         }

--- a/DivineAscension/assets/divineascension/config/rituals/caravan.json
+++ b/DivineAscension/assets/divineascension/config/rituals/caravan.json
@@ -1,0 +1,123 @@
+{
+  "domain": "Caravan",
+  "version": 1,
+  "rituals": [
+    {
+      "ritualId": "caravan_tier2_ritual",
+      "name": "Rite of the Open Road",
+      "sourceTier": 1,
+      "targetTier": 2,
+      "description": "Prove that this hearth has been earned at the stall and on the trail. Bear the spoils of many trades and many leagues back to the shrine.",
+      "steps": [
+        {
+          "stepId": "trader_proof",
+          "stepName": "Trader's Proof",
+          "requirements": [
+            {
+              "requirementId": "rusty_gears",
+              "displayName": "Rusty Gears",
+              "quantity": 100,
+              "type": "Exact",
+              "itemCodes": ["game:gear-rusty"]
+            }
+          ]
+        },
+        {
+          "stepId": "road_provisions",
+          "stepName": "Road Provisions",
+          "requirements": [
+            {
+              "requirementId": "salt",
+              "displayName": "Salt",
+              "quantity": 50,
+              "type": "Exact",
+              "itemCodes": ["game:salt"]
+            },
+            {
+              "requirementId": "linen_cloth",
+              "displayName": "Linen Cloth",
+              "quantity": 30,
+              "type": "Exact",
+              "itemCodes": ["game:cloth-linen"]
+            }
+          ]
+        },
+        {
+          "stepId": "barter_goods",
+          "stepName": "Barter Goods",
+          "requirements": [
+            {
+              "requirementId": "trade_breads",
+              "displayName": "Trail Breads (Any Type)",
+              "quantity": 80,
+              "type": "Category",
+              "itemCodes": ["game:bread-*"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ritualId": "caravan_tier3_ritual",
+      "name": "Pilgrimage Rite",
+      "sourceTier": 2,
+      "targetTier": 3,
+      "description": "Walk every road that bears your sign. Carry far-traded goods and the rarest temporal coin back to the shrine, that the road itself may be hallowed.",
+      "steps": [
+        {
+          "stepId": "temporal_tribute",
+          "stepName": "Temporal Tribute",
+          "requirements": [
+            {
+              "requirementId": "temporal_gears",
+              "displayName": "Temporal Gears",
+              "quantity": 20,
+              "type": "Exact",
+              "itemCodes": ["game:gear-temporal"]
+            }
+          ]
+        },
+        {
+          "stepId": "far_traded_goods",
+          "stepName": "Far-Traded Goods",
+          "requirements": [
+            {
+              "requirementId": "resin",
+              "displayName": "Resin",
+              "quantity": 40,
+              "type": "Exact",
+              "itemCodes": ["game:resin"]
+            },
+            {
+              "requirementId": "wool",
+              "displayName": "Wool",
+              "quantity": 60,
+              "type": "Exact",
+              "itemCodes": ["game:wool"]
+            }
+          ]
+        },
+        {
+          "stepId": "exotic_market",
+          "stepName": "Exotic Market",
+          "requirements": [
+            {
+              "requirementId": "cheeses",
+              "displayName": "Aged Cheeses",
+              "quantity": 30,
+              "type": "Category",
+              "itemCodes": ["game:cheese-*"]
+            },
+            {
+              "requirementId": "dried_fruits",
+              "displayName": "Dried Fruits (Any Type)",
+              "quantity": 80,
+              "type": "Category",
+              "itemCodes": ["game:driedfruit-*"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Bundles **slice 2** (Caravan content + stat keys, closes #428) with a **slice 1 follow-up** fixing 6 production sites that hardcoded the 5-domain set and therefore never showed Caravan.

## Slice 2 — Caravan content (#428)
- **Blessings** (`config/blessings/caravan.json`): root First Step → Trade branch (Haggler → Master Trader) / Wayfaring branch (Pathfinder → Pathwarden) → capstone `caravan_avatar_road` (special-effect `grants_caravan_shrine` consumed by #432) + 4-step religion ladder.
- **Offerings** (`config/offerings/caravan.json`): 11 entries across 3 tiers — travel rations, cordage, rusty gears, salt, wool, cheeses, breads, temporal gears, linen, resin.
- **Rituals** (`config/rituals/caravan.json`): Rite of the Open Road (T1→T2) + Pilgrimage Rite (T2→T3). Rusty/temporal gears stand in for "N trades completed" until a TradeCount requirement type exists.
- **Stat keys** in `VintageStoryStats` + `BlessingLoader.KnownStatKeys`: `traderBuyPriceMultiplier`, `traderSellPriceMultiplier`, `chunkDiscoveryFavorMultiplier`.
- **Loaders**: appended `caravan` to `BlessingLoader`, `OfferingLoader`, and `RitualLoader` domain-file arrays. (Issue only named BlessingLoader; offerings + rituals use parallel arrays — needed for them to load.)

## Slice 1 fix-up — hardcoded 5-domain arrays (refs #427)
Slice 1 added the enum, glyph, helper, and lang keys but missed several sites that hardcode the 5-domain set as a literal array. Caravan didn't render in the Blessings/Vows tab glyph row, the cross-deity summary, the favor command list, or the server network handler's per-domain loop.

Touched:
- `BlessingStateManager.AllDeities` — drives **both** the Blessings *and* Vows tab glyph rows (shared backing array).
- `DeitySelectorRenderer.Order` + `TabCount = 6` — selector strip width.
- `GuiDialogHandlers` blessing-texture preload loop ("Across the Domains" hover preload).
- `FavorCommands.AllDeities`, `BlessingNetworkHandler.AllDeities`.
- `CrossDeitySummaryRenderer.DomainShort` — \"R\" (Road) for Caravan.
- `BlessingStateManagerPantheonTests` — renamed `LoadBlessingStates_PopulatesAllFiveDeityBuckets` → `…AllSixDeityBuckets`, asserts the Caravan bucket too.

## Notes
- Avatar of the Road's `grants_caravan_shrine` special-effect string is the contract #432 will read; if renamed there, update here.
- No automated test coverage for the new JSON — load is verified by build + test pass; in-game smoke is the real check.

## Test plan
- [x] `dotnet build -c Debug` clean.
- [x] `dotnet test` — 2400/2400 pass (after fix-up to `PopulatesAllSixDeityBuckets`).
- [x] All three JSON files parse.
- [x] In-game: Personal Blessings tab shows Caravan glyph as a 6th button and renders the Caravan tree.
- [x] In-game: Vows of the Order tab shows Caravan glyph as a 6th button.
- [ ] In-game: prayer at a tier-1+ altar accepts a Caravan offering and consumes it correctly.
- [ ] In-game: tier-1 caravan shrine accepts Rite of the Open Road items and advances.
- [ ] Saves load cleanly (new stat keys round-trip).

Refs #545
Closes #428