### PR TITLE
feat(config): add Caravan balance knobs to GameBalanceConfig

### DIFF
--- a/DivineAscension.Tests/Configuration/GameBalanceConfigCaravanTests.cs
+++ b/DivineAscension.Tests/Configuration/GameBalanceConfigCaravanTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+
+namespace DivineAscension.Tests.Configuration;
+
+[ExcludeFromCodeCoverage]
+public class GameBalanceConfigCaravanTests
+{
+    [Fact]
+    public void Defaults_MatchTrackerHardcodedValues()
+    {
+        var config = new GameBalanceConfig();
+
+        // Defaults must match the compiled-in tracker constants so legacy configs
+        // (or no-config scenarios) behave identically to pre-knob behaviour.
+        Assert.Equal(1.0f, config.CaravanTradeFavorMultiplier);
+        Assert.Equal(1.0f, config.CaravanExplorationFavorMultiplier);
+        Assert.Equal(1.0f, config.CaravanTradeTableFavorMultiplier);
+        Assert.Equal(20, config.CaravanPerTradeFavorCap);
+    }
+
+    [Fact]
+    public void Validate_AcceptsDefaults()
+    {
+        var ex = Record.Exception(() => new GameBalanceConfig().Validate());
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-0.5f)]
+    public void Validate_RejectsNonPositiveTradeMultiplier(float value)
+    {
+        var config = new GameBalanceConfig { CaravanTradeFavorMultiplier = value };
+        Assert.Throws<InvalidOperationException>(() => config.Validate());
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    public void Validate_RejectsNonPositiveExplorationMultiplier(float value)
+    {
+        var config = new GameBalanceConfig { CaravanExplorationFavorMultiplier = value };
+        Assert.Throws<InvalidOperationException>(() => config.Validate());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(1001)]
+    public void Validate_RejectsOutOfRangePerTradeCap(int value)
+    {
+        var config = new GameBalanceConfig { CaravanPerTradeFavorCap = value };
+        Assert.Throws<InvalidOperationException>(() => config.Validate());
+    }
+
+    [Fact]
+    public void Validate_AcceptsRebalancedValues()
+    {
+        var config = new GameBalanceConfig
+        {
+            CaravanTradeFavorMultiplier = 0.5f,
+            CaravanExplorationFavorMultiplier = 2.0f,
+            CaravanTradeTableFavorMultiplier = 1.5f,
+            CaravanPerTradeFavorCap = 50
+        };
+
+        var ex = Record.Exception(() => config.Validate());
+        Assert.Null(ex);
+    }
+}

--- a/DivineAscension.Tests/Systems/Favor/ExplorationFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/ExplorationFavorTrackerTests.cs
@@ -18,11 +18,13 @@ public class ExplorationFavorTrackerTests
         Mock<IEventService> mockEventService,
         Mock<IWorldService> mockWorldService,
         Mock<IPlayerProgressionDataManager> mockPlayerProgression,
-        Mock<IFavorSystem> mockFavor)
+        Mock<IFavorSystem> mockFavor,
+        DivineAscension.Configuration.GameBalanceConfig? config = null)
     {
         var mockLogger = new Mock<ILoggerWrapper>();
         return new ExplorationFavorTracker(mockLogger.Object, mockEventService.Object,
-            mockWorldService.Object, mockPlayerProgression.Object, mockFavor.Object);
+            mockWorldService.Object, mockPlayerProgression.Object, mockFavor.Object,
+            config ?? new DivineAscension.Configuration.GameBalanceConfig());
     }
 
     private static (Mock<IServerPlayer>, PlayerProgressionData) WirePlayer(
@@ -160,6 +162,46 @@ public class ExplorationFavorTrackerTests
         Assert.False(second);
         mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
             It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Once);
+    }
+
+    [Fact]
+    public void TryAwardChunkFavor_AppliesConfigExplorationMultiplier()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, _) = WirePlayer(mockMgr);
+        var config = new DivineAscension.Configuration.GameBalanceConfig
+        {
+            CaravanExplorationFavorMultiplier = 3.0f
+        };
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(),
+            mockMgr, mockFavor, config);
+
+        tracker.TryAwardChunkFavor(mockPlayer.Object, 7L, multiplier: 1.0f);
+
+        // BASE_CHUNK_FAVOR (1) * stat-multiplier (1) * config (3) = 3
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "discovered chunk",
+            3f, DeityDomain.Caravan), Times.Once);
+    }
+
+    [Fact]
+    public void TryAwardTraderBonus_AppliesConfigExplorationMultiplier()
+    {
+        var mockMgr = TestFixtures.CreateMockPlayerProgressionDataManager();
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var (mockPlayer, _) = WirePlayer(mockMgr);
+        var config = new DivineAscension.Configuration.GameBalanceConfig
+        {
+            CaravanExplorationFavorMultiplier = 0.5f
+        };
+        var tracker = CreateTracker(new Mock<IEventService>(), new Mock<IWorldService>(),
+            mockMgr, mockFavor, config);
+
+        tracker.TryAwardTraderBonus(mockPlayer.Object, 555L);
+
+        // TRADER_BONUS_FAVOR (10) * 0.5 = 5
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "encountered trader",
+            5f, DeityDomain.Caravan), Times.Once);
     }
 
     [Fact]

