### PR TITLE
feat(civ): add trade_hub Caravan milestone

### DIFF
--- a/DivineAscension.Tests/Systems/CivilizationMilestoneManagerTests.cs
+++ b/DivineAscension.Tests/Systems/CivilizationMilestoneManagerTests.cs
@@ -493,6 +493,59 @@ public class CivilizationMilestoneManagerTests
 
     #endregion
 
+    #region RecordNpcTrade Tests
+
+    [Fact]
+    public void RecordNpcTrade_IncrementsCount()
+    {
+        var civId = "test-civ-trade-1";
+        var civ = CreateTestCivilization(civId);
+        civ.NpcTradeCount = 12;
+
+        _mockCivilizationManager.Setup(c => c.GetCivilization(civId)).Returns(civ);
+        _mockMilestoneLoader.Setup(m => m.GetAllMilestones()).Returns(new List<MilestoneDefinition>());
+
+        _milestoneManager.RecordNpcTrade(civId);
+
+        Assert.Equal(13, civ.NpcTradeCount);
+    }
+
+    [Fact]
+    public void RecordNpcTrade_TriggersTradeHubMilestone()
+    {
+        var civId = "test-civ-trade-2";
+        var civ = CreateTestCivilization(civId);
+        civ.NpcTradeCount = 49; // one more trade completes the 50 threshold
+
+        var milestone = new MilestoneDefinition(
+            "trade_hub",
+            "The Crossroads Endured",
+            "Complete 50 NPC trader transactions",
+            MilestoneType.Minor,
+            new MilestoneTrigger(MilestoneTriggerType.NpcTradeCount, 50),
+            0,
+            300);
+
+        _mockCivilizationManager.Setup(c => c.GetCivilization(civId)).Returns(civ);
+        _mockMilestoneLoader.Setup(m => m.GetAllMilestones()).Returns(new List<MilestoneDefinition> { milestone });
+
+        _milestoneManager.RecordNpcTrade(civId);
+
+        Assert.Contains("trade_hub", civ.CompletedMilestones);
+    }
+
+    [Fact]
+    public void RecordNpcTrade_UnknownCiv_NoThrow()
+    {
+        _mockCivilizationManager.Setup(c => c.GetCivilization(It.IsAny<string>())).Returns((Civilization?)null);
+
+        var ex = Record.Exception(() => _milestoneManager.RecordNpcTrade("missing"));
+
+        Assert.Null(ex);
+    }
+
+    #endregion
+
     #region GetMilestoneProgress Tests
 
     [Fact]

--- a/DivineAscension/Data/CivilizationData.cs
+++ b/DivineAscension/Data/CivilizationData.cs
@@ -151,6 +151,13 @@ public class Civilization
     public int WarKillCount { get; set; } = 0;
 
     /// <summary>
+    ///     Cumulative completed NPC trader transactions across all members
+    ///     (for trade_hub milestone — Caravan domain). Defaults to 0 for legacy saves.
+    /// </summary>
+    [ProtoMember(24)]
+    public int NpcTradeCount { get; set; } = 0;
+
+    /// <summary>
     ///     In-game month captured at civ creation; drives the annual
     ///     Founding Day holiday. 0 for pre-feature civilizations (no migration).
     /// </summary>

--- a/DivineAscension/GUI/UI/Renderers/Civilization/MilestonePhrases.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/MilestonePhrases.cs
@@ -31,6 +31,7 @@ internal static class MilestonePhrases
         ["HolySiteTier"] = "tiers attained",
         ["DiplomaticRelationship"] = "accords sealed",
         ["AllMajorMilestones"] = "great deeds set down",
+        ["NpcTradeCount"] = "trades sealed at the post",
     };
 
     /// <summary>

--- a/DivineAscension/Models/MilestoneTrigger.cs
+++ b/DivineAscension/Models/MilestoneTrigger.cs
@@ -70,5 +70,11 @@ public enum MilestoneTriggerType
     /// <summary>
     ///     Complete all other major milestones
     /// </summary>
-    AllMajorMilestones
+    AllMajorMilestones,
+
+    /// <summary>
+    ///     Cumulative completed NPC trader transactions across the civilization
+    ///     (trade_hub milestone — Caravan domain).
+    /// </summary>
+    NpcTradeCount
 }

--- a/DivineAscension/Services/MilestoneDefinitionLoader.cs
+++ b/DivineAscension/Services/MilestoneDefinitionLoader.cs
@@ -243,6 +243,7 @@ public class MilestoneDefinitionLoader : IMilestoneDefinitionLoader
             "holy_site_tier" => (type = MilestoneTriggerType.HolySiteTier) == type,
             "diplomatic_relationship" => (type = MilestoneTriggerType.DiplomaticRelationship) == type,
             "all_major_milestones" => (type = MilestoneTriggerType.AllMajorMilestones) == type,
+            "npc_trade_count" => (type = MilestoneTriggerType.NpcTradeCount) == type,
             _ => false
         };
     }

--- a/DivineAscension/Systems/CivilizationMilestoneManager.cs
+++ b/DivineAscension/Systems/CivilizationMilestoneManager.cs
@@ -78,6 +78,9 @@ public class CivilizationMilestoneManager : ICivilizationMilestoneManager
         _religionManager.OnMemberAdded += HandleMemberAdded;
         _religionManager.OnMemberRemoved += HandleMemberRemoved;
 
+        // Subscribe to NPC trader transactions for the trade_hub milestone (Caravan)
+        Patches.TraderPatches.OnTraderTransaction += HandleTraderTransaction;
+
         _logger.Notification("[DivineAscension] Civilization Milestone Manager initialized");
     }
 
