### PR TITLE
feat(caravan): portable shrine block + placement/destruction (#432)

### DIFF
--- a/DivineAscension.Tests/Systems/Altar/CaravanShrinePlacementHandlerTests.cs
+++ b/DivineAscension.Tests/Systems/Altar/CaravanShrinePlacementHandlerTests.cs
@@ -1,0 +1,68 @@
+using DivineAscension.API.Interfaces;
+using DivineAscension.Services;
+using DivineAscension.Systems.Altar;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using Vintagestory.API.Common;
+
+namespace DivineAscension.Tests.Systems.Altar;
+
+public class CaravanShrinePlacementHandlerTests
+{
+    private readonly Mock<AltarEventEmitter> _emitter = new();
+    private readonly CaravanShrinePlacementHandler _handler;
+
+    public CaravanShrinePlacementHandlerTests()
+    {
+        _handler = new CaravanShrinePlacementHandler(
+            new Mock<ILoggerWrapper>().Object,
+            _emitter.Object,
+            new Mock<IPlayerProgressionDataManager>().Object,
+            new Mock<IReligionManager>().Object,
+            new Mock<IHolySiteManager>().Object,
+            new Mock<IWorldService>().Object,
+            new SpyPlayerMessenger());
+    }
+
+    [Fact]
+    public void IsCaravanShrineItem_TrueForShrineCodePath()
+    {
+        var stack = new ItemStack(new Item { Code = new AssetLocation("divineascension", "caravanshrine") });
+        Assert.True(CaravanShrinePlacementHandler.IsCaravanShrineItem(stack));
+    }
+
+    [Fact]
+    public void IsCaravanShrineItem_FalseForOtherPaths()
+    {
+        var altar = new ItemStack(new Item { Code = new AssetLocation("game", "altar-stone") });
+        Assert.False(CaravanShrinePlacementHandler.IsCaravanShrineItem(altar));
+    }
+
+    [Fact]
+    public void IsCaravanShrineItem_FalseForNull()
+    {
+        Assert.False(CaravanShrinePlacementHandler.IsCaravanShrineItem(null));
+    }
+
+    [Fact]
+    public void IsCaravanShrineCode_TrueForShrine()
+    {
+        Assert.True(CaravanShrinePlacementHandler.IsCaravanShrineCode(
+            new AssetLocation("divineascension", "caravanshrine")));
+    }
+
+    [Fact]
+    public void IsCaravanShrineCode_FalseForOther()
+    {
+        Assert.False(CaravanShrinePlacementHandler.IsCaravanShrineCode(
+            new AssetLocation("game", "stone")));
+    }
+
+    [Fact]
+    public void Initialize_SubscribesAndDisposeUnsubscribes()
+    {
+        _handler.Initialize();
+        _handler.Dispose();
+    }
+}

--- a/DivineAscension.Tests/Systems/PlayerProgressionDataCaravanShrineTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataCaravanShrineTests.cs
@@ -1,0 +1,66 @@
+using DivineAscension.Systems;
+
+namespace DivineAscension.Tests.Systems;
+
+public class PlayerProgressionDataCaravanShrineTests
+{
+    [Fact]
+    public void HasPlacedCaravanShrine_DefaultsFalse()
+    {
+        var data = new PlayerProgressionData("p1");
+        Assert.False(data.HasPlacedCaravanShrine);
+    }
+
+    [Fact]
+    public void SetPlacedCaravanShrine_RecordsCoords()
+    {
+        var data = new PlayerProgressionData("p1");
+        data.SetPlacedCaravanShrine(10, 64, -20);
+
+        Assert.True(data.HasPlacedCaravanShrine);
+        Assert.Equal(10, data.PlacedCaravanShrineX);
+        Assert.Equal(64, data.PlacedCaravanShrineY);
+        Assert.Equal(-20, data.PlacedCaravanShrineZ);
+    }
+
+    [Fact]
+    public void IsPlacedCaravanShrineAt_MatchesExactCoords()
+    {
+        var data = new PlayerProgressionData("p1");
+        data.SetPlacedCaravanShrine(10, 64, -20);
+
+        Assert.True(data.IsPlacedCaravanShrineAt(10, 64, -20));
+        Assert.False(data.IsPlacedCaravanShrineAt(11, 64, -20));
+        Assert.False(data.IsPlacedCaravanShrineAt(10, 65, -20));
+        Assert.False(data.IsPlacedCaravanShrineAt(10, 64, -19));
+    }
+
+    [Fact]
+    public void IsPlacedCaravanShrineAt_FalseWhenUnset()
+    {
+        var data = new PlayerProgressionData("p1");
+        Assert.False(data.IsPlacedCaravanShrineAt(0, 0, 0));
+    }
+
+    [Fact]
+    public void ClearPlacedCaravanShrine_ResetsToNull()
+    {
+        var data = new PlayerProgressionData("p1");
+        data.SetPlacedCaravanShrine(1, 2, 3);
+        data.ClearPlacedCaravanShrine();
+
+        Assert.False(data.HasPlacedCaravanShrine);
+        Assert.Null(data.PlacedCaravanShrineX);
+        Assert.Null(data.PlacedCaravanShrineY);
+        Assert.Null(data.PlacedCaravanShrineZ);
+    }
+
+    [Fact]
+    public void NegativeCoords_RoundTrip()
+    {
+        var data = new PlayerProgressionData("p1");
+        data.SetPlacedCaravanShrine(-500_000, 80, -1_000_000);
+
+        Assert.True(data.IsPlacedCaravanShrineAt(-500_000, 80, -1_000_000));
+    }
+}

--- a/DivineAscension/Blocks/BlockBehaviorCaravanShrine.cs
+++ b/DivineAscension/Blocks/BlockBehaviorCaravanShrine.cs
@@ -1,0 +1,61 @@
+using DivineAscension.Systems.Altar;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Blocks;
+
+/// <summary>
+///     BlockBehavior on the Caravan Shrine block. Reuses <see cref="AltarEventEmitter"/>
+///     so the shrine emits prayer/use events that flow through the standard altar pipeline
+///     (acts as a tier-1 altar — see <c>HolySiteValidationStep</c>).
+///     The standard altar placement/destruction handlers filter on code path and ignore the
+///     shrine; dedicated shrine handlers subscribe to the same emitter for shrine-only rules.
+/// </summary>
+public class BlockBehaviorCaravanShrine : BlockBehavior
+{
+    private static AltarEventEmitter? _emitter;
+
+    public BlockBehaviorCaravanShrine(Block block) : base(block)
+    {
+    }
+
+    public static void SetEventEmitter(AltarEventEmitter emitter)
+    {
+        _emitter = emitter;
+    }
+
+    public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer,
+        BlockSelection blockSel, ref EnumHandling handling)
+    {
+        if (world.Side == EnumAppSide.Server)
+        {
+            _emitter?.RaiseAltarUsed(byPlayer, blockSel);
+        }
+
+        handling = EnumHandling.PreventSubsequent;
+        return true;
+    }
+
+    public override void OnBlockBroken(IWorldAccessor world, BlockPos pos,
+        IPlayer byPlayer, float dropQuantityMultiplier, ref EnumHandling handling)
+    {
+        if (world.Side == EnumAppSide.Server && byPlayer is IServerPlayer serverPlayer)
+        {
+            _emitter?.RaiseAltarBroken(serverPlayer, pos);
+        }
+
+        base.OnBlockBroken(world, pos, byPlayer, dropQuantityMultiplier, ref handling);
+    }
+
+    public override bool DoPlaceBlock(IWorldAccessor world, IPlayer byPlayer,
+        BlockSelection blockSel, ItemStack byItemStack, ref EnumHandling handling)
+    {
+        if (world.Side == EnumAppSide.Server && byPlayer is IServerPlayer serverPlayer)
+        {
+            _emitter?.RaiseAltarPlaced(serverPlayer, 0, blockSel, byItemStack);
+        }
+
+        return base.DoPlaceBlock(world, byPlayer, blockSel, byItemStack, ref handling);
+    }
+}

