### PR TITLE
feat(favor): Caravan TraderTransactionFavorTracker + TraderPatches (Slice 3)

### DIFF
--- a/DivineAscension.Tests/Systems/Favor/TraderTransactionFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/TraderTransactionFavorTrackerTests.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems.Favor;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Systems.Patches;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Tests.Systems.Favor;
+
+[ExcludeFromCodeCoverage]
+public class TraderTransactionFavorTrackerTests
+{
+    private static TraderTransactionFavorTracker CreateTracker(
+        Mock<IWorldService> mockWorldService,
+        Mock<IFavorSystem> mockFavor)
+    {
+        var mockLogger = new Mock<ILoggerWrapper>();
+        return new TraderTransactionFavorTracker(mockLogger.Object, mockWorldService.Object, mockFavor.Object);
+    }
+
+    [Fact]
+    public void DeityDomain_IsCaravan()
+    {
+        var tracker = CreateTracker(new Mock<IWorldService>(), TestFixtures.CreateMockFavorSystem());
+
+        Assert.Equal(DeityDomain.Caravan, tracker.DeityDomain);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]      // empty trade — no favor
+    [InlineData(5, 2)]      // sub-divisor — base only
+    [InlineData(10, 3)]     // exactly divisor — base + 1
+    [InlineData(50, 7)]     // 2 + 5
+    [InlineData(180, 20)]   // 2 + 18 = 20 (at cap boundary)
+    [InlineData(200, 20)]   // would be 22 — clamped to cap
+    [InlineData(10000, 20)] // whale trade — clamped
+    public void ComputeFavor_FollowsBaseAndCap(int valueInGears, int expected)
+    {
+        Assert.Equal(expected, TraderTransactionFavorTracker.ComputeFavor(valueInGears));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void ComputeFavor_NegativeValue_ReturnsZero(int valueInGears)
+    {
+        Assert.Equal(0, TraderTransactionFavorTracker.ComputeFavor(valueInGears));
+    }
+
+    [Fact]
+    public void HandleTraderTransaction_AwardsCaravanFavorWithTradeAction()
+    {
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var tracker = CreateTracker(new Mock<IWorldService>(), mockFavor);
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.SetupGet(p => p.PlayerName).Returns("Tester");
+
+        tracker.HandleTraderTransaction(mockPlayer.Object, valueInGears: 50);
+
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "trade",
+            7f /* base 2 + 50/10 */, DeityDomain.Caravan), Times.Once);
+    }
+
+    [Fact]
+    public void HandleTraderTransaction_WhaleTrade_ClampedToCap()
+    {
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var tracker = CreateTracker(new Mock<IWorldService>(), mockFavor);
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.SetupGet(p => p.PlayerName).Returns("Whale");
+
+        tracker.HandleTraderTransaction(mockPlayer.Object, valueInGears: 9_999);
+
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "trade",
+            (float)TraderTransactionFavorTracker.MaxFavorPerTrade, DeityDomain.Caravan), Times.Once);
+    }
+
+    [Fact]
+    public void HandleTraderTransaction_ZeroValue_NoAward()
+    {
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var tracker = CreateTracker(new Mock<IWorldService>(), mockFavor);
+        var mockPlayer = new Mock<IServerPlayer>();
+
+        tracker.HandleTraderTransaction(mockPlayer.Object, valueInGears: 0);
+
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Never);
+    }
+
+    [Fact]
+    public void HandleTraderTransaction_NonServerPlayer_NoAward()
+    {
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var tracker = CreateTracker(new Mock<IWorldService>(), mockFavor);
+        // IPlayer that is *not* IServerPlayer — guards the server-authoritative gate.
+        var mockClient = new Mock<IPlayer>();
+
+        tracker.HandleTraderTransaction(mockClient.Object, valueInGears: 100);
+
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Never);
+    }
+
+    // Note: Initialize/Dispose subscribe/unsubscribe from the static TraderPatches event,
+    // which can't be invoked from outside the declaring type. The HandleTraderTransaction
+    // tests above cover the favor-award path the subscription routes to.
+}

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -347,6 +347,7 @@ public class DivineAscensionModSystem : ModSystem
         BlockCropPatches.ClearSubscribers();
         FlowerPatches.ClearSubscribers();
         MushroomPatches.ClearSubscribers();