--- a/DivineAscension.Tests/Systems/Favor/TraderTransactionFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/TraderTransactionFavorTrackerTests.cs
@@ -17,10 +17,12 @@ public class TraderTransactionFavorTrackerTests
 {
     private static TraderTransactionFavorTracker CreateTracker(
         Mock<IWorldService> mockWorldService,
-        Mock<IFavorSystem> mockFavor)
+        Mock<IFavorSystem> mockFavor,
+        DivineAscension.Configuration.GameBalanceConfig? config = null)
     {
         var mockLogger = new Mock<ILoggerWrapper>();
-        return new TraderTransactionFavorTracker(mockLogger.Object, mockWorldService.Object, mockFavor.Object);
+        return new TraderTransactionFavorTracker(mockLogger.Object, mockWorldService.Object, mockFavor.Object,
+            config ?? new DivineAscension.Configuration.GameBalanceConfig());
     }
 
     [Fact]
@@ -110,4 +112,43 @@ public class TraderTransactionFavorTrackerTests
     // Note: Initialize/Dispose subscribe/unsubscribe from the static TraderPatches event,
     // which can't be invoked from outside the declaring type. The HandleTraderTransaction
     // tests above cover the favor-award path the subscription routes to.
+
+    [Fact]
+    public void HandleTraderTransaction_AppliesConfigTradeMultiplier()
+    {
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        var config = new DivineAscension.Configuration.GameBalanceConfig
+        {
+            CaravanTradeFavorMultiplier = 2.5f
+        };
+        var tracker = CreateTracker(new Mock<IWorldService>(), mockFavor, config);
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.SetupGet(p => p.PlayerName).Returns("Multiplied");
+
+        tracker.HandleTraderTransaction(mockPlayer.Object, valueInGears: 50);
+
+        // Base 2 + 50/10 = 7, times 2.5 = 17.5
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "trade",
+            17.5f, DeityDomain.Caravan), Times.Once);
+    }
+
+    [Fact]
+    public void HandleTraderTransaction_AppliesConfigPerTradeCap()
+    {
+        var mockFavor = TestFixtures.CreateMockFavorSystem();
+        // Lower the cap so a mid-size trade hits it.
+        var config = new DivineAscension.Configuration.GameBalanceConfig
+        {
+            CaravanPerTradeFavorCap = 5
+        };
+        var tracker = CreateTracker(new Mock<IWorldService>(), mockFavor, config);
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.SetupGet(p => p.PlayerName).Returns("Capped");
+
+        tracker.HandleTraderTransaction(mockPlayer.Object, valueInGears: 1000);
+
+        // Raw 102, clamped to config cap 5, multiplier default 1.0.
+        mockFavor.Verify(f => f.AwardFavorForAction(mockPlayer.Object, "trade",
+            5f, DeityDomain.Caravan), Times.Once);
+    }
 }

--- a/DivineAscension/Configuration/GameBalanceConfig.cs
+++ b/DivineAscension/Configuration/GameBalanceConfig.cs
@@ -163,6 +163,33 @@ public class GameBalanceConfig
     /// <summary>Prestige multiplier during war (default: 1.5)</summary>
     public float WarPrestigeMultiplier { get; set; } = 1.5f;
 