@@ -118,6 +121,8 @@ public class CivilizationMilestoneManager : ICivilizationMilestoneManager
 
         if (_pvpManager != null)
             _pvpManager.OnWarKill -= HandleWarKill;
+
+        Patches.TraderPatches.OnTraderTransaction -= HandleTraderTransaction;
 
         OnMilestoneUnlocked = null;
         OnRankIncreased = null;
@@ -266,6 +271,19 @@ public class CivilizationMilestoneManager : ICivilizationMilestoneManager
     }
 
     /// <inheritdoc />
+    public void RecordNpcTrade(string civId)
+    {
+        var civ = _civilizationManager.GetCivilization(civId);
+        if (civ == null)
+            return;
+
+        civ.NpcTradeCount++;
+        _logger.Debug($"[DivineAscension MilestoneManager] NPC trade recorded for {civ.Name}: {civ.NpcTradeCount} total");
+
+        CheckMilestones(civId);
+    }
+
+    /// <inheritdoc />
     public int GetBonusHolySiteSlots(string civId)
     {
         return GetActiveBonuses(civId).BonusHolySiteSlots;
@@ -325,6 +343,20 @@ public class CivilizationMilestoneManager : ICivilizationMilestoneManager
     {
         _logger.Debug($"[DivineAscension MilestoneManager] War kill event received for civilization {civId}");
         RecordWarKill(civId);
+    }
+
+    private void HandleTraderTransaction(Vintagestory.API.Common.IPlayer player, int valueInGears)
+    {
+        if (string.IsNullOrEmpty(player?.PlayerUID))
+            return;
+
+        var religion = _religionManager.GetPlayerReligion(player.PlayerUID);
+        if (religion == null) return;
+
+        var civ = _civilizationManager.GetCivilizationByReligion(religion.ReligionUID);
+        if (civ == null) return;
+
+        RecordNpcTrade(civ.CivId);
     }
 
     private void HandleMemberAdded(string religionUID, string playerUID)
@@ -446,6 +478,7 @@ public class CivilizationMilestoneManager : ICivilizationMilestoneManager
             MilestoneTriggerType.HolySiteTier => GetHighestHolySiteTier(civ),
             MilestoneTriggerType.DiplomaticRelationship => GetDiplomaticRelationshipCount(civId),
             MilestoneTriggerType.AllMajorMilestones => GetCompletedMajorMilestoneCount(civ),
+            MilestoneTriggerType.NpcTradeCount => civ.NpcTradeCount,
             _ => 0
         };
     }

--- a/DivineAscension/Systems/Interfaces/ICivilizationMilestoneManager.cs
+++ b/DivineAscension/Systems/Interfaces/ICivilizationMilestoneManager.cs
@@ -87,6 +87,12 @@ public interface ICivilizationMilestoneManager
     void RecordWarKill(string civId);
 
     /// <summary>
+    ///     Records a completed NPC trader transaction for the trade_hub milestone (Caravan).
+    /// </summary>
+    /// <param name="civId">Civilization ID of the trading player.</param>
+    void RecordNpcTrade(string civId);
+
+    /// <summary>
     ///     Gets the bonus holy site slots granted by milestones
     /// </summary>
     /// <param name="civId">Civilization ID</param>

--- a/DivineAscension/assets/divineascension/config/milestones.json
+++ b/DivineAscension/assets/divineascension/config/milestones.json
@@ -114,6 +114,24 @@
       "prestigePayout": 200
     },
     {
+      "id": "trade_hub",
+      "name": "The Crossroads Endured",
+      "description": "Complete 50 NPC trader transactions across the civilization.",
+      "chronicleLine": "Fifty trades had been sealed at the civilization's posts.",
+      "type": "minor",
+      "trigger": {
+        "type": "npc_trade_count",
+        "threshold": 50
+      },
+      "rankReward": 0,
+      "prestigePayout": 300,
+      "temporaryBenefit": {
+        "type": "favor_multiplier",
+        "amount": 0.05,
+        "durationDays": 7
+      }
+    },
+    {
       "id": "war_heroes",
       "name": "Fifty Spears, Fifty Names",
       "description": "Achieve 50 PvP kills during active wars.",


### PR DESCRIPTION
## Summary
- Picks **option 2** from #436: new Caravan-specific `trade_hub` minor milestone instead of bumping `united_front` to 5 domains. Existing civs keep their milestone state; legacy `NpcTradeCount` defaults to 0.
- New `MilestoneTriggerType.NpcTradeCount` + `"npc_trade_count"` JSON mapping.
- `CivilizationData.NpcTradeCount` (`ProtoMember(24)`) — civ-wide cumulative counter.
- `ICivilizationMilestoneManager.RecordNpcTrade(civId)` mirrors `RecordWarKill`. `CivilizationMilestoneManager` subscribes to `TraderPatches.OnTraderTransaction` and resolves the player's civ via religion lookup.
- `trade_hub` JSON: 50 NPC trades, minor type, +5% favor for 7 days (`temporaryBenefit`), 300 prestige.
- Chronicle phrase: "trades sealed at the post".
- Marked minor (not major) so the `cultural_monument` "all 5 majors" gate is unaffected.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` clean
- [x] `dotnet test` — 2432/2432 pass
- [x] New `RecordNpcTrade` tests: increments count, triggers at 50 threshold, no-throw on unknown civ
- [x] Existing v4 saves: `CivilizationData.NpcTradeCount` is a new optional ProtoMember — deserializes to default 0 with no migration needed

Closes #436