### PR TITLE
feat(favor): add Caravan ExplorationFavorTracker (chunks + trader bonus)

### DIFF
--- a/DivineAscension.Tests/Systems/Favor/ExplorationFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/ExplorationFavorTrackerTests.cs
@@ -1,0 +1,177 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems;
+using DivineAscension.Systems.Favor;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Tests.Systems.Favor;
+
+[ExcludeFromCodeCoverage]
+public class ExplorationFavorTrackerTests
+{
+    private static ExplorationFavorTracker CreateTracker(
+        Mock<IEventService> mockEventService,
+        Mock<IWorldService> mockWorldService,
+        Mock<IPlayerProgressionDataManager> mockPlayerProgression,
+        Mock<IFavorSystem> mockFavor)
+    {
+        var mockLogger = new Mock<ILoggerWrapper>();
+        return new ExplorationFavorTracker(mockLogger.Object, mockEventService.Object,
+            mockWorldService.Object, mockPlayerProgression.Object, mockFavor.Object);
+    }
+
+    private static (Mock<IServerPlayer>, PlayerProgressionData) WirePlayer(
+        Mock<IPlayerProgressionDataManager> mockMgr,
+        string uid = "player-1")
+    {
+        var data = new PlayerProgressionData(uid);
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.SetupGet(p => p.PlayerUID).Returns(uid);
+        var d = data;
+        mockMgr.Setup(m => m.TryGetPlayerData(uid, out d!)).Returns(true);
+        return (mockPlayer, data);
+    }
+
+    [Fact]
+    public void DeityDomain_IsCaravan()
+    {
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(), TestFixtures.CreateMockFavorSystem());
+
+        Assert.Equal(DeityDomain.Caravan, tracker.DeityDomain);
+    }
+
+    [Fact]
+    public void Initialize_RegistersTwoSecondCallback()
+    {
+        var mockEventService = new Mock<IEventService>();
+        mockEventService.Setup(e => e.RegisterCallback(It.IsAny<Action<float>>(), It.IsAny<int>())).Returns(42L);
+
+        var tracker = CreateTracker(mockEventService, new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(), TestFixtures.CreateMockFavorSystem());
+        tracker.Initialize();
+
+        mockEventService.Verify(e => e.RegisterCallback(It.IsAny<Action<float>>(),
+            ExplorationFavorTracker.TICK_INTERVAL_MS), Times.Once);
+
+        tracker.Dispose();
+        mockEventService.Verify(e => e.UnregisterCallback(42L), Times.Once);
+    }
+
+    [Fact]
+    public void TryAwardChunkFavor_NewChunk_AwardsBaseFavorAndRecords()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, data) = WirePlayer(mockMgr);
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(), mockMgr, mockFavor);
+
+        var awarded = tracker.TryAwardChunkFavor(mockPlayer.Object, chunkKey: 7L, multiplier: 1.0f);
+
+        Assert.True(awarded);
+        Assert.True(data.HasDiscoveredChunk(7L));
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "discovered chunk",
+            ExplorationFavorTracker.BASE_CHUNK_FAVOR, DeityDomain.Caravan), Times.Once);
+    }
+
+    [Fact]
+    public void TryAwardChunkFavor_RevisitedChunk_NoFavor()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, data) = WirePlayer(mockMgr);
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(), mockMgr, mockFavor);
+
+        data.TryAddDiscoveredChunk(7L);
+
+        var awarded = tracker.TryAwardChunkFavor(mockPlayer.Object, 7L, 1.0f);
+
+        Assert.False(awarded);
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Never);
+    }
+
+    [Fact]
+    public void TryAwardChunkFavor_AppliesMultiplier()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, _) = WirePlayer(mockMgr);
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(), mockMgr, mockFavor);
+
+        tracker.TryAwardChunkFavor(mockPlayer.Object, 7L, multiplier: 2.5f);
+
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "discovered chunk",
+            ExplorationFavorTracker.BASE_CHUNK_FAVOR * 2.5f, DeityDomain.Caravan), Times.Once);
+    }
+
+    [Fact]
+    public void TryAwardChunkFavor_AtSoftCap_StopsAwarding()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, data) = WirePlayer(mockMgr);
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(), mockMgr, mockFavor);
+
+        for (long i = 0; i < PlayerProgressionData.DiscoveredChunksSoftCap; i++)
+        {
+            data.TryAddDiscoveredChunk(i);
+        }
+
+        var awarded = tracker.TryAwardChunkFavor(mockPlayer.Object, long.MaxValue, 1.0f);
+
+        Assert.False(awarded);
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Never);
+    }
+
+    [Fact]
+    public void TryAwardTraderBonus_FirstEncounter_AwardsTenFavor()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, data) = WirePlayer(mockMgr);
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(), mockMgr, mockFavor);
+
+        var awarded = tracker.TryAwardTraderBonus(mockPlayer.Object, traderEntityId: 555L);
+
+        Assert.True(awarded);
+        Assert.True(data.HasDiscoveredTrader(555L));
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "encountered trader",
+            ExplorationFavorTracker.TRADER_BONUS_FAVOR, DeityDomain.Caravan), Times.Once);
+    }
+
+    [Fact]
+    public void TryAwardTraderBonus_RepeatEncounter_NoFavor()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, _) = WirePlayer(mockMgr);
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(), mockMgr, mockFavor);
+
+        tracker.TryAwardTraderBonus(mockPlayer.Object, 555L);
+        var second = tracker.TryAwardTraderBonus(mockPlayer.Object, 555L);
+
+        Assert.False(second);
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Once);
+    }
+
+    [Fact]
+    public void PackChunkKey_IgnoresVerticalDifference()
+    {
+        // Verticals not represented in the key — moving up/down inside the same column should
+        // produce the same chunkKey (no double-award for digging straight down).
+        var a = ExplorationFavorTracker.PackChunkKey(5, -3);
+        var b = ExplorationFavorTracker.PackChunkKey(5, -3);
+        Assert.Equal(a, b);
+
+        var c = ExplorationFavorTracker.PackChunkKey(5, 7);
+        Assert.NotEqual(a, c);
+    }
+}