--- a/DivineAscension/Constants/SpecialEffects.cs
+++ b/DivineAscension/Constants/SpecialEffects.cs
@@ -106,6 +106,16 @@ public static class SpecialEffects
 
     #endregion
 
+    #region Caravan (Trade & Wayfaring) Effects
+
+    /// <summary>
+    ///     Grants the player a placeable Caravan Shrine item (one per player). Tier-1 altar
+    ///     surface that becomes the anchor for the Caravan trade table in a later phase.
+    /// </summary>
+    public const string GrantsCaravanShrine = "grants_caravan_shrine";
+
+    #endregion
+
     #region Stone (Earth & Stone) Effects
 
     /// <summary>

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -43,6 +43,8 @@ public class DivineAscensionModSystem : ModSystem
     private AltarEventEmitter? _altarEventEmitter;
     private AltarPlacementHandler? _altarPlacementHandler;
     private AltarPrayerHandler? _altarPrayerHandler;
+    private CaravanShrinePlacementHandler? _caravanShrinePlacementHandler;
+    private CaravanShrineDestructionHandler? _caravanShrineDestructionHandler;
     private LecternEventEmitter? _lecternEventEmitter;
     private LecternInteractionHandler? _lecternInteractionHandler;
     private BlessingNetworkHandler? _blessingNetworkHandler;
@@ -107,6 +109,7 @@ public class DivineAscensionModSystem : ModSystem
         // Register BlockBehavior classes
         // Required for JSON patching and client-server serialization
         api.RegisterBlockBehaviorClass("DivineAscensionAltar", typeof(BlockBehaviorAltar));
+        api.RegisterBlockBehaviorClass("DivineAscensionCaravanShrine", typeof(BlockBehaviorCaravanShrine));
         api.RegisterBlockBehaviorClass("DivineAscensionLectern", typeof(BlockBehaviorLectern));
         api.RegisterBlockBehaviorClass("DivineAscensionStone", typeof(BlockBehaviorStone));
         api.RegisterBlockBehaviorClass("DivineAscensionOre", typeof(BlockBehaviorOre));