+    // === CARAVAN DOMAIN ===
+
+    /// <summary>
+    ///     Multiplier applied to favor awarded by completed NPC trader transactions
+    ///     (consumed by <c>TraderTransactionFavorTracker</c>). Default 1.0.
+    /// </summary>
+    public float CaravanTradeFavorMultiplier { get; set; } = 1.0f;
+
+    /// <summary>
+    ///     Multiplier applied to favor awarded on first-time chunk discovery
+    ///     (consumed by <c>ExplorationFavorTracker</c>). Default 1.0.
+    /// </summary>
+    public float CaravanExplorationFavorMultiplier { get; set; } = 1.0f;
+
+    /// <summary>
+    ///     Multiplier applied to favor awarded by the player-to-player trade table
+    ///     (consumed once #435 lands). Default 1.0.
+    /// </summary>
+    public float CaravanTradeTableFavorMultiplier { get; set; } = 1.0f;
+
+    /// <summary>
+    ///     Hard cap on favor awarded per single NPC trade. Overrides the tracker's
+    ///     compiled <c>MaxFavorPerTrade</c> when set, so admins can rebalance whale-trade
+    ///     anti-farming without a code release. Default 20.
+    /// </summary>
+    public int CaravanPerTradeFavorCap { get; set; } = 20;
+
     // === HOLY SITE BUFFS ===
 
     /// <summary>Favor/Prestige multiplier for Tier 1 holy sites (default: 1.25)</summary>
@@ -260,6 +287,17 @@ public class GameBalanceConfig
         if (UnlearnRefundPercent < 0f || UnlearnRefundPercent > 1f)
         {
             throw new InvalidOperationException("UnlearnRefundPercent must be between 0 and 1");
+        }
+
+        if (CaravanTradeFavorMultiplier <= 0 || CaravanExplorationFavorMultiplier <= 0 ||
+            CaravanTradeTableFavorMultiplier <= 0)
+        {
+            throw new InvalidOperationException("Caravan favor multipliers must be positive");
+        }
+
+        if (CaravanPerTradeFavorCap <= 0 || CaravanPerTradeFavorCap > 1000)
+        {
+            throw new InvalidOperationException("CaravanPerTradeFavorCap must be between 1 and 1000");
         }
     }
 

--- a/DivineAscension/Systems/Favor/ExplorationFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/ExplorationFavorTracker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using DivineAscension.API.Interfaces;
+using DivineAscension.Configuration;
 using DivineAscension.Constants;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