--- a/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
@@ -744,7 +744,7 @@ public class PlayerProgressionDataManagerTests
         Assert.Equal(150, loadedData.GetFavor(DeityDomain.Craft));
         Assert.Equal(200, loadedData.GetTotalFavorEarned(DeityDomain.Craft));
         _mockLogger.Verify(
-            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v7"))),
+            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v8"))),
             Times.Once()
         );
     }

--- a/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
@@ -34,8 +34,9 @@ public class PlayerProgressionDataTests
         Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
         Assert.Equal(0, data.GetTotalFavorEarned(DeityDomain.Craft));
         Assert.Equal(0f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft));
-        Assert.Equal(7, data.DataVersion); // v7: DiscoveredChunks (Caravan / Wayfaring)
+        Assert.Equal(8, data.DataVersion); // v8: DiscoveredTraderEntityIds (Caravan trader bonus)
         Assert.Equal(0, data.DiscoveredChunkCount);
+        Assert.Equal(0, data.DiscoveredTraderCount);
         Assert.Empty(data.UnlockedBlessings);
     }
 
@@ -422,6 +423,26 @@ public class PlayerProgressionDataTests
         Assert.False(data.TryAddDiscoveredChunk(long.MaxValue));
         Assert.False(data.HasDiscoveredChunk(long.MaxValue));
         Assert.Equal(PlayerProgressionData.DiscoveredChunksSoftCap, data.DiscoveredChunkCount);
+    }
+
+    [Fact]
+    public void TryAddDiscoveredTrader_NewId_ReturnsTrueAndStores()
+    {
+        var data = new PlayerProgressionData("player-123");
+
+        Assert.True(data.TryAddDiscoveredTrader(99L));
+        Assert.True(data.HasDiscoveredTrader(99L));
+        Assert.Equal(1, data.DiscoveredTraderCount);
+    }
+
+    [Fact]
+    public void TryAddDiscoveredTrader_Duplicate_ReturnsFalse()
+    {
+        var data = new PlayerProgressionData("player-123");
+        data.TryAddDiscoveredTrader(99L);
+
+        Assert.False(data.TryAddDiscoveredTrader(99L));
+        Assert.Equal(1, data.DiscoveredTraderCount);
     }
 
     [Fact]

--- a/DivineAscension/Constants/VintageStoryStats.cs
+++ b/DivineAscension/Constants/VintageStoryStats.cs
@@ -87,6 +87,7 @@ public static class VintageStoryStats
     // Divine Ascension Progression Stats
     public const string HolySiteFavorMultiplier = "holySiteFavorMultiplier";
     public const string HolySitePrestigeMultiplier = "holySitePrestigeMultiplier";