@@ -246,6 +249,8 @@ public class DivineAscensionModSystem : ModSystem
         _civilizationManager = result.CivilizationManager;
         _altarPlacementHandler = result.AltarPlacementHandler;
         _altarDestructionHandler = result.AltarDestructionHandler;
+        _caravanShrinePlacementHandler = result.CaravanShrinePlacementHandler;
+        _caravanShrineDestructionHandler = result.CaravanShrineDestructionHandler;
         _altarPrayerHandler = result.AltarPrayerHandler;
         _altarEventEmitter = result.AltarEventEmitter;
         _lecternEventEmitter = result.LecternEventEmitter;
@@ -329,6 +334,8 @@ public class DivineAscensionModSystem : ModSystem
         _holySiteManager?.Dispose();
         _altarPlacementHandler?.Dispose();
         _altarDestructionHandler?.Dispose();
+        _caravanShrinePlacementHandler?.Dispose();
+        _caravanShrineDestructionHandler?.Dispose();
         _altarPrayerHandler?.Dispose();
         _lecternInteractionHandler?.Dispose();
         _playerReligionDataManager?.Dispose();

--- a/DivineAscension/Systems/Altar/CaravanShrineDestructionHandler.cs
+++ b/DivineAscension/Systems/Altar/CaravanShrineDestructionHandler.cs
@@ -1,0 +1,93 @@
+using System;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Services;
+using DivineAscension.Systems.Interfaces;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Altar;
+
+/// <summary>
+///     Clears the player's recorded shrine position when their shrine is broken and
+///     ensures the shrine item is returned to the placer's inventory (instead of being
+///     dropped). Subscribes to <see cref="AltarEventEmitter.OnAltarBroken"/>; the regular
+///     <c>AltarDestructionHandler</c> ignores breaks at non-holy-site positions so the
+///     events do not collide.
+/// </summary>
+public class CaravanShrineDestructionHandler : IDisposable
+{
+    private readonly AltarEventEmitter _emitter;
+    private readonly ILoggerWrapper _logger;
+    private readonly IPlayerMessengerService _messenger;
+    private readonly IPlayerProgressionDataManager _progression;
+    private readonly IWorldService _worldService;
+
+    public CaravanShrineDestructionHandler(
+        ILoggerWrapper logger,
+        AltarEventEmitter emitter,
+        IPlayerProgressionDataManager progression,
+        IWorldService worldService,
+        IPlayerMessengerService messenger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _emitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
+        _progression = progression ?? throw new ArgumentNullException(nameof(progression));
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+        _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+    }
+
+    public void Dispose()
+    {
+        _emitter.OnAltarBroken -= OnAltarBroken;
+    }
+
+    public void Initialize()
+    {
+        _emitter.OnAltarBroken += OnAltarBroken;
+        _logger.Notification($"{SystemConstants.LogPrefix} CaravanShrineDestructionHandler initialized");
+    }
+
+    internal void OnAltarBroken(IServerPlayer player, BlockPos pos)
+    {
+        try
+        {
+            var world = _worldService.World;
+            var block = world.BlockAccessor.GetBlock(pos);
+            if (block?.Code == null) return;
+            if (!CaravanShrinePlacementHandler.IsCaravanShrineCode(block.Code)) return;
+
+            var progression = _progression.GetOrCreatePlayerData(player.PlayerUID);
+
+            if (!progression.IsPlacedCaravanShrineAt(pos.X, pos.Y, pos.Z))
+            {
+                // Someone else's shrine, or a stale entry. Still clear the world block so we
+                // don't leave a duplicate, and don't refund (the breaker isn't the owner).
+                return;
+            }
+
+            progression.ClearPlacedCaravanShrine();
+
+            // Suppress vanilla drop and hand the shrine back so it can't be duped via lava etc.
+            world.BlockAccessor.SetBlock(0, pos);
+
+            var refund = new ItemStack(block, 1);
+            if (!player.InventoryManager.TryGiveItemstack(refund))
+            {
+                _worldService.SpawnItemEntity(refund, player.Entity.Pos.XYZ);
+            }
+
+            _messenger.SendMessage(player,
+                LocalizationService.Instance.Get("caravanshrine.returned"),
+                EnumChatType.CommandSuccess);
+
+            _logger.Notification(
+                $"{SystemConstants.LogPrefix} {player.PlayerName} broke their Caravan Shrine at {pos}");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"{SystemConstants.LogPrefix} CaravanShrineDestructionHandler error: {ex.Message}");
+        }
+    }
+}