+        TraderPatches.ClearSubscribers();
     }
 
     #region Server Networking

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -74,6 +74,7 @@ public static class DivineAscensionSystemInitializer
         MushroomPatches.ClearSubscribers();
         SkinningPatches.ClearSubscribers();
         SkinningPatches.Initialize(api);
+        TraderPatches.ClearSubscribers();
         BlockBehaviorStone.ClearSubscribers();
         BlockBehaviorOre.ClearSubscribers();
         CollectibleBehaviorChiselTracking.ClearSubscribers();

--- a/DivineAscension/Systems/Favor/TraderTransactionFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/TraderTransactionFavorTracker.cs
@@ -1,0 +1,72 @@
+using System;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Systems.Patches;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Favor;
+
+/// <summary>
+///     Caravan Trade favor source. Awards Caravan favor on completed NPC trader transactions.
+///     Per-trade favor follows <c>base + floor(value / DivisorGears)</c>, capped at
+///     <see cref="MaxFavorPerTrade"/> so a single whale trade can't ladder a player to Avatar.
+/// </summary>
+public class TraderTransactionFavorTracker(
+    ILoggerWrapper logger,
+    IWorldService worldService,
+    IFavorSystem favorSystem) : IFavorTracker, IDisposable
+{
+    internal const int BaseFavor = 2;
+    internal const int DivisorGears = 10;
+    internal const int MaxFavorPerTrade = 20;
+
+    private readonly IFavorSystem _favorSystem = favorSystem ?? throw new ArgumentNullException(nameof(favorSystem));
+    private readonly ILoggerWrapper _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    private readonly IWorldService
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+
+    public void Dispose()
+    {
+        TraderPatches.OnTraderTransaction -= HandleTraderTransaction;
+        _logger.Debug("[DivineAscension] TraderTransactionFavorTracker disposed");
+    }
+
+    public DeityDomain DeityDomain { get; } = DeityDomain.Caravan;
+
+    public void Initialize()
+    {
+        TraderPatches.OnTraderTransaction += HandleTraderTransaction;
+        _logger.Notification("[DivineAscension] TraderTransactionFavorTracker initialized");
+    }
+
+    /// <summary>
+    ///     Awards Caravan favor for a completed NPC trade. Exposed for tests so we don't have
+    ///     to drive a Harmony patch in CI.
+    /// </summary>
+    internal void HandleTraderTransaction(IPlayer player, int valueInGears)
+    {
+        if (player is not IServerPlayer serverPlayer) return;
+        if (valueInGears <= 0) return;
+
+        var favor = ComputeFavor(valueInGears);
+        _favorSystem.AwardFavorForAction(serverPlayer, "trade", favor, DeityDomain.Caravan);
+        _logger.Debug(
+            $"[TraderTransactionFavorTracker] Awarded {favor} favor to {serverPlayer.PlayerName} for NPC trade worth {valueInGears} gears");
+    }
+
+    /// <summary>
+    ///     <c>BaseFavor + floor(value / DivisorGears)</c>, clamped to
+    ///     <see cref="MaxFavorPerTrade"/>. The clamp is the anti-whale guard — without it,
+    ///     a single 1000-gear swap would dwarf the favor income of a normal trader run.
+    /// </summary>
+    internal static int ComputeFavor(int valueInGears)
+    {
+        if (valueInGears <= 0) return 0;
+        var raw = BaseFavor + valueInGears / DivisorGears;
+        return raw > MaxFavorPerTrade ? MaxFavorPerTrade : raw;
+    }
+}

--- a/DivineAscension/Systems/FavorSystem.cs
+++ b/DivineAscension/Systems/FavorSystem.cs
@@ -53,6 +53,7 @@ public class FavorSystem : IFavorSystem
     private SmeltingFavorTracker? _smeltingFavorTracker;
     private StoneFavorTracker? _stoneFavorTracker;
     private PatrolFavorTracker? _patrolFavorTracker;
+    private TraderTransactionFavorTracker? _traderTransactionFavorTracker;
 
     public FavorSystem(ILoggerWrapper logger,
         IEventService eventService,
@@ -157,6 +158,9 @@ public class FavorSystem : IFavorSystem
             _playerProgressionDataManager, this);
         _explorationFavorTracker.Initialize();
 