+    public const string ChunkDiscoveryFavorMultiplier = "chunkDiscoveryFavorMultiplier";
 
     #region CombatOverhaul Compatible Stats
 

--- a/DivineAscension/Systems/Favor/ExplorationFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/ExplorationFavorTracker.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems.Interfaces;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+using Vintagestory.GameContent;
+
+namespace DivineAscension.Systems.Favor;
+
+/// <summary>
+///     Caravan Wayfaring favor source. Awards favor when a player transitions into a
+///     previously-unvisited chunk, and a one-time bonus for the first encounter with each
+///     trader entity. Standing still in a chunk grants nothing.
+/// </summary>
+public class ExplorationFavorTracker(
+    ILoggerWrapper logger,
+    IEventService eventService,
+    IWorldService worldService,
+    IPlayerProgressionDataManager playerProgressionDataManager,
+    IFavorSystem favorSystem) : IFavorTracker, IDisposable
+{
+    internal const int TICK_INTERVAL_MS = 2000;
+    internal const float BASE_CHUNK_FAVOR = 1.0f;
+    internal const float TRADER_BONUS_FAVOR = 10.0f;
+    internal const float TRADER_SCAN_RADIUS = 8.0f;
+
+    private readonly IEventService
+        _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
+
+    private readonly IFavorSystem
+        _favorSystem = favorSystem ?? throw new ArgumentNullException(nameof(favorSystem));
+
+    private readonly ILoggerWrapper
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    private readonly IPlayerProgressionDataManager _playerProgressionDataManager =
+        playerProgressionDataManager ?? throw new ArgumentNullException(nameof(playerProgressionDataManager));
+
+    private readonly IWorldService
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+
+    private readonly Dictionary<string, long> _lastChunkKeyByPlayer = new();
+
+    private long _callbackId;
+
+    public DeityDomain DeityDomain { get; } = DeityDomain.Caravan;
+
+    public void Initialize()
+    {
+        _callbackId = _eventService.RegisterCallback(OnTick, TICK_INTERVAL_MS);
+        _logger.Debug($"{SystemConstants.LogPrefix} Initialized ExplorationFavorTracker");
+    }
+
+    public void Dispose()
+    {
+        _eventService.UnregisterCallback(_callbackId);
+        _lastChunkKeyByPlayer.Clear();
+    }
+
+    /// <summary>
+    ///     Packs 2D chunk coordinates into a single long. Y is intentionally ignored so vertical
+    ///     traversal doesn't multiply favor.
+    /// </summary>
+    internal static long PackChunkKey(int chunkX, int chunkZ) =>
+        ((long)chunkX << 32) | (uint)chunkZ;
+
+    private void OnTick(float deltaTime)
+    {
+        foreach (var p in _worldService.GetAllOnlinePlayers())
+        {
+            if (p is not IServerPlayer player || player.Entity == null) continue;
+            ProcessPlayer(player);
+        }
+    }
+
+    private void ProcessPlayer(IServerPlayer player)
+    {
+        var pos = player.Entity.Pos.AsBlockPos;
+        var chunkSize = GlobalConstants.ChunkSize;
+        var chunkX = pos.X / chunkSize;
+        var chunkZ = pos.Z / chunkSize;
+        var chunkKey = PackChunkKey(chunkX, chunkZ);
+
+        // Only act on a transition; standing still grants nothing.
+        if (_lastChunkKeyByPlayer.TryGetValue(player.PlayerUID, out var lastKey) && lastKey == chunkKey)
+        {
+            ScanForTrader(player);
+            return;
+        }
+
+        _lastChunkKeyByPlayer[player.PlayerUID] = chunkKey;
+        var multiplier = player.Entity?.Stats?.GetBlended(
+            VintageStoryStats.ChunkDiscoveryFavorMultiplier) ?? 1.0f;
+        TryAwardChunkFavor(player, chunkKey, multiplier);
+        ScanForTrader(player);
+    }
+
+    /// <summary>
+    ///     Credits chunk-discovery favor if this chunk is new to the player. Returns true when
+    ///     favor was awarded. Multiplier is taken from the player's blended
+    ///     <see cref="VintageStoryStats.ChunkDiscoveryFavorMultiplier"/> stat in the live path;
+    ///     tests inject it directly.
+    /// </summary>
+    internal bool TryAwardChunkFavor(IServerPlayer player, long chunkKey, float multiplier)
+    {
+        if (!_playerProgressionDataManager.TryGetPlayerData(player.PlayerUID, out var data) || data == null)
+            return false;
+
+        if (!data.TryAddDiscoveredChunk(chunkKey))
+            return false;
+
+        _favorSystem.AwardFavorForAction(player, "discovered chunk", BASE_CHUNK_FAVOR * multiplier,
+            DeityDomain.Caravan);
+        return true;
+    }
+
+    private void ScanForTrader(IServerPlayer player)
+    {
+        var pos = player.Entity.Pos.XYZ;
+        Entity? nearest = _worldService.World?.GetNearestEntity(pos, TRADER_SCAN_RADIUS, TRADER_SCAN_RADIUS,
+            e => e is EntityTrader);
+
+        if (nearest is EntityTrader trader)
+        {
+            TryAwardTraderBonus(player, trader.EntityId);
+        }
+    }
+
+    /// <summary>
+    ///     Credits the trader first-encounter bonus if this entity ID hasn't been credited yet.
+    ///     Returns true when favor was awarded.
+    /// </summary>
+    internal bool TryAwardTraderBonus(IServerPlayer player, long traderEntityId)
+    {
+        if (!_playerProgressionDataManager.TryGetPlayerData(player.PlayerUID, out var data) || data == null)
+            return false;
+
+        if (!data.TryAddDiscoveredTrader(traderEntityId))
+            return false;
+
+        _favorSystem.AwardFavorForAction(player, "encountered trader", TRADER_BONUS_FAVOR,
+            DeityDomain.Caravan);
+        return true;
+    }
+}