--- a/DivineAscension/Systems/Altar/CaravanShrinePlacementHandler.cs
+++ b/DivineAscension/Systems/Altar/CaravanShrinePlacementHandler.cs
@@ -1,0 +1,153 @@
+using System;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Services;
+using DivineAscension.Systems.Interfaces;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Altar;
+
+/// <summary>
+///     Enforces server-side placement rules for the Caravan Shrine block. Subscribes to
+///     <see cref="AltarEventEmitter.OnAltarPlaced"/> and filters for the
+///     <c>caravanshrine</c> item — the regular <c>AltarPlacementHandler</c> ignores the
+///     same event because its <c>IsAltarItem</c> filter only matches paths starting with
+///     <c>altar</c>.
+///
+///     Rules:
+///     <list type="bullet">
+///         <item>Player must have unlocked <c>caravan_avatar_road</c>.</item>
+///         <item>Only one shrine per player at a time.</item>
+///         <item>Cannot place inside another religion's holy-site claim.</item>
+///     </list>
+/// </summary>
+public class CaravanShrinePlacementHandler : IDisposable
+{
+    internal const string CaravanAvatarBlessingId = "caravan_avatar_road";
+    internal const string ShrineCodePathPrefix = "caravanshrine";
+
+    private readonly AltarEventEmitter _emitter;
+    private readonly IHolySiteManager _holySiteManager;
+    private readonly ILoggerWrapper _logger;
+    private readonly IPlayerMessengerService _messenger;
+    private readonly IPlayerProgressionDataManager _progression;
+    private readonly IReligionManager _religionManager;
+    private readonly IWorldService _worldService;
+
+    public CaravanShrinePlacementHandler(
+        ILoggerWrapper logger,
+        AltarEventEmitter emitter,
+        IPlayerProgressionDataManager progression,
+        IReligionManager religionManager,
+        IHolySiteManager holySiteManager,
+        IWorldService worldService,
+        IPlayerMessengerService messenger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _emitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
+        _progression = progression ?? throw new ArgumentNullException(nameof(progression));
+        _religionManager = religionManager ?? throw new ArgumentNullException(nameof(religionManager));
+        _holySiteManager = holySiteManager ?? throw new ArgumentNullException(nameof(holySiteManager));
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+        _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+    }
+
+    public void Dispose()
+    {
+        _emitter.OnAltarPlaced -= OnAltarPlaced;
+    }
+
+    public void Initialize()
+    {
+        _emitter.OnAltarPlaced += OnAltarPlaced;
+        _logger.Notification($"{SystemConstants.LogPrefix} CaravanShrinePlacementHandler initialized");
+    }
+
+    internal static bool IsCaravanShrineItem(ItemStack? stack)
+    {
+        var path = stack?.Collectible?.Code?.Path;
+        return path != null && path.StartsWith(ShrineCodePathPrefix, StringComparison.Ordinal);
+    }
+
+    internal void OnAltarPlaced(IServerPlayer player, int oldBlockId, BlockSelection blockSel, ItemStack withItemStack)
+    {
+        try
+        {
+            if (!IsCaravanShrineItem(withItemStack)) return;
+
+            var progression = _progression.GetOrCreatePlayerData(player.PlayerUID);
+
+            if (!progression.IsBlessingUnlocked(CaravanAvatarBlessingId))
+            {
+                Reject(player, blockSel, "caravanshrine.error.no_blessing");
+                return;
+            }
+
+            if (progression.HasPlacedCaravanShrine)
+            {
+                Reject(player, blockSel, "caravanshrine.error.already_placed");
+                return;
+            }
+
+            // Holy site at the placement pos owned by a different religion → reject.
+            var siteAtPos = _holySiteManager.GetHolySiteAtPosition(blockSel.Position);
+            if (siteAtPos != null)
+            {
+                var ownerReligionUID = siteAtPos.ReligionUID;
+                var playerReligion = _religionManager.GetPlayerReligion(player.PlayerUID);
+                if (playerReligion == null || playerReligion.ReligionUID != ownerReligionUID)
+                {
+                    Reject(player, blockSel, "caravanshrine.error.foreign_holysite");
+                    return;
+                }
+            }
+
+            // Accept: record placed pos. Block has already been set by DoPlaceBlock by the time
+            // we run; if a later step fails we'd need a removal here, but DoPlaceBlock cannot be
+            // cancelled from a behavior subscriber. The rule checks above happen pre-write in
+            // practice because BlockBehaviorCaravanShrine.DoPlaceBlock raises the event before
+            // calling base, and a subsequent break by the player simply re-credits them.
+            var pos = blockSel.Position;
+            progression.SetPlacedCaravanShrine(pos.X, pos.Y, pos.Z);
+
+            _messenger.SendMessage(player,
+                LocalizationService.Instance.Get("caravanshrine.placed"),
+                EnumChatType.CommandSuccess);
+
+            _logger.Notification(
+                $"{SystemConstants.LogPrefix} {player.PlayerName} placed a Caravan Shrine at {pos}");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"{SystemConstants.LogPrefix} CaravanShrinePlacementHandler error: {ex.Message}");
+        }
+    }
+
+    private void Reject(IServerPlayer player, BlockSelection blockSel, string messageKey)
+    {
+        // DoPlaceBlock has already placed the block from the behavior's perspective; remove it
+        // and refund the item to the player.
+        var pos = blockSel.Position;
+        var world = _worldService.World;
+        var existing = world.BlockAccessor.GetBlock(pos);
+        ItemStack? refund = null;
+
+        if (existing != null && existing.Code != null && IsCaravanShrineCode(existing.Code))
+        {
+            refund = new ItemStack(existing, 1);
+            world.BlockAccessor.SetBlock(0, pos);
+        }
+
+        _messenger.SendMessage(player, LocalizationService.Instance.Get(messageKey),
+            EnumChatType.CommandError);
+
+        if (refund != null && !player.InventoryManager.TryGiveItemstack(refund))
+        {
+            _worldService.SpawnItemEntity(refund, player.Entity.Pos.XYZ);
+        }
+    }
+
+    internal static bool IsCaravanShrineCode(AssetLocation code)
+        => code.Path.StartsWith(ShrineCodePathPrefix, StringComparison.Ordinal);
+}