+        _traderTransactionFavorTracker = new TraderTransactionFavorTracker(_logger, _worldService, this);
+        _traderTransactionFavorTracker.Initialize();
+
         // Initialize patrol tracker only if dependencies were set
         if (_holySiteAreaTracker != null && _civilizationManager != null && _holySiteManager != null)
         {
@@ -172,11 +176,11 @@ public class FavorSystem : IFavorSystem
                 _messenger,
                 _eventService);
             _patrolFavorTracker.Initialize();
-            _logger.Notification("[DivineAscension] Initialized 12 favor trackers (including patrol)");
+            _logger.Notification("[DivineAscension] Initialized 13 favor trackers (including patrol)");
         }
         else
         {
-            _logger.Notification("[DivineAscension] Initialized 11 favor trackers (patrol disabled - missing dependencies)");
+            _logger.Notification("[DivineAscension] Initialized 12 favor trackers (patrol disabled - missing dependencies)");
         }
     }
 
@@ -195,6 +199,7 @@ public class FavorSystem : IFavorSystem
         _conquestFavorTracker?.Dispose();
         _ruinDiscoveryFavorTracker?.Dispose();
         _explorationFavorTracker?.Dispose();
+        _traderTransactionFavorTracker?.Dispose();
         _patrolFavorTracker?.Dispose();
     }
 
@@ -345,6 +350,11 @@ public class FavorSystem : IFavorSystem
                 actionLower.Contains("brick") ||
                 actionLower.Contains("clay") ||
                 actionLower.Contains("carving"),
+
+            DeityDomain.Caravan =>
+                actionLower.Contains("trade") ||
+                actionLower.Contains("discovered chunk") ||
+                actionLower.Contains("encountered trader"),
 
             _ => false
         };

--- a/DivineAscension/Systems/Patches/TraderPatches.cs
+++ b/DivineAscension/Systems/Patches/TraderPatches.cs
@@ -1,0 +1,95 @@
+using System;
+using HarmonyLib;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.GameContent;
+
+namespace DivineAscension.Systems.Patches;
+
+/// <summary>
+///     Harmony patch on <c>InventoryTrader.TryBuySell</c> (1.22) raising an event on every
+///     successful NPC trade. The method is internal but Harmony patches it by name. Prefix
+///     snapshots the cart values in gears; postfix emits only on
+///     <see cref="EnumTransactionResult.Success"/> so cancelled/insufficient-funds attempts
+///     don't grant favor.
+/// </summary>
+[HarmonyPatch]
+public static class TraderPatches
+{
+    /// <summary>
+    ///     Fires once per completed NPC transaction with (player, total value in rusty gears).
+    ///     <para>
+    ///         Total value sums the price columns of every non-empty cart slot — both items the
+    ///         player buys from the trader and items the player sells to the trader. The value
+    ///         is the trader's gear quote, not the underlying item's rarity.
+    ///     </para>
+    /// </summary>
+    public static event Action<IPlayer, int>? OnTraderTransaction;
+
+    /// <summary>
+    ///     Drops all subscribers; called from <c>DivineAscensionSystemInitializer</c> on
+    ///     server start/reload so stale handlers from a previous load don't accumulate.
+    /// </summary>
+    public static void ClearSubscribers()
+    {
+        OnTraderTransaction = null;
+    }
+
+    [HarmonyPatch(typeof(InventoryTrader), "TryBuySell")]
+    [HarmonyPrefix]
+    public static void Prefix_TryBuySell(InventoryTrader __instance, IPlayer buyingPlayer, out int __state)
+    {
+        __state = 0;
+        try
+        {
+            __state = SnapshotCartValue(__instance);
+        }
+        catch
+        {
+            // Never throw from a Harmony prefix — a failed snapshot just means no favor.
+            __state = 0;
+        }
+    }
+
+    [HarmonyPatch(typeof(InventoryTrader), "TryBuySell")]
+    [HarmonyPostfix]
+    public static void Postfix_TryBuySell(IPlayer buyingPlayer, EnumTransactionResult __result, int __state)
+    {
+        if (__result != EnumTransactionResult.Success) return;
+        if (__state <= 0) return;
+        if (buyingPlayer is not { } player) return;
+
+        OnTraderTransaction?.Invoke(player, __state);
+    }
+
+    /// <summary>
+    ///     Walks both cart sides and returns the trader-priced gear value of the trade.
+    ///     Mirrors the math in <c>InventoryTrader.GetTraderAssets</c> from 1.22.
+    /// </summary>
+    private static int SnapshotCartValue(InventoryTrader inv)
+    {
+        var total = 0;
+
+        for (var i = 0; i < 4; i++)
+        {
+            var buyingCartSlot = inv.GetBuyingCartSlot(i);
+            var stack = buyingCartSlot?.Itemstack;
+            var tradeItem = buyingCartSlot?.TradeItem;
+            if (stack == null || tradeItem?.Stack == null || tradeItem.Stack.StackSize <= 0) continue;
+            total += tradeItem.Price * (stack.StackSize / tradeItem.Stack.StackSize);
+        }
+
+        for (var i = 0; i < 4; i++)
+        {
+            var sellingCartSlot = inv.GetSellingCartSlot(i);
+            var stack = sellingCartSlot?.Itemstack;
+            if (stack == null) continue;
+            var conditions = inv.GetBuyingConditionsSlot(stack);
+            var tradeItem = conditions?.TradeItem;
+            if (tradeItem?.Stack == null || tradeItem.Stack.StackSize <= 0) continue;
+            total += tradeItem.Price * (stack.StackSize / tradeItem.Stack.StackSize);
+        }
+
+        return total;
+    }
+}