--- a/DivineAscension/Systems/FavorSystem.cs
+++ b/DivineAscension/Systems/FavorSystem.cs
@@ -48,6 +48,7 @@ public class FavorSystem : IFavorSystem
     private HuntingFavorTracker? _huntingFavorTracker;
     private MiningFavorTracker? _miningFavorTracker;
     private RuinDiscoveryFavorTracker? _ruinDiscoveryFavorTracker;
+    private ExplorationFavorTracker? _explorationFavorTracker;
     private SkinningFavorTracker? _skinningFavorTracker;
     private SmeltingFavorTracker? _smeltingFavorTracker;
     private StoneFavorTracker? _stoneFavorTracker;
@@ -152,6 +153,10 @@ public class FavorSystem : IFavorSystem
             _playerProgressionDataManager, this);
         _ruinDiscoveryFavorTracker.Initialize();
 
+        _explorationFavorTracker = new ExplorationFavorTracker(_logger, _eventService, _worldService,
+            _playerProgressionDataManager, this);
+        _explorationFavorTracker.Initialize();
+
         // Initialize patrol tracker only if dependencies were set
         if (_holySiteAreaTracker != null && _civilizationManager != null && _holySiteManager != null)
         {
@@ -167,11 +172,11 @@ public class FavorSystem : IFavorSystem
                 _messenger,
                 _eventService);
             _patrolFavorTracker.Initialize();
-            _logger.Notification("[DivineAscension] Initialized 11 favor trackers (including patrol)");
+            _logger.Notification("[DivineAscension] Initialized 12 favor trackers (including patrol)");
         }
         else
         {
-            _logger.Notification("[DivineAscension] Initialized 10 favor trackers (patrol disabled - missing dependencies)");
+            _logger.Notification("[DivineAscension] Initialized 11 favor trackers (patrol disabled - missing dependencies)");
         }
     }
 
@@ -189,6 +194,7 @@ public class FavorSystem : IFavorSystem
         _stoneFavorTracker?.Dispose();
         _conquestFavorTracker?.Dispose();
         _ruinDiscoveryFavorTracker?.Dispose();
+        _explorationFavorTracker?.Dispose();
         _patrolFavorTracker?.Dispose();
     }
 

--- a/DivineAscension/Systems/PlayerProgressionData.cs
+++ b/DivineAscension/Systems/PlayerProgressionData.cs
@@ -90,13 +90,19 @@ public class PlayerProgressionData
     ///     Data version (internal bookkeeping only — Pantheon 2.0 no longer carries cross-version save migrations).
     /// </summary>
     [ProtoMember(104)]