@@ -24,8 +25,10 @@ public class ExplorationFavorTracker(
     IEventService eventService,
     IWorldService worldService,
     IPlayerProgressionDataManager playerProgressionDataManager,
-    IFavorSystem favorSystem) : IFavorTracker, IDisposable
+    IFavorSystem favorSystem,
+    GameBalanceConfig config) : IFavorTracker, IDisposable
 {
+    private readonly GameBalanceConfig _config = config ?? throw new ArgumentNullException(nameof(config));
     internal const int TICK_INTERVAL_MS = 2000;
     internal const float BASE_CHUNK_FAVOR = 1.0f;
     internal const float TRADER_BONUS_FAVOR = 10.0f;
@@ -116,7 +119,8 @@ public class ExplorationFavorTracker(
         if (!data.TryAddDiscoveredChunk(chunkKey))
             return false;
 
-        _favorSystem.AwardFavorForAction(player, "discovered chunk", BASE_CHUNK_FAVOR * multiplier,
+        _favorSystem.AwardFavorForAction(player, "discovered chunk",
+            BASE_CHUNK_FAVOR * multiplier * _config.CaravanExplorationFavorMultiplier,
             DeityDomain.Caravan);
         return true;
     }
@@ -145,7 +149,8 @@ public class ExplorationFavorTracker(
         if (!data.TryAddDiscoveredTrader(traderEntityId))
             return false;
 
-        _favorSystem.AwardFavorForAction(player, "encountered trader", TRADER_BONUS_FAVOR,
+        _favorSystem.AwardFavorForAction(player, "encountered trader",
+            TRADER_BONUS_FAVOR * _config.CaravanExplorationFavorMultiplier,
             DeityDomain.Caravan);
         return true;
     }

--- a/DivineAscension/Systems/Favor/TraderTransactionFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/TraderTransactionFavorTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using DivineAscension.API.Interfaces;
+using DivineAscension.Configuration;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
 using DivineAscension.Systems.Interfaces;
@@ -17,7 +18,8 @@ namespace DivineAscension.Systems.Favor;
 public class TraderTransactionFavorTracker(
     ILoggerWrapper logger,
     IWorldService worldService,
-    IFavorSystem favorSystem) : IFavorTracker, IDisposable
+    IFavorSystem favorSystem,
+    GameBalanceConfig config) : IFavorTracker, IDisposable
 {
     internal const int BaseFavor = 2;
     internal const int DivisorGears = 10;
@@ -25,6 +27,7 @@ public class TraderTransactionFavorTracker(
 
     private readonly IFavorSystem _favorSystem = favorSystem ?? throw new ArgumentNullException(nameof(favorSystem));
     private readonly ILoggerWrapper _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly GameBalanceConfig _config = config ?? throw new ArgumentNullException(nameof(config));
 
     private readonly IWorldService
         _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
@@ -52,21 +55,27 @@ public class TraderTransactionFavorTracker(
         if (player is not IServerPlayer serverPlayer) return;
         if (valueInGears <= 0) return;
 
-        var favor = ComputeFavor(valueInGears);
+        var favor = ComputeFavor(valueInGears, _config.CaravanPerTradeFavorCap) *
+                    _config.CaravanTradeFavorMultiplier;
         _favorSystem.AwardFavorForAction(serverPlayer, "trade", favor, DeityDomain.Caravan);
         _logger.Debug(
             $"[TraderTransactionFavorTracker] Awarded {favor} favor to {serverPlayer.PlayerName} for NPC trade worth {valueInGears} gears");
     }
 
     /// <summary>
-    ///     <c>BaseFavor + floor(value / DivisorGears)</c>, clamped to
-    ///     <see cref="MaxFavorPerTrade"/>. The clamp is the anti-whale guard — without it,
-    ///     a single 1000-gear swap would dwarf the favor income of a normal trader run.
+    ///     <c>BaseFavor + floor(value / DivisorGears)</c>, clamped to <paramref name="cap"/>
+    ///     (the live config cap). The clamp is the anti-whale guard — without it, a single
+    ///     1000-gear swap would dwarf the favor income of a normal trader run.
     /// </summary>
-    internal static int ComputeFavor(int valueInGears)
+    internal static int ComputeFavor(int valueInGears, int cap)
     {
         if (valueInGears <= 0) return 0;
         var raw = BaseFavor + valueInGears / DivisorGears;
-        return raw > MaxFavorPerTrade ? MaxFavorPerTrade : raw;
+        return raw > cap ? cap : raw;
     }
+
+    /// <summary>
+    ///     Back-compat overload using the compiled <see cref="MaxFavorPerTrade"/> default.
+    /// </summary>
+    internal static int ComputeFavor(int valueInGears) => ComputeFavor(valueInGears, MaxFavorPerTrade);
 }

--- a/DivineAscension/Systems/FavorSystem.cs
+++ b/DivineAscension/Systems/FavorSystem.cs
@@ -155,10 +155,10 @@ public class FavorSystem : IFavorSystem
         _ruinDiscoveryFavorTracker.Initialize();
 
         _explorationFavorTracker = new ExplorationFavorTracker(_logger, _eventService, _worldService,
-            _playerProgressionDataManager, this);
+            _playerProgressionDataManager, this, _config);
         _explorationFavorTracker.Initialize();
 
-        _traderTransactionFavorTracker = new TraderTransactionFavorTracker(_logger, _worldService, this);
+        _traderTransactionFavorTracker = new TraderTransactionFavorTracker(_logger, _worldService, this, _config);
         _traderTransactionFavorTracker.Initialize();
 
         // Initialize patrol tracker only if dependencies were set


### PR DESCRIPTION
## Summary
Four new server-tunable knobs on `GameBalanceConfig` so Caravan favor rates can be rebalanced without a code release:

| Knob | Default | Consumer |
|---|---|---|
| `CaravanTradeFavorMultiplier` | 1.0 | `TraderTransactionFavorTracker` |
| `CaravanExplorationFavorMultiplier` | 1.0 | `ExplorationFavorTracker` (chunk + trader encounter) |
| `CaravanTradeTableFavorMultiplier` | 1.0 | wired when #435 ships |
| `CaravanPerTradeFavorCap` | 20 | overrides `MaxFavorPerTrade` |

Both Caravan trackers now take `GameBalanceConfig` and apply the knobs in their award paths. `Validate()` rejects non-positive multipliers and out-of-range caps (1..1000).

Defaults match the trackers' compiled-in constants, so behaviour is identical on a fresh config.

## Test plan
- [x] `dotnet build DivineAscension.sln -c Debug` clean
- [x] `dotnet test` — 2443/2443 pass
- [x] New `GameBalanceConfigCaravanTests`: defaults match hardcoded values, accept defaults + rebalanced values, reject non-positive multipliers, reject out-of-range cap
- [x] New tracker tests verify each knob measurably changes award amount: `TraderTransactionFavorTracker` × `CaravanTradeFavorMultiplier`, `× CaravanPerTradeFavorCap`; `ExplorationFavorTracker` × `CaravanExplorationFavorMultiplier` (chunk + trader bonus paths)

Closes #437