### PR DESCRIPTION
Central verb for the Caravan domain: completing an NPC trade awards Caravan favor, so Tier-1 blessings become reachable through normal play. Closes Phase 1.

## Summary
- `TraderPatches.cs` — Harmony prefix on `InventoryTrader.TryBuySell` snapshots cart value in rusty gears (mirrors `GetTraderAssets` math: walks both buying-cart and selling-cart slots, multiplies `Price` by effective stack count). Postfix raises `OnTraderTransaction(player, valueInGears)` only on `EnumTransactionResult.Success`. Prefix catches any snapshot failure → returns 0 so a bad cart state can never cancel a trade.
- `TraderTransactionFavorTracker.cs` — `IFavorTracker` for `DeityDomain.Caravan`. Formula: `base 2 + floor(value / 10)`, clamped at **20 favor per trade** (whale-trade guard). Awards via `FavorSystem.AwardFavorForAction(player, "trade", …, Caravan)` so patron 1.5× still applies.
- `FavorSystem` — owns the 13th tracker (init + dispose match siblings). `ShouldAwardPrestigeForActivity` Caravan case added (`trade`, `discovered chunk`, `encountered trader`).
- `ClearSubscribers` wired into both server-reload init (`DivineAscensionSystemInitializer`) and `ModSystem.Dispose`.

## Recon notes
1.22 method is `InventoryTrader.TryBuySell(IPlayer)` returning `EnumTransactionResult`, **not** `PerformTrade` (issue body's hint was outdated). Method is `internal` — Harmony patches it by name.

## Why Harmony, not JSON patches
JSON patches attach behaviors to blocks/items/entities; they don't intercept compiled C# methods. The only JSON-attachable alternatives (a `CollectibleBehavior` overriding `OnDidTrade` on every collectible, or an `EntityBehavior` on `EntityTrader`) fire per-stack-moved (not per-transaction) and lose the value-total context needed for the cap formula. Convention in this repo: JSON patches for content/behaviors, Harmony for code-only events (see `AnvilPatches`, `StonePatches`, `CookingPatches`).

## Test plan
- [x] `dotnet build -c Debug` clean.
- [x] `dotnet test` — 2429/2429 pass (14 new in `TraderTransactionFavorTrackerTests`).
- [x] Favor formula table covers: zero, sub-divisor, exactly-divisor, mid-range, at-cap boundary, over-cap, whale (10000).
- [x] Server-authoritative guard: non-`IServerPlayer` invocation grants nothing.
- [ ] In-game: complete an NPC trade → Caravan favor appears in `/favor info` for the trading player; pre-trade balance + computed delta match.
- [ ] In-game: cancelling a trade (Goodbye! before Buy/Sell) grants no favor.
- [ ] In-game: a single high-value (>180 gears) swap awards exactly 20 favor (cap respected).
- [ ] In-game: patron-Caravan player gets 1.5× the favor of a non-patron player on identical trades.

Refs #545
Closes #429