-    public int DataVersion { get; set; } = 7;
+    public int DataVersion { get; set; } = 8;
 
     /// <summary>
     ///     Soft cap on tracked discovered chunks per player. Past this, <see cref="TryAddDiscoveredChunk"/>
     ///     stops awarding to bound memory growth for explorers who roam tens of thousands of chunks.
     /// </summary>
     public const int DiscoveredChunksSoftCap = 100_000;
+
+    /// <summary>
+    ///     Soft cap on tracked trader entity IDs per player. Mirrors <see cref="DiscoveredChunksSoftCap"/>
+    ///     but for the Caravan first-trader-encounter bonus.
+    /// </summary>
+    public const int DiscoveredTradersSoftCap = 10_000;
 
     /// <summary>
     ///     Accumulated fractional favor per deity domain (not yet awarded) for passive generation.
@@ -388,6 +394,53 @@ public class PlayerProgressionData
     ///     (no retroactive rewards).
     /// </summary>
     [ProtoMember(116)] private HashSet<long> _discoveredChunks = new();
+
+    /// <summary>
+    ///     Set of trader entity IDs the player has earned the first-encounter bonus from
+    ///     (Caravan Wayfaring branch).
+    /// </summary>
+    [ProtoMember(117)] private HashSet<long> _discoveredTraderEntityIds = new();
+
+    /// <summary>
+    ///     Count of trader entities already credited for first-encounter bonus (thread-safe).
+    /// </summary>
+    public int DiscoveredTraderCount
+    {
+        get
+        {
+            lock (Lock)
+            {
+                return _discoveredTraderEntityIds.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Checks if the player has already encountered a trader entity (thread-safe).
+    /// </summary>
+    public bool HasDiscoveredTrader(long entityId)
+    {
+        lock (Lock)
+        {
+            return _discoveredTraderEntityIds.Contains(entityId);
+        }
+    }
+
+    /// <summary>
+    ///     Records a trader-entity first encounter. Returns <c>true</c> if newly added and the caller
+    ///     should award the bonus. <c>false</c> if already known, or if <see cref="DiscoveredTradersSoftCap"/>
+    ///     has been reached. Thread-safe.
+    /// </summary>
+    public bool TryAddDiscoveredTrader(long entityId)
+    {
+        lock (Lock)
+        {
+            if (_discoveredTraderEntityIds.Count >= DiscoveredTradersSoftCap)
+                return false;
+
+            return _discoveredTraderEntityIds.Add(entityId);
+        }
+    }
 
     /// <summary>
     ///     Count of discovered chunks (thread-safe).


### PR DESCRIPTION
## Summary
- New `Systems/Favor/ExplorationFavorTracker.cs` — ~2s tick, per-player last-chunk dict, awards `BASE_CHUNK_FAVOR` (scaled by `chunkDiscoveryFavorMultiplier` stat) on transition into a chunk not already in `DiscoveredChunks` (gated by #430's `TryAddDiscoveredChunk`).
- Chunk key is 2D `(x,z)` packed — vertical traversal doesn't double-award.
- Trader first-encounter bonus: `TRADER_BONUS_FAVOR = 10`, tracked by `EntityId` in a new persisted `HashSet<long>` on `PlayerProgressionData` (`ProtoMember(117)`, soft cap `10_000`). `DataVersion` 7 → 8.
- New stat key `VintageStoryStats.ChunkDiscoveryFavorMultiplier` — no-op until #428 publishes the blessing JSON, then transparently scales.
- Registered in `FavorSystem.Initialize` / `Dispose` alongside the other 10–11 trackers.

**Scope note**: issue #431 also listed a +5 translocator-discovery bonus. Skipped per maintainer call to keep the surface area small and let the base rate playtest first; can be a follow-up.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` clean
- [x] `dotnet test` — 2415/2415 pass
- [x] New tests in `ExplorationFavorTrackerTests`:
  - Domain = Caravan, init registers 2s callback, dispose unregisters
  - New chunk → awards `BASE_CHUNK_FAVOR`
  - Revisited chunk → no award
  - Multiplier applied to awarded amount
  - At soft cap → stops awarding
  - First trader encounter → +10 favor; repeat → no favor
  - `PackChunkKey` ignores vertical (no double-award for digging)
- [x] `PlayerProgressionData` proto roundtrip preserves the trader set; `DataVersion` assertion bumped to 8

Closes #431