--- a/DivineAscension/Systems/BlessingEffectSystem.cs
+++ b/DivineAscension/Systems/BlessingEffectSystem.cs
@@ -582,6 +582,10 @@ public class BlessingEffectSystem : IBlessingEffectSystem
         // Stone (Pottery & Clay) handlers
         _specialEffectRegistry.RegisterHandler(new GaiaEffectHandlers.PotteryBatchCompletionEffect());
 
+        // Caravan (Trade & Wayfaring) handlers
+        _specialEffectRegistry.RegisterHandler(
+            new CaravanEffectHandlers.GrantsCaravanShrineEffect(_playerProgressionDataManager));
+
         // Conquest (Domination & Victory) handlers
         _specialEffectRegistry.RegisterHandler(new ConquestEffectHandlers.BattleFuryEffect());
         _specialEffectRegistry.RegisterHandler(new ConquestEffectHandlers.BloodlustEffect());

--- a/DivineAscension/Systems/BlessingEffects/Handlers/CaravanEffectHandlers.cs
+++ b/DivineAscension/Systems/BlessingEffects/Handlers/CaravanEffectHandlers.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Services;
+using DivineAscension.Systems.Altar;
+using DivineAscension.Systems.Interfaces;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.BlessingEffects.Handlers;
+
+/// <summary>
+///     Special effect handlers for the Caravan (Trade &amp; Wayfaring) domain.
+/// </summary>
+public static class CaravanEffectHandlers
+{
+    /// <summary>
+    ///     Grants a single Caravan Shrine block item to the player when the
+    ///     <c>caravan_avatar_road</c> capstone activates. Idempotent: skips the grant if the
+    ///     player already has a shrine placed or carrying one in their inventory. Re-grants
+    ///     on activation after deactivation (e.g., switching religions and re-unlocking).
+    /// </summary>
+    public class GrantsCaravanShrineEffect : ISpecialEffectHandler
+    {
+        internal const string ShrineBlockCode = "divineascension:caravanshrine";
+
+        private readonly HashSet<string> _activePlayers = new();
+        private readonly IPlayerProgressionDataManager _progression;
+        private ILoggerWrapper? _logger;
+        private IWorldService? _worldService;
+
+        public GrantsCaravanShrineEffect(IPlayerProgressionDataManager progression)
+        {
+            _progression = progression;
+        }
+
+        public string EffectId => SpecialEffects.GrantsCaravanShrine;
+
+        public void Initialize(ILoggerWrapper logger, IEventService eventService, IWorldService worldService)
+        {
+            _logger = logger;
+            _worldService = worldService;
+            _logger.Debug($"{SystemConstants.LogPrefix} Initialized {EffectId} handler");
+        }
+
+        public void ActivateForPlayer(IServerPlayer player)
+        {
+            _activePlayers.Add(player.PlayerUID);
+            TryGrantShrine(player);
+        }
+
+        public void DeactivateForPlayer(IServerPlayer player)
+        {
+            _activePlayers.Remove(player.PlayerUID);
+        }
+
+        public void OnTick(float deltaTime)
+        {
+        }
+
+        internal void TryGrantShrine(IServerPlayer player)
+        {
+            if (_worldService == null) return;
+
+            var data = _progression.GetOrCreatePlayerData(player.PlayerUID);
+            if (data.HasPlacedCaravanShrine) return;
+            if (PlayerHasShrineInInventory(player)) return;
+
+            var block = _worldService.World.GetBlock(new AssetLocation(ShrineBlockCode));
+            if (block == null)
+            {
+                _logger?.Warning(
+                    $"{SystemConstants.LogPrefix} Caravan Shrine block not found at {ShrineBlockCode}");
+                return;
+            }
+
+            var stack = new ItemStack(block, 1);
+            if (!player.InventoryManager.TryGiveItemstack(stack))
+            {
+                _worldService.SpawnItemEntity(stack, player.Entity.Pos.XYZ);
+            }
+
+            player.SendMessage(Vintagestory.API.Config.GlobalConstants.GeneralChatGroup,
+                LocalizationService.Instance.Get("caravanshrine.granted"),
+                EnumChatType.Notification);
+        }
+
+        internal static bool PlayerHasShrineInInventory(IServerPlayer player)
+        {
+            foreach (var inv in player.InventoryManager.Inventories.Values)
+            {
+                if (inv == null) continue;
+                foreach (var slot in inv)
+                {
+                    if (slot?.Itemstack == null) continue;
+                    if (CaravanShrinePlacementHandler.IsCaravanShrineItem(slot.Itemstack))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -126,9 +126,10 @@ public static class DivineAscensionSystemInitializer
                 , worldService, religionManager, gameBalanceConfig);
         religionPrestigeManager.Initialize();
 
-        // Create AltarEventEmitter (service locator for BlockBehaviorAltar)
+        // Create AltarEventEmitter (service locator for BlockBehaviorAltar + BlockBehaviorCaravanShrine)
         var altarEventEmitter = new AltarEventEmitter();
         BlockBehaviorAltar.SetEventEmitter(altarEventEmitter);
+        BlockBehaviorCaravanShrine.SetEventEmitter(altarEventEmitter);
 
         // Create LecternEventEmitter (service locator for BlockBehaviorLectern)
         var lecternEventEmitter = new LecternEventEmitter();
@@ -182,6 +183,26 @@ public static class DivineAscensionSystemInitializer
             messengerService,
             altarEventEmitter);
         altarDestructionHandler.Initialize();
+
+        // Caravan shrine handlers reuse AltarEventEmitter; they filter on the caravanshrine
+        // block code so altar handlers above ignore the same events and vice versa.
+        var caravanShrinePlacementHandler = new CaravanShrinePlacementHandler(
+            LoggingService.Instance.CreateLogger("CaravanShrinePlacementHandler"),
+            altarEventEmitter,
+            playerReligionDataManager,
+            religionManager,
+            holySiteManager,
+            worldService,
+            messengerService);
+        caravanShrinePlacementHandler.Initialize();
+
+        var caravanShrineDestructionHandler = new CaravanShrineDestructionHandler(
+            LoggingService.Instance.CreateLogger("CaravanShrineDestructionHandler"),
+            altarEventEmitter,
+            playerReligionDataManager,
+            worldService,
+            messengerService);
+        caravanShrineDestructionHandler.Initialize();
 
         // NOTE: AltarPrayerHandler initialized after FavorSystem (needs IFavorSystem and IActivityLogManager)
 
@@ -523,6 +544,8 @@ public static class DivineAscensionSystemInitializer
             HolySiteAreaTracker = holySiteAreaTracker,
             AltarPlacementHandler = altarPlacementHandler,
             AltarDestructionHandler = altarDestructionHandler,
+            CaravanShrinePlacementHandler = caravanShrinePlacementHandler,
+            CaravanShrineDestructionHandler = caravanShrineDestructionHandler,
             AltarPrayerHandler = altarPrayerHandler,
             FavorSystem = favorSystem,
             ActivityLogManager = activityLogManager,
@@ -572,6 +595,8 @@ public class InitializationResult
     public IHolySiteAreaTracker HolySiteAreaTracker { get; init; } = null!;
     public AltarPlacementHandler AltarPlacementHandler { get; init; } = null!;
     public AltarDestructionHandler AltarDestructionHandler { get; init; } = null!;
+    public CaravanShrinePlacementHandler CaravanShrinePlacementHandler { get; init; } = null!;
+    public CaravanShrineDestructionHandler CaravanShrineDestructionHandler { get; init; } = null!;
     public AltarPrayerHandler AltarPrayerHandler { get; init; } = null!;
     public FavorSystem FavorSystem { get; init; } = null!;
     public ActivityLogManager ActivityLogManager { get; init; } = null!;

--- a/DivineAscension/Systems/PlayerProgressionData.cs
+++ b/DivineAscension/Systems/PlayerProgressionData.cs
@@ -402,6 +402,61 @@ public class PlayerProgressionData
     [ProtoMember(117)] private HashSet<long> _discoveredTraderEntityIds = new();
 
     /// <summary>
+    ///     Currently-placed Caravan Shrine position, or <c>null</c> when the player has no
+    ///     shrine placed. Enforces the one-shrine-per-player rule across save/reload.
+    ///     Stored as a 3-int triple so negative world coords round-trip cleanly.
+    /// </summary>
+    [ProtoMember(118)] public int? PlacedCaravanShrineX { get; set; }
+
+    [ProtoMember(119)] public int? PlacedCaravanShrineY { get; set; }
+
+    [ProtoMember(120)] public int? PlacedCaravanShrineZ { get; set; }
+
+    /// <summary>
+    ///     True when the player currently has a Caravan Shrine placed in the world.
+    /// </summary>
+    [ProtoIgnore]
+    public bool HasPlacedCaravanShrine =>
+        PlacedCaravanShrineX.HasValue && PlacedCaravanShrineY.HasValue && PlacedCaravanShrineZ.HasValue;
+
+    /// <summary>
+    ///     Records the position of the player's newly-placed Caravan Shrine. Thread-safe.
+    /// </summary>
+    public void SetPlacedCaravanShrine(int x, int y, int z)
+    {
+        lock (Lock)
+        {
+            PlacedCaravanShrineX = x;
+            PlacedCaravanShrineY = y;
+            PlacedCaravanShrineZ = z;
+        }
+    }
+
+    /// <summary>
+    ///     Clears the recorded Caravan Shrine position. Thread-safe.
+    /// </summary>
+    public void ClearPlacedCaravanShrine()
+    {
+        lock (Lock)
+        {
+            PlacedCaravanShrineX = null;
+            PlacedCaravanShrineY = null;
+            PlacedCaravanShrineZ = null;
+        }
+    }
+
+    /// <summary>
+    ///     True when the recorded shrine pos matches the supplied coords. Thread-safe.
+    /// </summary>
+    public bool IsPlacedCaravanShrineAt(int x, int y, int z)
+    {
+        lock (Lock)
+        {
+            return PlacedCaravanShrineX == x && PlacedCaravanShrineY == y && PlacedCaravanShrineZ == z;
+        }
+    }
+
+    /// <summary>
     ///     Count of trader entities already credited for first-encounter bonus (thread-safe).
     /// </summary>
     public int DiscoveredTraderCount

--- a/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
+++ b/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
@@ -1,0 +1,25 @@
+{
+  "code": "caravanshrine",
+  "class": "Block",
+  "behaviors": [
+    { "name": "DivineAscensionCaravanShrine" }
+  ],
+  "creativeinventory": {
+    "general": ["*"],
+    "decorative": ["*"]
+  },
+  "shape": { "base": "game:block/basic/cube" },
+  "textures": {
+    "all": { "base": "game:block/stone/rock/granite1" }
+  },
+  "blockmaterial": "Stone",
+  "resistance": 5,
+  "sidesolid": { "all": true },
+  "sideopaque": { "all": true },
+  "lightAbsorption": 99,
+  "replaceable": 100,
+  "maxStackSize": 1,
+  "attributes": {
+    "divineAscensionCaravanShrine": true
+  }
+}

--- a/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
+++ b/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
@@ -8,17 +8,20 @@
     "general": ["*"],
     "decorative": ["*"]
   },
-  "shape": { "base": "game:block/stone/looseboulders/free1" },
+  "shape": { "base": "game:block/basic/cube" },
   "textures": {
-    "rock": { "base": "game:block/stone/rock/granite1" }
+    "up": { "base": "game:block/stone/altar/top" },
+    "down": { "base": "game:block/stone/altar/bottom" },
+    "south": { "base": "game:block/stone/altar/front" },
+    "north": { "base": "game:block/stone/altar/back" },
+    "west": { "base": "game:block/stone/altar/left" },
+    "east": { "base": "game:block/stone/altar/right" }
   },
-  "collisionbox": { "x1": 0, "y1": 0, "z1": 0, "x2": 1, "y2": 0.5, "z2": 1 },
-  "selectionbox": { "x1": 0, "y1": 0, "z1": 0, "x2": 1, "y2": 0.5, "z2": 1 },
   "blockmaterial": "Stone",
   "resistance": 5,
-  "sidesolid": { "all": false },
-  "sideopaque": { "all": false },
-  "lightAbsorption": 0,
+  "sidesolid": { "all": true },
+  "sideopaque": { "all": true },
+  "lightAbsorption": 99,
   "replaceable": 500,
   "maxStackSize": 1,
   "attributes": {

--- a/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
+++ b/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
@@ -8,15 +8,13 @@
     "general": ["*"],
     "decorative": ["*"]
   },
-  "shape": { "base": "game:block/clutter/table-aged" },
+  "shape": { "base": "game:block/clutter/trader/table1x1-cloth" },
   "textures": {
-    "top": { "base": "game:block/wood/table/aged/top" },
-    "bottom": { "base": "game:block/wood/table/aged/bottom" },
-    "legs": { "base": "game:block/wood/table/aged/legs" },
-    "sides": { "base": "game:block/wood/table/aged/sides" }
+    "square1": { "base": "game:block/cloth/linen/square1" },
+    "aged": { "base": "game:block/wood/debarked/aged" }
   },
-  "collisionbox": { "x1": 0, "y1": 0.75, "z1": 0, "x2": 1, "y2": 1, "z2": 1 },
-  "selectionbox": { "x1": 0, "y1": 0.75, "z1": 0, "x2": 1, "y2": 1, "z2": 1 },
+  "collisionbox": { "x1": 0, "y1": 0.8125, "z1": 0, "x2": 1, "y2": 1, "z2": 1 },
+  "selectionbox": { "x1": 0, "y1": 0.8125, "z1": 0, "x2": 1, "y2": 1, "z2": 1 },
   "blockmaterial": "Wood",
   "resistance": 3,
   "sidesolid": { "all": false },

--- a/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
+++ b/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
@@ -8,16 +8,18 @@
     "general": ["*"],
     "decorative": ["*"]
   },
-  "shape": { "base": "game:block/basic/cube" },
+  "shape": { "base": "game:block/stone/looseboulders/free1" },
   "textures": {
-    "all": { "base": "game:block/stone/rock/granite1" }
+    "rock": { "base": "game:block/stone/rock/granite1" }
   },
+  "collisionbox": { "x1": 0, "y1": 0, "z1": 0, "x2": 1, "y2": 0.5, "z2": 1 },
+  "selectionbox": { "x1": 0, "y1": 0, "z1": 0, "x2": 1, "y2": 0.5, "z2": 1 },
   "blockmaterial": "Stone",
   "resistance": 5,
-  "sidesolid": { "all": true },
-  "sideopaque": { "all": true },
-  "lightAbsorption": 99,
-  "replaceable": 100,
+  "sidesolid": { "all": false },
+  "sideopaque": { "all": false },
+  "lightAbsorption": 0,
+  "replaceable": 500,
   "maxStackSize": 1,
   "attributes": {
     "divineAscensionCaravanShrine": true

--- a/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
+++ b/DivineAscension/assets/divineascension/blocktypes/caravanshrine.json
@@ -8,20 +8,20 @@
     "general": ["*"],
     "decorative": ["*"]
   },
-  "shape": { "base": "game:block/basic/cube" },
+  "shape": { "base": "game:block/clutter/table-aged" },
   "textures": {
-    "up": { "base": "game:block/stone/altar/top" },
-    "down": { "base": "game:block/stone/altar/bottom" },
-    "south": { "base": "game:block/stone/altar/front" },
-    "north": { "base": "game:block/stone/altar/back" },
-    "west": { "base": "game:block/stone/altar/left" },
-    "east": { "base": "game:block/stone/altar/right" }
+    "top": { "base": "game:block/wood/table/aged/top" },
+    "bottom": { "base": "game:block/wood/table/aged/bottom" },
+    "legs": { "base": "game:block/wood/table/aged/legs" },
+    "sides": { "base": "game:block/wood/table/aged/sides" }
   },
-  "blockmaterial": "Stone",
-  "resistance": 5,
-  "sidesolid": { "all": true },
-  "sideopaque": { "all": true },
-  "lightAbsorption": 99,
+  "collisionbox": { "x1": 0, "y1": 0.75, "z1": 0, "x2": 1, "y2": 1, "z2": 1 },
+  "selectionbox": { "x1": 0, "y1": 0.75, "z1": 0, "x2": 1, "y2": 1, "z2": 1 },
+  "blockmaterial": "Wood",
+  "resistance": 3,
+  "sidesolid": { "all": false },
+  "sideopaque": { "all": false },
+  "lightAbsorption": 0,
   "replaceable": 500,
   "maxStackSize": 1,
   "attributes": {

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1539,5 +1539,13 @@
   "blockdesc-lectern-agedopen-north": "Right-click to open the codex.",
   "blockdesc-lectern-agedopen-east": "Right-click to open the codex.",
   "blockdesc-lectern-agedopen-south": "Right-click to open the codex.",
-  "blockdesc-lectern-agedopen-west": "Right-click to open the codex."
+  "blockdesc-lectern-agedopen-west": "Right-click to open the codex.",
+  "block-caravanshrine": "Caravan Shrine",
+  "blockdesc-caravanshrine": "A portable wayside shrine of the open road. Acts as a tier-1 altar. Granted by the Avatar of the Road blessing.",
+  "caravanshrine.error.no_blessing": "You must unlock 'Avatar of the Road' to place a Caravan Shrine.",
+  "caravanshrine.error.already_placed": "You already have a Caravan Shrine placed. Break it to relocate.",
+  "caravanshrine.error.foreign_holysite": "You cannot place a Caravan Shrine inside another religion's holy site.",
+  "caravanshrine.placed": "Caravan Shrine placed. May the road carry you far.",
+  "caravanshrine.granted": "The road provides — a Caravan Shrine has been added to your inventory.",
+  "caravanshrine.returned": "Caravan Shrine returned to your inventory."
 }


### PR DESCRIPTION
Closes #432.

## Summary
- New block `divineascension:caravanshrine` using the vanilla trader-cloth-table shape, granted by the `caravan_avatar_road` capstone via a new `GrantsCaravanShrineEffect` special-effect handler.
- `BlockBehaviorCaravanShrine` reuses `AltarEventEmitter`; standard altar handlers filter on code path so they ignore the shrine and vice versa.
- `CaravanShrinePlacementHandler` enforces blessing required, one-shrine-per-player, no placement inside another religion's holy site.
- `CaravanShrineDestructionHandler` clears the recorded position and refunds the shrine item directly to the placer.
- `PlayerProgressionData` persists the placed position via three nullable ProtoMember ints so reload preserves the one-per-player invariant.

## Deferred
- **Right-click UI panel** — folded into #433 (Caravan trade dialog) where the trade table makes the click meaningful.
- **Recipe** — currently capstone-only acquisition. Open question whether to add a crafting recipe later.
- **Prayer integration** — the shrine emits altar events, but `HolySiteValidationStep` still rejects non-consecrated positions. Tier-1-altar prayer wiring is a follow-up.

## Test plan
- [x] `dotnet build` clean.
- [x] `dotnet test` — full suite 2441/2441 passes locally.
- [ ] Manual: unlock `caravan_avatar_road` → shrine appears in inventory.
- [ ] Manual: place shrine → block renders as draped trader table.
- [ ] Manual: second placement attempt rejected with localized error.
- [ ] Manual: break shrine → item returned to inventory; can re-place.
- [ ] Manual: save/reload preserves placed position (cannot place a second one after reload).