### PR TITLE
feat(caravan): Caravan domain (shrine trade table) shipped behind off-flag

### DIFF
--- a/DivineAscension.Tests/GUI/UI/Utilities/DomainHelperTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Utilities/DomainHelperTests.cs
@@ -15,14 +15,24 @@ public class DomainHelperTests
     [Fact]
     public void DeityNames_ContainsAllDomains()
     {
-        // Assert - DeityNames is now an alias for DomainNames
-        Assert.Equal(6, DomainHelper.DeityNames.Length);
+        // DeityNames is an alias for DomainNames. Caravan is gated behind
+        // FeatureFlags.CaravanDomainEnabled, so it's present only when enabled.
         Assert.Contains("Craft", DomainHelper.DeityNames);
         Assert.Contains("Wild", DomainHelper.DeityNames);
         Assert.Contains("Conquest", DomainHelper.DeityNames);
         Assert.Contains("Harvest", DomainHelper.DeityNames);
         Assert.Contains("Stone", DomainHelper.DeityNames);
-        Assert.Contains("Caravan", DomainHelper.DeityNames);
+
+        if (DivineAscension.Configuration.FeatureFlags.CaravanDomainEnabled)
+        {
+            Assert.Equal(6, DomainHelper.DeityNames.Length);
+            Assert.Contains("Caravan", DomainHelper.DeityNames);
+        }
+        else
+        {
+            Assert.Equal(5, DomainHelper.DeityNames.Length);
+            Assert.DoesNotContain("Caravan", DomainHelper.DeityNames);
+        }
     }
 
     #endregion

--- a/DivineAscension.Tests/Systems/Caravan/CaravanTradeSessionManagerTests.cs
+++ b/DivineAscension.Tests/Systems/Caravan/CaravanTradeSessionManagerTests.cs
@@ -1,0 +1,239 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.Network.Caravan;
+using DivineAscension.Services;
+using DivineAscension.Systems.Caravan;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using Vintagestory.API.Server;
+using Xunit;
+
+namespace DivineAscension.Tests.Systems.Caravan;
+
+/// <summary>
+///     Tests for the server-authoritative caravan trade session state machine (#433):
+///     seating, sync broadcast, anti-switcheroo ready-clear, cancel, and disconnect.
+///     Players are created via <see cref="FakeWorldService" /> so the manager's broadcasts
+///     can resolve them; their mock entity has no world position, so the open-time
+///     proximity check is skipped (covered separately by integration/play-test).
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class CaravanTradeSessionManagerTests
+{
+    private readonly SpyNetworkService _net = new();
+    private readonly FakeWorldService _world = new();
+    private readonly FakeEventService _events = new();
+    private readonly SpyPlayerMessenger _messenger = new();
+    private readonly CaravanTradeSessionManager _manager;
+
+    private readonly IServerPlayer _alice;
+    private readonly IServerPlayer _bob;
+    private readonly IServerPlayer _carol;
+
+    // Shrine positions kept near origin so the (0,0,0) mock entity position is in reach.
+    private static readonly (int X, int Y, int Z) Shrine = (1, 0, 1);
+    private static readonly (int X, int Y, int Z) OtherShrine = (3, 0, 1);
+
+    public CaravanTradeSessionManagerTests()
+    {
+        var logger = new Mock<ILoggerWrapper>().Object;
+        _manager = new CaravanTradeSessionManager(logger, _net, _world, _events, _messenger);
+        _manager.Initialize();
+
+        _alice = _world.CreatePlayer("alice", "Alice");
+        _bob = _world.CreatePlayer("bob", "Bob");
+        _carol = _world.CreatePlayer("carol", "Carol");
+    }
+
+    // ----- helpers -----
+
+    private void Open(IServerPlayer player, (int X, int Y, int Z) pos)
+        => _net.SimulateReceive(player, new OpenTradeRequestPacket { ShrineX = pos.X, ShrineY = pos.Y, ShrineZ = pos.Z });
+
+    private void Offer(IServerPlayer player, (int X, int Y, int Z) pos, params string[] names)
+        => _net.SimulateReceive(player, new OfferUpdatePacket
+        {
+            ShrineX = pos.X,
+            ShrineY = pos.Y,
+            ShrineZ = pos.Z,
+            Offer = names.Select((n, i) => new TradeOfferSlot { ItemCode = n, DisplayName = n, Quantity = 1, SlotIndex = i }).ToList()
+        });
+
+    private void SetReady(IServerPlayer player, (int X, int Y, int Z) pos, bool ready)
+        => _net.SimulateReceive(player, new SetReadyPacket { ShrineX = pos.X, ShrineY = pos.Y, ShrineZ = pos.Z, Ready = ready });
+
+    private void Cancel(IServerPlayer player, (int X, int Y, int Z) pos)
+        => _net.SimulateReceive(player, new CancelTradePacket { ShrineX = pos.X, ShrineY = pos.Y, ShrineZ = pos.Z });
+
+    private TradeStateSyncPacket? LastSync() => _net.GetLastSentMessage<TradeStateSyncPacket>();
+
+    private int SyncCount() => _net.GetSentMessages<TradeStateSyncPacket>().Count();
+
+    private List<TradeStateSyncPacket> SyncsTo(string uid) => _net.GetSentMessages()
+        .Where(m => m.Message is TradeStateSyncPacket && m.Player?.PlayerUID == uid)
+        .Select(m => (TradeStateSyncPacket)m.Message)
+        .ToList();
+
+    // ----- tests -----
+
+    [Fact]
+    public void OpenTrade_FirstPlayer_SeatsSideA_AwaitingPartner()
+    {
+        Open(_alice, Shrine);
+
+        var sync = LastSync();
+        Assert.NotNull(sync);
+        Assert.Equal(TradePhase.AwaitingPartner, sync!.Phase);
+        Assert.Equal("alice", sync.SideAPlayerUid);
+        Assert.Equal(string.Empty, sync.SideBPlayerUid);
+        Assert.Single(SyncsTo("alice"));
+    }
+
+    [Fact]
+    public void OpenTrade_SecondPlayer_SeatsSideB_Active_BroadcastsToBoth()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+
+        var sync = LastSync();
+        Assert.NotNull(sync);
+        Assert.Equal(TradePhase.Active, sync!.Phase);
+        Assert.Equal("alice", sync.SideAPlayerUid);
+        Assert.Equal("bob", sync.SideBPlayerUid);
+
+        // Both participants receive the post-join snapshot.
+        Assert.Contains(SyncsTo("alice"), s => s.Phase == TradePhase.Active);
+        Assert.Contains(SyncsTo("bob"), s => s.Phase == TradePhase.Active);
+    }
+
+    [Fact]
+    public void OpenTrade_ThirdPlayer_RejectedAsFull()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+        Open(_carol, Shrine);
+
+        // Carol is never seated, so she never receives a sync.
+        Assert.Empty(SyncsTo("carol"));
+        Assert.True(_messenger.GetMessageCountForPlayer("carol") > 0);
+    }
+
+    [Fact]
+    public void OfferUpdate_BroadcastsToBoth_AndClampsToNine()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+
+        var twelve = Enumerable.Range(0, 12).Select(i => $"item{i}").ToArray();
+        Offer(_alice, Shrine, twelve);
+
+        var sync = LastSync();
+        Assert.NotNull(sync);
+        Assert.Equal(CaravanTradeSession.MaxOfferSlots, sync!.SideAOffer.Count);
+        Assert.Equal(0, sync.SideAOffer[0].SlotIndex);
+        Assert.Equal(8, sync.SideAOffer[8].SlotIndex);
+    }
+
+    [Fact]
+    public void OfferUpdate_ClearsBothReadyFlags_AntiSwitcheroo()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+        SetReady(_alice, Shrine, true);
+        SetReady(_bob, Shrine, true);
+
+        var sealedSync = LastSync();
+        Assert.True(sealedSync!.SideAReady);
+        Assert.True(sealedSync.SideBReady);
+
+        // Alice changes her offer — both seals must break.
+        Offer(_alice, Shrine, "axe");
+
+        var after = LastSync();
+        Assert.False(after!.SideAReady);
+        Assert.False(after.SideBReady);
+    }
+
+    [Fact]
+    public void SetReady_BeforePartnerJoins_IsIgnored()
+    {
+        Open(_alice, Shrine);
+        SetReady(_alice, Shrine, true);
+
+        var sync = LastSync();
+        Assert.False(sync!.SideAReady);
+    }
+
+    [Fact]
+    public void SetReady_BothParties_ReachesSealedState()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+        SetReady(_alice, Shrine, true);
+        SetReady(_bob, Shrine, true);
+
+        var sync = LastSync();
+        Assert.True(sync!.SideAReady);
+        Assert.True(sync.SideBReady);
+        Assert.Equal(TradePhase.Active, sync.Phase);
+    }
+
+    [Fact]
+    public void CancelTrade_ClosesSession_NotifiesPartner_AndIgnoresLaterPackets()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+
+        Cancel(_alice, Shrine);
+
+        // A Closed snapshot is pushed so dialogs tear down.
+        var sync = LastSync();
+        Assert.NotNull(sync);
+        Assert.Equal(TradePhase.Closed, sync!.Phase);
+
+        // Partner Bob is told the table closed.
+        Assert.True(_messenger.GetMessageCountForPlayer("bob") > 0);
+
+        // Session is gone — further offers from Bob produce no new sync.
+        var before = SyncCount();
+        Offer(_bob, Shrine, "bread");
+        Assert.Equal(before, SyncCount());
+    }
+
+    [Fact]
+    public void Disconnect_ClosesSession_NotifiesRemainingPartner()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+
+        _events.TriggerPlayerDisconnect(_alice);
+
+        var sync = LastSync();
+        Assert.NotNull(sync);
+        Assert.Equal(TradePhase.Closed, sync!.Phase);
+        Assert.True(_messenger.GetMessageCountForPlayer("bob") > 0);
+    }
+
+    [Fact]
+    public void OpenTrade_SamePlayerReopens_ResendsSnapshotWithoutDoubleSeating()
+    {
+        Open(_alice, Shrine);
+        Open(_alice, Shrine);
+
+        var sync = LastSync();
+        Assert.Equal("alice", sync!.SideAPlayerUid);
+        Assert.Equal(string.Empty, sync.SideBPlayerUid);
+    }
+
+    [Fact]
+    public void OpenTrade_WhileSeatedElsewhere_IsRejected()
+    {
+        Open(_alice, Shrine);
+        Open(_alice, OtherShrine);
+
+        // No session ever syncs the other shrine; Alice gets an error instead.
+        Assert.DoesNotContain(_net.GetSentMessages<TradeStateSyncPacket>(), s => s.ShrineX == OtherShrine.X);
+        Assert.True(_messenger.GetMessageCountForPlayer("alice") > 0);
+    }
+}

--- a/DivineAscension/Blocks/BlockBehaviorCaravanShrine.cs
+++ b/DivineAscension/Blocks/BlockBehaviorCaravanShrine.cs
@@ -1,3 +1,4 @@
+using System;
 using DivineAscension.Systems.Altar;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -6,15 +7,22 @@ using Vintagestory.API.Server;
 namespace DivineAscension.Blocks;
 
 /// <summary>
-///     BlockBehavior on the Caravan Shrine block. Reuses <see cref="AltarEventEmitter"/>
-///     so the shrine emits prayer/use events that flow through the standard altar pipeline
-///     (acts as a tier-1 altar — see <c>HolySiteValidationStep</c>).
-///     The standard altar placement/destruction handlers filter on code path and ignore the
-///     shrine; dedicated shrine handlers subscribe to the same emitter for shrine-only rules.
+///     BlockBehavior on the Caravan Shrine block. Placement/destruction still flow through
+///     <see cref="AltarEventEmitter"/> so the shrine sites a tier-1 holy site like an altar.
+///     Right-clicking the shrine opens the player-to-player trade table (#433) rather than
+///     praying — prayer is performed at the regular altar. The trade open is client-initiated:
+///     the behavior runs client-side and asks the trade dialog to send an
+///     <c>OpenTradeRequest</c>; the server is authoritative for seating and state.
 /// </summary>
 public class BlockBehaviorCaravanShrine : BlockBehavior
 {
     private static AltarEventEmitter? _emitter;
+
+    /// <summary>
+    ///     Client-side hook set by the trade dialog (no DI in behaviors). Invoked with the
+    ///     shrine position when a player right-clicks the block on the client.
+    /// </summary>
+    private static Action<BlockPos>? _onTradeInteractClient;
 
     public BlockBehaviorCaravanShrine(Block block) : base(block)
     {
@@ -25,16 +33,35 @@ public class BlockBehaviorCaravanShrine : BlockBehavior
         _emitter = emitter;
     }
 
+    public static void SetTradeInteractClientHandler(Action<BlockPos>? handler)
+    {
+        _onTradeInteractClient = handler;
+    }
+
     public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer,
         BlockSelection blockSel, ref EnumHandling handling)
     {
-        if (world.Side == EnumAppSide.Server)
+        // Trade is opened from the client; the server seats the player when the
+        // OpenTradeRequest packet arrives. No prayer event is raised for the shrine.
+        if (world.Side == EnumAppSide.Client && blockSel?.Position != null)
         {
-            _emitter?.RaiseAltarUsed(byPlayer, blockSel);
+            _onTradeInteractClient?.Invoke(blockSel.Position);
         }
 
         handling = EnumHandling.PreventSubsequent;
         return true;
+    }
+
+    /// <summary>
+    ///     End the interaction immediately. Without this VS keeps the player in a use-block
+    ///     hold loop until right-click is released — and with the ImGui trade dialog open the
+    ///     release goes to ImGui, leaving the camera pinned. Mirrors BlockBehaviorLectern.
+    /// </summary>
+    public override bool OnBlockInteractStep(float secondsUsed, IWorldAccessor world, IPlayer byPlayer,
+        BlockSelection blockSelection, ref EnumHandling handled)
+    {
+        handled = EnumHandling.PreventSubsequent;
+        return false;
     }
 
     public override void OnBlockBroken(IWorldAccessor world, BlockPos pos,

--- a/DivineAscension/Configuration/FeatureFlags.cs
+++ b/DivineAscension/Configuration/FeatureFlags.cs
@@ -1,0 +1,26 @@
+namespace DivineAscension.Configuration;
+
+/// <summary>
+///     Compile-time feature flags for domains/features still in development.
+///     Flip to <c>true</c> and rebuild to enable. Kept off so unfinished work can
+///     ship in mainline (no branch divergence) while it bakes.
+/// </summary>
+public static class FeatureFlags
+{
+    /// <summary>
+    ///     Caravan domain (#433): the Caravan patron deity, its favor sources
+    ///     (exploration + NPC-trade), the portable trade-table shrine block, and the
+    ///     <c>trade_hub</c> civilization milestone. Off until the domain is debugged
+    ///     and balance-tested. When false:
+    ///     <list type="bullet">
+    ///         <item>Caravan is hidden from the deity selector.</item>
+    ///         <item>The shrine placement/destruction + trade-session servers are not constructed.</item>
+    ///         <item>The Civilization milestone manager ignores NPC-trade events.</item>
+    ///         <item><c>trade_hub</c> is dropped from the loaded milestone set.</item>
+    ///     </list>
+    ///     The caravan favor trackers still construct (harmless: no player can worship
+    ///     Caravan, so their awards no-op), and the shrine block stays registered but
+    ///     creative-inventory-only.
+    /// </summary>
+    public const bool CaravanDomainEnabled = false;
+}

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -11,11 +11,13 @@ using DivineAscension.Constants;
 using DivineAscension.Data;
 using DivineAscension.GUI.State;
 using DivineAscension.Network;
+using DivineAscension.Network.Caravan;
 using DivineAscension.Network.Civilization;
 using DivineAscension.Network.Diplomacy;
 using DivineAscension.Network.HolySite;
 using DivineAscension.Services;
 using DivineAscension.Systems;
+using DivineAscension.Systems.Caravan;
 using DivineAscension.Systems.Altar;
 using DivineAscension.Systems.Lectern;
 using DivineAscension.Systems.Interfaces;
@@ -45,6 +47,7 @@ public class DivineAscensionModSystem : ModSystem
     private AltarPrayerHandler? _altarPrayerHandler;
     private CaravanShrinePlacementHandler? _caravanShrinePlacementHandler;
     private CaravanShrineDestructionHandler? _caravanShrineDestructionHandler;
+    private CaravanTradeSessionManager? _caravanTradeSessionManager;
     private LecternEventEmitter? _lecternEventEmitter;
     private LecternInteractionHandler? _lecternInteractionHandler;
     private BlessingNetworkHandler? _blessingNetworkHandler;
@@ -205,7 +208,13 @@ public class DivineAscensionModSystem : ModSystem
             .RegisterMessageType<MilestoneProgressResponsePacket>()
             .RegisterMessageType<MilestoneUnlockedPacket>()
             .RegisterMessageType<OpenMenuPacket>()
-            .RegisterMessageType<CloseMenuPacket>();
+            .RegisterMessageType<CloseMenuPacket>()
+            .RegisterMessageType<OpenTradeRequestPacket>()
+            .RegisterMessageType<JoinTradeRequestPacket>()
+            .RegisterMessageType<OfferUpdatePacket>()
+            .RegisterMessageType<SetReadyPacket>()
+            .RegisterMessageType<CancelTradePacket>()
+            .RegisterMessageType<TradeStateSyncPacket>();
     }
 
     public override void AssetsFinalize(ICoreAPI api)
@@ -251,6 +260,7 @@ public class DivineAscensionModSystem : ModSystem
         _altarDestructionHandler = result.AltarDestructionHandler;
         _caravanShrinePlacementHandler = result.CaravanShrinePlacementHandler;
         _caravanShrineDestructionHandler = result.CaravanShrineDestructionHandler;
+        _caravanTradeSessionManager = result.CaravanTradeSessionManager;
         _altarPrayerHandler = result.AltarPrayerHandler;
         _altarEventEmitter = result.AltarEventEmitter;
         _lecternEventEmitter = result.LecternEventEmitter;
@@ -336,6 +346,7 @@ public class DivineAscensionModSystem : ModSystem
         _altarDestructionHandler?.Dispose();
         _caravanShrinePlacementHandler?.Dispose();
         _caravanShrineDestructionHandler?.Dispose();
+        _caravanTradeSessionManager?.Dispose();
         _altarPrayerHandler?.Dispose();
         _lecternInteractionHandler?.Dispose();
         _playerReligionDataManager?.Dispose();

--- a/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
+++ b/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using DivineAscension.API.Implementation;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Blocks;
+using DivineAscension.GUI.UI.Renderers.Caravan;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Network.Caravan;
+using DivineAscension.Systems.Caravan;
+using DivineAscension.Systems.Networking.Client;
+using ImGuiNET;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using VSImGui;
+using VSImGui.API;
+
+namespace DivineAscension.GUI.Caravan;
+
+/// <summary>
+///     Client-side ImGui dialog for the caravan shrine trade table (#433). Opens when the
+///     server sends a <see cref="TradeStateSyncPacket" /> for a session the local player is
+///     seated at (triggered by right-clicking a caravan shrine), renders the "Bill of Barter"
+///     ledger, and relays click intents back as offer/ready/cancel packets. UI + sync only —
+///     no item movement.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class CaravanTradeDialog : ModSystem
+{
+    private const float WindowWidth = 1040f;
+    private const float WindowHeight = 660f;
+
+    private readonly CaravanTradeState _state = new();
+
+    private ICoreClientAPI? _capi;
+    private DivineAscensionModSystem? _das;
+    private DivineAscensionNetworkClient? _network;
+    private ImGuiModSystem? _imgui;
+    private IModLoaderService? _modLoader;
+    private ImGuiViewportPtr _viewport;
+
+    public override bool ShouldLoad(EnumAppSide forSide) => forSide == EnumAppSide.Client;
+
+    public override double ExecuteOrder() => 1.6; // after DivineAscensionModSystem (1.0) and GuiDialog (1.5)
+
+    public override void StartClientSide(ICoreClientAPI api)
+    {
+        base.StartClientSide(api);
+        _capi = api;
+        _viewport = ImGui.GetMainViewport();
+        _modLoader = new ModLoaderService(api.ModLoader);
+
+        _das = _modLoader.GetModSystem<DivineAscensionModSystem>();
+        _network = _das?.NetworkClient;
+        if (_network != null)
+            _network.TradeStateReceived += OnTradeState;
+
+        // No DI in block behaviors: route the shrine right-click through the network client.
+        BlockBehaviorCaravanShrine.SetTradeInteractClientHandler(pos => _network?.SendOpenTradeRequest(pos));
+
+        _imgui = _modLoader.GetModSystem<ImGuiModSystem>();
+        if (_imgui != null)
+        {
+            _imgui.Draw += OnDraw;
+            _imgui.Closed += OnClose;
+        }
+
+        api.Logger.Notification("[DivineAscension] Caravan trade dialog initialized");
+    }
+
+    private void OnTradeState(TradeStateSyncPacket packet)
+    {
+        if (packet.Phase == TradePhase.Closed)
+        {
+            _state.IsOpen = false;
+            return;
+        }
+
+        _state.Apply(packet);
+        if (!_state.IsOpen)
+        {
+            _state.IsOpen = true;
+            _imgui?.Show();
+        }
+    }
+
+    private CallbackGUIStatus OnDraw(float deltaSeconds)
+    {
+        if (!_state.IsOpen || _capi == null) return CallbackGUIStatus.Closed;
+
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+        {
+            // Hide locally; the seat persists server-side until "Leave the table".
+            _state.IsOpen = false;
+            return CallbackGUIStatus.Closed;
+        }
+
+        DrawWindow();
+        return CallbackGUIStatus.GrabMouse;
+    }
+
+    private void DrawWindow()
+    {
+        var width = MathF.Min(WindowWidth, _viewport.Size.X - 64f);
+        var height = MathF.Min(WindowHeight, _viewport.Size.Y - 64f);
+
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0);
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0);
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
+        ImGui.PushStyleColor(ImGuiCol.WindowBg, ColorPalette.Background);
+
+        ImGui.SetNextWindowSize(new Vector2(width, height), ImGuiCond.Always);
+        ImGui.SetNextWindowPos(new Vector2(
+            _viewport.Pos.X + (_viewport.Size.X - width) / 2f,
+            _viewport.Pos.Y + (_viewport.Size.Y - height) / 2f), ImGuiCond.Always);
+
+        var flags = ImGuiWindowFlags.NoTitleBar |
+                    ImGuiWindowFlags.NoResize |
+                    ImGuiWindowFlags.NoMove |
+                    ImGuiWindowFlags.NoScrollbar |
+                    ImGuiWindowFlags.NoScrollWithMouse |
+                    ImGuiWindowFlags.NoSavedSettings;
+
+        ImGui.Begin("DivineAscension Caravan Trade", flags);
+
+        var pos = ImGui.GetWindowPos();
+        var size = ImGui.GetWindowSize();
+
+        // Border to match the main codex frame.
+        var drawList = ImGui.GetWindowDrawList();
+        drawList.AddRect(pos, new Vector2(pos.X + size.X, pos.Y + size.Y),
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 0, ImDrawFlags.None, 4f);
+
+        var myUid = _capi!.World.Player.PlayerUID;
+        var pack = BuildPack();
+
+        var result = CaravanTradeRenderer.Draw(_state, myUid, pack, pos.X, pos.Y, size.X, size.Y);
+        ApplyResult(result, myUid, pack);
+
+        ImGui.End();
+        ImGui.PopStyleColor();
+        ImGui.PopStyleVar(3);
+    }
+
+    private void ApplyResult(CaravanTradeRenderer.Result result, string myUid,
+        IReadOnlyList<CaravanTradeRenderer.PackEntry> pack)
+    {
+        if (_network == null || _state.ShrinePos == null) return;
+
+        if (result.AddPackIndex >= 0 && result.AddPackIndex < pack.Count)
+        {
+            var entry = pack[result.AddPackIndex];
+            var offer = CloneMyOffer(myUid);
+            if (offer.Count < CaravanTradeSession.MaxOfferSlots)
+            {
+                offer.Add(new TradeOfferSlot
+                {
+                    ItemCode = entry.Code,
+                    DisplayName = entry.Name,
+                    Quantity = entry.Quantity,
+                    SlotIndex = offer.Count
+                });
+                _network.SendOfferUpdate(_state.ShrinePos, offer);
+            }
+        }
+        else if (result.RemoveOfferIndex >= 0)
+        {
+            var offer = CloneMyOffer(myUid);
+            if (result.RemoveOfferIndex < offer.Count)
+            {
+                offer.RemoveAt(result.RemoveOfferIndex);
+                _network.SendOfferUpdate(_state.ShrinePos, offer);
+            }
+        }
+        else if (result.SealToggleClicked)
+        {
+            _network.SendSetReady(_state.ShrinePos, !_state.MyReady(myUid));
+        }
+        else if (result.LeaveClicked)
+        {
+            _network.SendCancelTrade(_state.ShrinePos);
+            _state.IsOpen = false;
+        }
+    }
+
+    private List<TradeOfferSlot> CloneMyOffer(string myUid)
+        => _state.MyOffer(myUid)
+            .Select(s => new TradeOfferSlot
+            {
+                ItemCode = s.ItemCode,
+                DisplayName = s.DisplayName,
+                Quantity = s.Quantity,
+                SlotIndex = s.SlotIndex
+            })
+            .ToList();
+
+    /// <summary>
+    ///     Snapshot the local player's hotbar + backpack as click-to-add pack entries.
+    ///     Read-only — items are not moved (that is #434).
+    /// </summary>
+    private List<CaravanTradeRenderer.PackEntry> BuildPack()
+    {
+        var entries = new List<CaravanTradeRenderer.PackEntry>();
+        var player = _capi?.World.Player;
+        if (player?.InventoryManager == null) return entries;
+
+        foreach (var className in new[] { GlobalConstants.hotBarInvClassName, GlobalConstants.backpackInvClassName })
+        {
+            var inventory = player.InventoryManager.GetOwnInventory(className);
+            if (inventory == null) continue;
+
+            foreach (var slot in inventory)
+            {
+                var stack = slot?.Itemstack;
+                if (stack?.Collectible?.Code == null) continue;
+                entries.Add(new CaravanTradeRenderer.PackEntry(
+                    stack.Collectible.Code.ToString(),
+                    stack.GetName(),
+                    stack.StackSize));
+            }
+        }
+
+        return entries;
+    }
+
+    private void OnClose()
+    {
+        _state.IsOpen = false;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        if (_network != null)
+            _network.TradeStateReceived -= OnTradeState;
+        if (_imgui != null)
+        {
+            _imgui.Draw -= OnDraw;
+            _imgui.Closed -= OnClose;
+        }
+        BlockBehaviorCaravanShrine.SetTradeInteractClientHandler(null);
+    }
+}

--- a/DivineAscension/GUI/Caravan/CaravanTradeState.cs
+++ b/DivineAscension/GUI/Caravan/CaravanTradeState.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using DivineAscension.Network.Caravan;
+using DivineAscension.Systems.Caravan;
+using Vintagestory.API.MathTools;
+
+namespace DivineAscension.GUI.Caravan;
+
+/// <summary>
+///     Client-side view state for the caravan trade dialog. Holds the latest
+///     server-authoritative <see cref="TradeStateSyncPacket" /> snapshot and resolves
+///     which side is "self" so the local trader always renders on the left.
+/// </summary>
+public class CaravanTradeState
+{
+    public bool IsOpen { get; set; }
+
+    public BlockPos? ShrinePos { get; private set; }
+    public TradePhase Phase { get; private set; } = TradePhase.AwaitingPartner;
+
+    public string SideAUid { get; private set; } = string.Empty;
+    public string SideAName { get; private set; } = string.Empty;
+    public bool SideAReady { get; private set; }
+    public List<TradeOfferSlot> SideAOffer { get; private set; } = new();
+
+    public string SideBUid { get; private set; } = string.Empty;
+    public string SideBName { get; private set; } = string.Empty;
+    public bool SideBReady { get; private set; }
+    public List<TradeOfferSlot> SideBOffer { get; private set; } = new();
+
+    public void Apply(TradeStateSyncPacket packet)
+    {
+        ShrinePos = new BlockPos(packet.ShrineX, packet.ShrineY, packet.ShrineZ);
+        Phase = packet.Phase;
+        SideAUid = packet.SideAPlayerUid;
+        SideAName = packet.SideAPlayerName;
+        SideAReady = packet.SideAReady;
+        SideAOffer = packet.SideAOffer ?? new List<TradeOfferSlot>();
+        SideBUid = packet.SideBPlayerUid;
+        SideBName = packet.SideBPlayerName;
+        SideBReady = packet.SideBReady;
+        SideBOffer = packet.SideBOffer ?? new List<TradeOfferSlot>();
+    }
+
+    public TradeSide GetMySide(string myUid)
+    {
+        if (SideAUid == myUid) return TradeSide.A;
+        if (SideBUid == myUid) return TradeSide.B;
+        return TradeSide.None;
+    }
+
+    public List<TradeOfferSlot> MyOffer(string myUid)
+        => GetMySide(myUid) == TradeSide.B ? SideBOffer : SideAOffer;
+
+    public List<TradeOfferSlot> TheirOffer(string myUid)
+        => GetMySide(myUid) == TradeSide.B ? SideAOffer : SideBOffer;
+
+    public bool MyReady(string myUid) => GetMySide(myUid) == TradeSide.B ? SideBReady : SideAReady;
+
+    public bool TheirReady(string myUid) => GetMySide(myUid) == TradeSide.B ? SideAReady : SideBReady;
+
+    public string MyName(string myUid) => GetMySide(myUid) == TradeSide.B ? SideBName : SideAName;
+
+    /// <summary>Partner display name, or empty while still awaiting a second trader.</summary>
+    public string TheirName(string myUid) => GetMySide(myUid) == TradeSide.B ? SideAName : SideBName;
+
+    public bool HasPartner(string myUid)
+    {
+        var mine = GetMySide(myUid);
+        if (mine == TradeSide.B) return !string.IsNullOrEmpty(SideAUid);
+        return !string.IsNullOrEmpty(SideBUid);
+    }
+}

--- a/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using DivineAscension.Configuration;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models.Enum;
@@ -20,14 +21,21 @@ internal static class DeitySelectorRenderer
     private const float PatronBorderThickness = 2.5f;
     private const float ActiveBorderThickness = 2f;
     public const float Height = TabSize + 4f;
-    public const int TabCount = 6;
+    public const int TabCount = FeatureFlags.CaravanDomainEnabled ? 6 : 5;
     public const float StripWidth = TabCount * TabSize + (TabCount - 1) * TabSpacing;
 
-    private static readonly DeityDomain[] Order =
-    {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
-        DeityDomain.Caravan
-    };
+    // Caravan is appended only when its domain is enabled (see FeatureFlags). Keep the
+    // count above (TabCount) in sync with this array's length.
+    private static readonly DeityDomain[] Order = FeatureFlags.CaravanDomainEnabled
+        ? new[]
+        {
+            DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
+            DeityDomain.Caravan
+        }
+        : new[]
+        {
+            DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone
+        };
 
     /// <summary>
     ///     Draw the deity selector. Returns the deity the user clicked this frame, or null.

--- a/DivineAscension/GUI/UI/Renderers/Caravan/CaravanTradeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Caravan/CaravanTradeRenderer.cs
@@ -1,0 +1,247 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.Caravan;
+using DivineAscension.GUI.UI.Components.Buttons;
+using DivineAscension.GUI.UI.Renderers.Utilities;
+using DivineAscension.GUI.UI.Utilities;
+using DivineAscension.Models.Enum;
+using DivineAscension.Network.Caravan;
+using DivineAscension.Services;
+using ImGuiNET;
+
+namespace DivineAscension.GUI.UI.Renderers.Caravan;
+
+/// <summary>
+///     Renders the caravan trade table as a paper "Bill of Barter" ledger: a chapter
+///     strip with the Caravan glyph, two side-by-side offer columns (self always left),
+///     dotted-leader item lines, a per-side wax-seal mark, the local player's pack as
+///     click-to-add entries, and Seal / Leave actions. Stateless — returns the click
+///     intents for the dialog to act on. UI only; no item movement (#433).
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class CaravanTradeRenderer
+{
+    private const float Padding = 18f;
+    private const float ColumnGap = 28f;
+    private const float RowHeight = 26f;
+    private const float SectionGap = 14f;
+
+    /// <summary>A pack item the local player can lay on the table.</summary>
+    public readonly record struct PackEntry(string Code, string Name, int Quantity);
+
+    public readonly record struct Result(
+        int AddPackIndex,
+        int RemoveOfferIndex,
+        bool SealToggleClicked,
+        bool LeaveClicked);
+
+    public static Result Draw(
+        CaravanTradeState state,
+        string myUid,
+        IReadOnlyList<PackEntry> pack,
+        float windowX,
+        float windowY,
+        float windowWidth,
+        float windowHeight)
+    {
+        var drawList = ImGui.GetWindowDrawList();
+        var x = windowX + Padding;
+        var contentWidth = windowWidth - Padding * 2;
+
+        var addPackIndex = -1;
+        var removeOfferIndex = -1;
+        var sealClicked = false;
+        var leaveClicked = false;
+
+        // Chapter strip with Caravan wagon-wheel glyph.
+        var strip = ChapterStripRenderer.Draw(
+            drawList, x, windowY, contentWidth, 0f,
+            LocalizationService.Instance.Get("caravantrade.title"),
+            rightGlyph: DeityDomain.Caravan);
+        var y = strip.BodyY + SectionGap;
+
+        // Prose intro.
+        TextRenderer.DrawInfoText(drawList,
+            LocalizationService.Instance.Get("caravantrade.intro"),
+            x, y, contentWidth, FontSizes.Body, ColorPalette.Grey);
+        y += RowHeight + 4f;
+
+        // Two columns: self on the left.
+        var colWidth = (contentWidth - ColumnGap) / 2f;
+        var leftX = x;
+        var rightX = x + colWidth + ColumnGap;
+        var columnsTop = y;
+
+        var myName = string.IsNullOrEmpty(state.MyName(myUid)) ? "You" : state.MyName(myUid);
+        var theirName = state.HasPartner(myUid)
+            ? state.TheirName(myUid)
+            : LocalizationService.Instance.Get("caravantrade.awaiting_partner");
+
+        // Left (editable) column — clicking an entry returns it to the pack.
+        var leftBottom = DrawMyColumn(drawList, leftX, columnsTop, colWidth,
+            myName, state.MyOffer(myUid), state.MyReady(myUid), ref removeOfferIndex);
+
+        // Right (read-only) column — the partner's offer.
+        var rightBottom = DrawTheirColumn(drawList, rightX, columnsTop, colWidth,
+            theirName, state.TheirOffer(myUid), state.TheirReady(myUid), state.HasPartner(myUid));
+
+        y = (leftBottom > rightBottom ? leftBottom : rightBottom) + SectionGap;
+
+        // Divider.
+        ChromeRenderer.DrawDivider(drawList, x, y, contentWidth);
+        y += SectionGap;
+
+        // Local pack — click-to-add.
+        TextRenderer.DrawLabel(drawList,
+            LocalizationService.Instance.Get("caravantrade.your_pack"),
+            x, y, FontSizes.SubsectionLabel, ColorPalette.Gold);
+        y += RowHeight;
+
+        var canAdd = state.MyOffer(myUid).Count < CaravanTradeSlotLimit;
+        var packX = x;
+        var packTop = y;
+        for (var i = 0; i < pack.Count; i++)
+        {
+            var entry = pack[i];
+            var label = $"{entry.Name} ×{entry.Quantity}";
+            var btnWidth = ImGui.CalcTextSize(label).X + 24f;
+            if (packX + btnWidth > x + contentWidth)
+            {
+                packX = x;
+                packTop += RowHeight + 4f;
+            }
+
+            if (ButtonRenderer.DrawButton(drawList, label, packX, packTop, btnWidth, RowHeight,
+                    isPrimary: false, enabled: canAdd))
+            {
+                addPackIndex = i;
+            }
+
+            packX += btnWidth + 6f;
+        }
+
+        y = packTop + RowHeight + SectionGap;
+
+        // Footer prose + actions.
+        ChromeRenderer.DrawDivider(drawList, x, y, contentWidth);
+        y += SectionGap;
+        TextRenderer.DrawInfoText(drawList,
+            LocalizationService.Instance.Get("caravantrade.switcheroo_note"),
+            x, y, contentWidth, FontSizes.Secondary, ColorPalette.MutedText);
+        y += RowHeight + 4f;
+
+        const float buttonWidth = 200f;
+        const float buttonHeight = 34f;
+        var sealLabel = LocalizationService.Instance.Get(
+            state.MyReady(myUid) ? "caravantrade.unseal" : "caravantrade.seal");
+        var sealEnabled = state.HasPartner(myUid);
+        var leaveLabel = LocalizationService.Instance.Get("caravantrade.leave");
+
+        var actionsY = windowY + windowHeight - buttonHeight - Padding;
+        if (actionsY < y) actionsY = y;
+        var sealX = x + (contentWidth / 2f) - buttonWidth - 10f;
+        var leaveX = x + (contentWidth / 2f) + 10f;
+
+        if (ButtonRenderer.DrawButton(drawList, sealLabel, sealX, actionsY, buttonWidth, buttonHeight,
+                isPrimary: true, enabled: sealEnabled))
+        {
+            sealClicked = true;
+        }
+
+        if (ButtonRenderer.DrawButton(drawList, leaveLabel, leaveX, actionsY, buttonWidth, buttonHeight,
+                isPrimary: false, enabled: true))
+        {
+            leaveClicked = true;
+        }
+
+        return new Result(addPackIndex, removeOfferIndex, sealClicked, leaveClicked);
+    }
+
+    private const int CaravanTradeSlotLimit = 9;
+
+    private static float DrawMyColumn(ImDrawListPtr drawList, float x, float y, float width,
+        string name, List<TradeOfferSlot> offer, bool ready, ref int removeIndex)
+    {
+        TextRenderer.DrawLabel(drawList, $"❧ {name} lays down", x, y, FontSizes.SubsectionLabel,
+            ColorPalette.White);
+        var rowY = y + RowHeight;
+
+        for (var i = 0; i < offer.Count; i++)
+        {
+            var slot = offer[i];
+            var label = $"{slot.DisplayName} ×{slot.Quantity}";
+            if (ButtonRenderer.DrawButton(drawList, label, x, rowY, width, RowHeight - 4f,
+                    isPrimary: false, enabled: true))
+            {
+                removeIndex = i;
+            }
+
+            rowY += RowHeight;
+        }
+
+        rowY = DrawHandsFree(drawList, x, rowY, offer.Count);
+        DrawSealMark(drawList, x, rowY, ready);
+        return rowY + RowHeight;
+    }
+
+    private static float DrawTheirColumn(ImDrawListPtr drawList, float x, float y, float width,
+        string name, List<TradeOfferSlot> offer, bool ready, bool hasPartner)
+    {
+        TextRenderer.DrawLabel(drawList, $"{name} lays down ❧", x, y, FontSizes.SubsectionLabel,
+            hasPartner ? ColorPalette.White : ColorPalette.MutedText);
+        var rowY = y + RowHeight;
+
+        if (hasPartner)
+        {
+            foreach (var slot in offer)
+            {
+                DrawLeaderLine(drawList, x, rowY, width, slot.DisplayName, $"×{slot.Quantity}");
+                rowY += RowHeight;
+            }
+
+            rowY = DrawHandsFree(drawList, x, rowY, offer.Count);
+            DrawSealMark(drawList, x, rowY, ready);
+        }
+
+        return rowY + RowHeight;
+    }
+
+    private static float DrawHandsFree(ImDrawListPtr drawList, float x, float rowY, int used)
+    {
+        var free = CaravanTradeSlotLimit - used;
+        if (free <= 0) return rowY;
+        TextRenderer.DrawLabel(drawList,
+            $"· · · ({free} hands free)", x, rowY, FontSizes.Secondary, ColorPalette.MutedText);
+        return rowY + RowHeight;
+    }
+
+    private static void DrawSealMark(ImDrawListPtr drawList, float x, float rowY, bool ready)
+    {
+        var mark = ready
+            ? "† " + LocalizationService.Instance.Get("caravantrade.sealed")
+            : "◇ " + LocalizationService.Instance.Get("caravantrade.pondering");
+        TextRenderer.DrawLabel(drawList, mark, x, rowY, FontSizes.Body,
+            ready ? ColorPalette.Verdigris : ColorPalette.MutedText);
+    }
+
+    /// <summary>Draws "name ........ value" with a dotted leader filling the gap.</summary>
+    private static void DrawLeaderLine(ImDrawListPtr drawList, float x, float y, float width,
+        string left, string right)
+    {
+        TextRenderer.DrawLabel(drawList, left, x, y, FontSizes.Body, ColorPalette.White);
+        var rightWidth = ImGui.CalcTextSize(right).X;
+        var rightX = x + width - rightWidth;
+        TextRenderer.DrawLabel(drawList, right, rightX, y, FontSizes.Body, ColorPalette.White);
+
+        var leftWidth = ImGui.CalcTextSize(left).X;
+        var dotsStart = x + leftWidth + 6f;
+        var dotsEnd = rightX - 6f;
+        if (dotsEnd <= dotsStart) return;
+
+        var color = ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor);
+        var dotY = y + FontSizes.Body * 0.6f;
+        for (var dx = dotsStart; dx < dotsEnd; dx += 6f)
+            drawList.AddCircleFilled(new Vector2(dx, dotY), 1f, color);
+    }
+}

--- a/DivineAscension/GUI/UI/Utilities/DomainHelper.cs
+++ b/DivineAscension/GUI/UI/Utilities/DomainHelper.cs
@@ -11,12 +11,12 @@ namespace DivineAscension.GUI.UI.Utilities;
 internal static class DomainHelper
 {
     /// <summary>
-    ///     All domain names in order (6 domains)
+    ///     All selectable domain names in order. Caravan is appended only when its
+    ///     domain is enabled (see <see cref="Configuration.FeatureFlags.CaravanDomainEnabled"/>).
     /// </summary>
-    public static readonly string[] DomainNames =
-    {
-        "Craft", "Wild", "Conquest", "Harvest", "Stone", "Caravan"
-    };
+    public static readonly string[] DomainNames = Configuration.FeatureFlags.CaravanDomainEnabled
+        ? new[] { "Craft", "Wild", "Conquest", "Harvest", "Stone", "Caravan" }
+        : new[] { "Craft", "Wild", "Conquest", "Harvest", "Stone" };
 
     /// <summary>
     ///     Legacy: All deity names (now domain names) - alias for DomainNames

--- a/DivineAscension/Network/Caravan/CaravanTradePackets.cs
+++ b/DivineAscension/Network/Caravan/CaravanTradePackets.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using ProtoBuf;
+
+namespace DivineAscension.Network.Caravan;
+
+/// <summary>
+///     Lifecycle phase of a shrine-hosted trade session, mirrored to clients via
+///     <see cref="TradeStateSyncPacket" />.
+/// </summary>
+public enum TradePhase
+{
+    /// <summary>One trader is seated, waiting for a second to join.</summary>
+    AwaitingPartner = 0,
+
+    /// <summary>Both seats filled; offers and ready flags are live.</summary>
+    Active = 1,
+
+    /// <summary>Session has ended (cancelled, disconnect, or completed). Clients close their dialog.</summary>
+    Closed = 2
+}
+
+/// <summary>
+///     A single offered item line. Phase 4 (#433) is UI + state sync only — no item
+///     movement — so this carries just enough to render the ledger entry. The full
+///     <see cref="ItemCode" /> is retained for the escrow/atomic-swap work in #434.
+/// </summary>
+[ProtoContract]
+public class TradeOfferSlot
+{
+    public TradeOfferSlot()
+    {
+    }
+
+    /// <summary>Full collectible asset code (e.g. <c>game:axe-copper</c>). Drives #434's escrow.</summary>
+    [ProtoMember(1)]
+    public string ItemCode { get; set; } = string.Empty;
+
+    /// <summary>Localized display name resolved on the offering client, shown to both parties.</summary>
+    [ProtoMember(2)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Stack size offered.</summary>
+    [ProtoMember(3)]
+    public int Quantity { get; set; }
+
+    /// <summary>Position within the offering side's grid (0-8).</summary>
+    [ProtoMember(4)]
+    public int SlotIndex { get; set; }
+}
+
+/// <summary>
+///     Client → server. The recipient right-clicked a caravan shrine and wants to sit at
+///     its trade table. Server auto-assigns the seat (side A then side B).
+/// </summary>
+[ProtoContract]
+public class OpenTradeRequestPacket
+{
+    public OpenTradeRequestPacket()
+    {
+    }
+
+    [ProtoMember(1)] public int ShrineX { get; set; }
+    [ProtoMember(2)] public int ShrineY { get; set; }
+    [ProtoMember(3)] public int ShrineZ { get; set; }
+}
+
+/// <summary>
+///     Client → server. Explicit request to take the open seat at a shrine's trade table.
+///     With server-assigned seating the common path is <see cref="OpenTradeRequestPacket" />;
+///     this is defined/handled (routed through the same seating logic) and reserved for a
+///     future invite-driven join.
+/// </summary>
+[ProtoContract]
+public class JoinTradeRequestPacket
+{
+    public JoinTradeRequestPacket()
+    {
+    }
+
+    [ProtoMember(1)] public int ShrineX { get; set; }
+    [ProtoMember(2)] public int ShrineY { get; set; }
+    [ProtoMember(3)] public int ShrineZ { get; set; }
+}
+
+/// <summary>
+///     Client → server. Replaces the sender's entire offer for the session at the shrine.
+///     Any offer change clears both sides' ready flags (anti-switcheroo).
+/// </summary>
+[ProtoContract]
+public class OfferUpdatePacket
+{
+    public OfferUpdatePacket()
+    {
+    }
+
+    [ProtoMember(1)] public int ShrineX { get; set; }
+    [ProtoMember(2)] public int ShrineY { get; set; }
+    [ProtoMember(3)] public int ShrineZ { get; set; }
+
+    [ProtoMember(4)] public List<TradeOfferSlot> Offer { get; set; } = new();
+}
+
+/// <summary>
+///     Client → server. Seal ("ready") or un-seal the sender's offer.
+/// </summary>
+[ProtoContract]
+public class SetReadyPacket
+{
+    public SetReadyPacket()
+    {
+    }
+
+    [ProtoMember(1)] public int ShrineX { get; set; }
+    [ProtoMember(2)] public int ShrineY { get; set; }
+    [ProtoMember(3)] public int ShrineZ { get; set; }
+
+    [ProtoMember(4)] public bool Ready { get; set; }
+}
+
+/// <summary>
+///     Client → server. Leave the table; tears the session down for both parties.
+/// </summary>
+[ProtoContract]
+public class CancelTradePacket
+{
+    public CancelTradePacket()
+    {
+    }
+
+    [ProtoMember(1)] public int ShrineX { get; set; }
+    [ProtoMember(2)] public int ShrineY { get; set; }
+    [ProtoMember(3)] public int ShrineZ { get; set; }
+}
+
+/// <summary>
+///     Server → client. Authoritative snapshot of a trade session, broadcast to both
+///     participants on every change. Each client decides which side is "self" by
+///     comparing its own player UID to <see cref="SideAPlayerUid" /> / <see cref="SideBPlayerUid" />.
+/// </summary>
+[ProtoContract]
+public class TradeStateSyncPacket
+{
+    public TradeStateSyncPacket()
+    {
+    }
+
+    [ProtoMember(1)] public int ShrineX { get; set; }
+    [ProtoMember(2)] public int ShrineY { get; set; }
+    [ProtoMember(3)] public int ShrineZ { get; set; }
+
+    [ProtoMember(4)] public TradePhase Phase { get; set; } = TradePhase.AwaitingPartner;
+
+    [ProtoMember(5)] public string SideAPlayerUid { get; set; } = string.Empty;
+    [ProtoMember(6)] public string SideAPlayerName { get; set; } = string.Empty;
+    [ProtoMember(7)] public bool SideAReady { get; set; }
+    [ProtoMember(8)] public List<TradeOfferSlot> SideAOffer { get; set; } = new();
+
+    [ProtoMember(9)] public string SideBPlayerUid { get; set; } = string.Empty;
+    [ProtoMember(10)] public string SideBPlayerName { get; set; } = string.Empty;
+    [ProtoMember(11)] public bool SideBReady { get; set; }
+    [ProtoMember(12)] public List<TradeOfferSlot> SideBOffer { get; set; } = new();
+}

--- a/DivineAscension/Services/MilestoneDefinitionLoader.cs
+++ b/DivineAscension/Services/MilestoneDefinitionLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using DivineAscension.Configuration;
 using DivineAscension.Models;
 using DivineAscension.Services.Interfaces;
 using Vintagestory.API.Common;
@@ -63,6 +64,13 @@ public class MilestoneDefinitionLoader : IMilestoneDefinitionLoader
             {
                 try
                 {
+                    // Caravan domain gated off: drop its trade_hub milestone so it
+                    // doesn't show as a permanently-unreachable goal (see FeatureFlags).
+                    if (!FeatureFlags.CaravanDomainEnabled &&
+                        string.Equals(dto.Trigger?.Type, "npc_trade_count",
+                            StringComparison.OrdinalIgnoreCase))
+                        continue;
+
                     var milestone = ConvertToMilestoneDefinition(dto);
                     if (milestone != null)
                     {

--- a/DivineAscension/Systems/Caravan/CaravanTradeSession.cs
+++ b/DivineAscension/Systems/Caravan/CaravanTradeSession.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using DivineAscension.Network.Caravan;
+using Vintagestory.API.MathTools;
+
+namespace DivineAscension.Systems.Caravan;
+
+/// <summary>
+///     Which seat at a trade table a player occupies.
+/// </summary>
+public enum TradeSide
+{
+    None = 0,
+    A = 1,
+    B = 2
+}
+
+/// <summary>
+///     Server-authoritative state for a single shrine-hosted trade table. One session
+///     exists per shrine position while a trade is in progress. State is mirrored to
+///     clients via <see cref="TradeStateSyncPacket" />.
+///
+///     Phase 4 (#433) tracks seats, offers, and ready flags only — no item movement.
+///     Escrow / atomic swap plug into this same session in #434.
+/// </summary>
+public class CaravanTradeSession
+{
+    /// <summary>Maximum offered stacks per side (the former 3×3 grid = 9).</summary>
+    public const int MaxOfferSlots = 9;
+
+    public CaravanTradeSession(BlockPos shrinePos)
+    {
+        ShrinePos = shrinePos.Copy();
+    }
+
+    public BlockPos ShrinePos { get; }
+
+    public TradePhase Phase { get; set; } = TradePhase.AwaitingPartner;
+
+    public string? SideAUid { get; set; }
+    public string SideAName { get; set; } = string.Empty;
+    public bool SideAReady { get; set; }
+    public List<TradeOfferSlot> SideAOffer { get; set; } = new();
+
+    public string? SideBUid { get; set; }
+    public string SideBName { get; set; } = string.Empty;
+    public bool SideBReady { get; set; }
+    public List<TradeOfferSlot> SideBOffer { get; set; } = new();
+
+    /// <summary>True once both seats are filled.</summary>
+    public bool HasBothSeats => !string.IsNullOrEmpty(SideAUid) && !string.IsNullOrEmpty(SideBUid);
+
+    /// <summary>True once both parties have sealed their offers — the terminal state handed to #434.</summary>
+    public bool BothSealed => HasBothSeats && SideAReady && SideBReady;
+
+    public TradeSide GetSide(string playerUid)
+    {
+        if (SideAUid == playerUid) return TradeSide.A;
+        if (SideBUid == playerUid) return TradeSide.B;
+        return TradeSide.None;
+    }
+
+    public bool IsParticipant(string playerUid) => GetSide(playerUid) != TradeSide.None;
+
+    /// <summary>
+    ///     Seat a player into the first free seat. Returns the seat taken, or
+    ///     <see cref="TradeSide.None" /> if the table is already full with other players.
+    /// </summary>
+    public TradeSide Seat(string playerUid, string playerName)
+    {
+        if (string.IsNullOrEmpty(SideAUid))
+        {
+            SideAUid = playerUid;
+            SideAName = playerName;
+            return TradeSide.A;
+        }
+
+        if (SideAUid == playerUid)
+            return TradeSide.A;
+
+        if (string.IsNullOrEmpty(SideBUid))
+        {
+            SideBUid = playerUid;
+            SideBName = playerName;
+            Phase = TradePhase.Active;
+            return TradeSide.B;
+        }
+
+        if (SideBUid == playerUid)
+            return TradeSide.B;
+
+        return TradeSide.None;
+    }
+
+    public void SetOffer(TradeSide side, List<TradeOfferSlot> offer)
+    {
+        if (side == TradeSide.A) SideAOffer = offer;
+        else if (side == TradeSide.B) SideBOffer = offer;
+    }
+
+    public void SetReady(TradeSide side, bool ready)
+    {
+        if (side == TradeSide.A) SideAReady = ready;
+        else if (side == TradeSide.B) SideBReady = ready;
+    }
+
+    /// <summary>
+    ///     Anti-switcheroo: any offer change voids both sealed offers so neither party
+    ///     can complete a trade whose contents shifted under them.
+    /// </summary>
+    public void ClearReadyFlags()
+    {
+        SideAReady = false;
+        SideBReady = false;
+    }
+
+    public TradeStateSyncPacket ToSyncPacket()
+    {
+        return new TradeStateSyncPacket
+        {
+            ShrineX = ShrinePos.X,
+            ShrineY = ShrinePos.Y,
+            ShrineZ = ShrinePos.Z,
+            Phase = Phase,
+            SideAPlayerUid = SideAUid ?? string.Empty,
+            SideAPlayerName = SideAName,
+            SideAReady = SideAReady,
+            SideAOffer = SideAOffer,
+            SideBPlayerUid = SideBUid ?? string.Empty,
+            SideBPlayerName = SideBName,
+            SideBReady = SideBReady,
+            SideBOffer = SideBOffer
+        };
+    }
+}

--- a/DivineAscension/Systems/Caravan/CaravanTradeSessionManager.cs
+++ b/DivineAscension/Systems/Caravan/CaravanTradeSessionManager.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Network.Caravan;
+using DivineAscension.Services;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Caravan;
+
+/// <summary>
+///     Server-authoritative state machine for shrine-hosted player-to-player trade tables
+///     (#433). Owns one <see cref="CaravanTradeSession" /> per shrine position, validates the
+///     client request packets, and broadcasts <see cref="TradeStateSyncPacket" /> to both
+///     participants on every change.
+///
+///     Scope (Phase 4, slice 7): seats, offers, ready flags, anti-switcheroo, and
+///     disconnect cleanup. No item movement — escrow / atomic swap and the continuous
+///     distance leash land in #434. A light proximity check runs at open time only.
+/// </summary>
+public class CaravanTradeSessionManager : IDisposable
+{
+    /// <summary>Maximum distance allowed between player and shrine when sitting down.</summary>
+    private const double MaxOpenInteractDistance = 6.0;
+
+    private readonly ILoggerWrapper _logger;
+    private readonly INetworkService _networkService;
+    private readonly IWorldService _worldService;
+    private readonly IEventService _eventService;
+    private readonly IPlayerMessengerService _messenger;
+
+    // Keyed by shrine position string ("x,y,z").
+    private readonly Dictionary<string, CaravanTradeSession> _sessions = new();
+
+    // Reverse index: player UID -> shrine key of the session they are seated at.
+    private readonly Dictionary<string, string> _playerSession = new();
+
+    public CaravanTradeSessionManager(
+        ILoggerWrapper logger,
+        INetworkService networkService,
+        IWorldService worldService,
+        IEventService eventService,
+        IPlayerMessengerService messenger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _networkService = networkService ?? throw new ArgumentNullException(nameof(networkService));
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+        _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
+        _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+    }
+
+    public void Initialize()
+    {
+        _networkService.RegisterMessageHandler<OpenTradeRequestPacket>(OnOpenTrade);
+        _networkService.RegisterMessageHandler<JoinTradeRequestPacket>(OnJoinTrade);
+        _networkService.RegisterMessageHandler<OfferUpdatePacket>(OnOfferUpdate);
+        _networkService.RegisterMessageHandler<SetReadyPacket>(OnSetReady);
+        _networkService.RegisterMessageHandler<CancelTradePacket>(OnCancelTrade);
+        _eventService.OnPlayerDisconnect(OnPlayerDisconnect);
+        _logger.Notification($"{SystemConstants.LogPrefix} CaravanTradeSessionManager initialized");
+    }
+
+    public void Dispose()
+    {
+        _eventService.UnsubscribePlayerDisconnect(OnPlayerDisconnect);
+        _sessions.Clear();
+        _playerSession.Clear();
+    }
+
+    private static string Key(int x, int y, int z) => $"{x},{y},{z}";
+
+    // ----- Request handlers -----
+
+    private void OnOpenTrade(IServerPlayer player, OpenTradeRequestPacket packet)
+        => SeatPlayer(player, new BlockPos(packet.ShrineX, packet.ShrineY, packet.ShrineZ));
+
+    private void OnJoinTrade(IServerPlayer player, JoinTradeRequestPacket packet)
+        => SeatPlayer(player, new BlockPos(packet.ShrineX, packet.ShrineY, packet.ShrineZ));
+
+    private void OnOfferUpdate(IServerPlayer player, OfferUpdatePacket packet)
+    {
+        var session = GetSessionFor(player, packet.ShrineX, packet.ShrineY, packet.ShrineZ);
+        if (session == null) return;
+
+        var side = session.GetSide(player.PlayerUID);
+        if (side == TradeSide.None) return;
+
+        // Normalize: clamp to capacity and re-number slot indices so the ledger stays tidy.
+        var offer = (packet.Offer ?? new List<TradeOfferSlot>())
+            .Take(CaravanTradeSession.MaxOfferSlots)
+            .ToList();
+        for (var i = 0; i < offer.Count; i++)
+            offer[i].SlotIndex = i;
+
+        session.SetOffer(side, offer);
+        session.ClearReadyFlags(); // anti-switcheroo: any change voids both seals
+        Broadcast(session);
+    }
+
+    private void OnSetReady(IServerPlayer player, SetReadyPacket packet)
+    {
+        var session = GetSessionFor(player, packet.ShrineX, packet.ShrineY, packet.ShrineZ);
+        if (session == null) return;
+
+        var side = session.GetSide(player.PlayerUID);
+        if (side == TradeSide.None) return;
+
+        // A seal only makes sense once both parties are present.
+        if (packet.Ready && !session.HasBothSeats) return;
+
+        session.SetReady(side, packet.Ready);
+        Broadcast(session);
+
+        if (session.BothSealed)
+        {
+            // Terminal state for #433: both offers sealed. The atomic swap + escrow that
+            // consumes this state is #434 — no item movement happens here.
+            _logger.Notification(
+                $"{SystemConstants.LogPrefix} Trade at {session.ShrinePos} sealed by both parties " +
+                $"({session.SideAName} / {session.SideBName}). Awaiting swap (#434).");
+        }
+    }
+
+    private void OnCancelTrade(IServerPlayer player, CancelTradePacket packet)
+    {
+        var session = GetSessionFor(player, packet.ShrineX, packet.ShrineY, packet.ShrineZ);
+        if (session == null) return;
+        CloseSession(session, player.PlayerUID, "caravantrade.cancelled");
+    }
+
+    private void OnPlayerDisconnect(IServerPlayer player)
+    {
+        if (!_playerSession.TryGetValue(player.PlayerUID, out var key)) return;
+        if (_sessions.TryGetValue(key, out var session))
+            CloseSession(session, player.PlayerUID, "caravantrade.partner_left");
+    }
+
+    // ----- Core logic -----
+
+    private void SeatPlayer(IServerPlayer player, BlockPos shrinePos)
+    {
+        var key = Key(shrinePos.X, shrinePos.Y, shrinePos.Z);
+
+        // Already seated somewhere?
+        if (_playerSession.TryGetValue(player.PlayerUID, out var existingKey))
+        {
+            if (existingKey == key && _sessions.TryGetValue(key, out var existing))
+            {
+                // Re-opening their own table — resend the snapshot so the dialog reopens.
+                SendSync(player, existing);
+                return;
+            }
+
+            _messenger.SendMessage(player,
+                LocalizationService.Instance.Get("caravantrade.error.busy"),
+                EnumChatType.CommandError);
+            return;
+        }
+
+        if (!IsWithinReach(player, shrinePos))
+        {
+            _messenger.SendMessage(player,
+                LocalizationService.Instance.Get("caravantrade.error.too_far"),
+                EnumChatType.CommandError);
+            return;
+        }
+
+        if (!_sessions.TryGetValue(key, out var session) || session.Phase == TradePhase.Closed)
+        {
+            session = new CaravanTradeSession(shrinePos);
+            _sessions[key] = session;
+        }
+
+        var seat = session.Seat(player.PlayerUID, player.PlayerName);
+        if (seat == TradeSide.None)
+        {
+            _messenger.SendMessage(player,
+                LocalizationService.Instance.Get("caravantrade.error.full"),
+                EnumChatType.CommandError);
+
+            // Drop an empty session we just speculatively created with no seats taken.
+            if (string.IsNullOrEmpty(session.SideAUid) && string.IsNullOrEmpty(session.SideBUid))
+                _sessions.Remove(key);
+            return;
+        }
+
+        _playerSession[player.PlayerUID] = key;
+        Broadcast(session);
+    }
+
+    private CaravanTradeSession? GetSessionFor(IServerPlayer player, int x, int y, int z)
+    {
+        if (!_playerSession.TryGetValue(player.PlayerUID, out var key)) return null;
+        if (key != Key(x, y, z)) return null; // packet's shrine must match the seated session
+        return _sessions.TryGetValue(key, out var session) ? session : null;
+    }
+
+    private void CloseSession(CaravanTradeSession session, string? initiatorUid, string partnerMessageKey)
+    {
+        session.Phase = TradePhase.Closed;
+        var key = Key(session.ShrinePos.X, session.ShrinePos.Y, session.ShrinePos.Z);
+
+        // Notify the other side, if there is one and it isn't the initiator.
+        var partnerUid = session.SideAUid == initiatorUid ? session.SideBUid : session.SideAUid;
+        if (!string.IsNullOrEmpty(partnerUid) && partnerUid != initiatorUid)
+        {
+            var partner = _worldService.GetPlayerByUID(partnerUid);
+            if (partner != null)
+                _messenger.SendMessage(partner,
+                    LocalizationService.Instance.Get(partnerMessageKey),
+                    EnumChatType.Notification);
+        }
+
+        // Push a Closed snapshot so both dialogs tear down, then clear server state.
+        Broadcast(session);
+
+        if (!string.IsNullOrEmpty(session.SideAUid)) _playerSession.Remove(session.SideAUid!);
+        if (!string.IsNullOrEmpty(session.SideBUid)) _playerSession.Remove(session.SideBUid!);
+        _sessions.Remove(key);
+    }
+
+    private void Broadcast(CaravanTradeSession session)
+    {
+        SendSyncToUid(session.SideAUid, session);
+        SendSyncToUid(session.SideBUid, session);
+    }
+
+    private void SendSyncToUid(string? uid, CaravanTradeSession session)
+    {
+        if (string.IsNullOrEmpty(uid)) return;
+        var player = _worldService.GetPlayerByUID(uid!);
+        if (player != null) SendSync(player, session);
+    }
+
+    private void SendSync(IServerPlayer player, CaravanTradeSession session)
+        => _networkService.SendToPlayer(player, session.ToSyncPacket());
+
+    private static bool IsWithinReach(IServerPlayer player, BlockPos shrinePos)
+    {
+        // Entity is null only in unit tests; a connected player always has one. Allow when
+        // absent so seating logic stays testable without mocking the entity graph.
+        var pos = player.Entity?.Pos;
+        if (pos == null) return true;
+
+        var dx = pos.X - (shrinePos.X + 0.5);
+        var dy = pos.Y - (shrinePos.Y + 0.5);
+        var dz = pos.Z - (shrinePos.Z + 0.5);
+        return dx * dx + dy * dy + dz * dz <= MaxOpenInteractDistance * MaxOpenInteractDistance;
+    }
+}

--- a/DivineAscension/Systems/CivilizationMilestoneManager.cs
+++ b/DivineAscension/Systems/CivilizationMilestoneManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using DivineAscension.Configuration;
 using DivineAscension.Constants;
 using DivineAscension.Data;
 using DivineAscension.Models;
@@ -78,8 +79,10 @@ public class CivilizationMilestoneManager : ICivilizationMilestoneManager
         _religionManager.OnMemberAdded += HandleMemberAdded;
         _religionManager.OnMemberRemoved += HandleMemberRemoved;
 
-        // Subscribe to NPC trader transactions for the trade_hub milestone (Caravan)
-        Patches.TraderPatches.OnTraderTransaction += HandleTraderTransaction;
+        // Subscribe to NPC trader transactions for the trade_hub milestone (Caravan).
+        // Gated: when the Caravan domain is off, NPC trades never feed the milestone.
+        if (FeatureFlags.CaravanDomainEnabled)
+            Patches.TraderPatches.OnTraderTransaction += HandleTraderTransaction;
 
         _logger.Notification("[DivineAscension] Civilization Milestone Manager initialized");
     }

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -185,35 +185,44 @@ public static class DivineAscensionSystemInitializer
             altarEventEmitter);
         altarDestructionHandler.Initialize();
 
-        // Caravan shrine handlers reuse AltarEventEmitter; they filter on the caravanshrine
-        // block code so altar handlers above ignore the same events and vice versa.
-        var caravanShrinePlacementHandler = new CaravanShrinePlacementHandler(
-            LoggingService.Instance.CreateLogger("CaravanShrinePlacementHandler"),
-            altarEventEmitter,
-            playerReligionDataManager,
-            religionManager,
-            holySiteManager,
-            worldService,
-            messengerService);
-        caravanShrinePlacementHandler.Initialize();
+        // Caravan domain (#433) is gated behind FeatureFlags.CaravanDomainEnabled while it
+        // bakes. When off, none of the shrine/trade servers are constructed; the block stays
+        // registered but creative-only and the favor trackers no-op (no Caravan worshippers).
+        CaravanShrinePlacementHandler? caravanShrinePlacementHandler = null;
+        CaravanShrineDestructionHandler? caravanShrineDestructionHandler = null;
+        CaravanTradeSessionManager? caravanTradeSessionManager = null;
+        if (FeatureFlags.CaravanDomainEnabled)
+        {
+            // Caravan shrine handlers reuse AltarEventEmitter; they filter on the caravanshrine
+            // block code so altar handlers above ignore the same events and vice versa.
+            caravanShrinePlacementHandler = new CaravanShrinePlacementHandler(
+                LoggingService.Instance.CreateLogger("CaravanShrinePlacementHandler"),
+                altarEventEmitter,
+                playerReligionDataManager,
+                religionManager,
+                holySiteManager,
+                worldService,
+                messengerService);
+            caravanShrinePlacementHandler.Initialize();
 
-        var caravanShrineDestructionHandler = new CaravanShrineDestructionHandler(
-            LoggingService.Instance.CreateLogger("CaravanShrineDestructionHandler"),
-            altarEventEmitter,
-            playerReligionDataManager,
-            worldService,
-            messengerService);
-        caravanShrineDestructionHandler.Initialize();
+            caravanShrineDestructionHandler = new CaravanShrineDestructionHandler(
+                LoggingService.Instance.CreateLogger("CaravanShrineDestructionHandler"),
+                altarEventEmitter,
+                playerReligionDataManager,
+                worldService,
+                messengerService);
+            caravanShrineDestructionHandler.Initialize();
 
-        // Player-to-player trade table hosted at caravan shrines (#433). Server-authoritative
-        // session state + sync; subscribes to the trade request packets and player disconnect.
-        var caravanTradeSessionManager = new CaravanTradeSessionManager(
-            LoggingService.Instance.CreateLogger("CaravanTradeSessionManager"),
-            networkService,
-            worldService,
-            eventService,
-            messengerService);
-        caravanTradeSessionManager.Initialize();
+            // Player-to-player trade table hosted at caravan shrines (#433). Server-authoritative
+            // session state + sync; subscribes to the trade request packets and player disconnect.
+            caravanTradeSessionManager = new CaravanTradeSessionManager(
+                LoggingService.Instance.CreateLogger("CaravanTradeSessionManager"),
+                networkService,
+                worldService,
+                eventService,
+                messengerService);
+            caravanTradeSessionManager.Initialize();
+        }
 
         // NOTE: AltarPrayerHandler initialized after FavorSystem (needs IFavorSystem and IActivityLogManager)
 
@@ -607,9 +616,10 @@ public class InitializationResult
     public IHolySiteAreaTracker HolySiteAreaTracker { get; init; } = null!;
     public AltarPlacementHandler AltarPlacementHandler { get; init; } = null!;
     public AltarDestructionHandler AltarDestructionHandler { get; init; } = null!;
-    public CaravanShrinePlacementHandler CaravanShrinePlacementHandler { get; init; } = null!;
-    public CaravanShrineDestructionHandler CaravanShrineDestructionHandler { get; init; } = null!;
-    public CaravanTradeSessionManager CaravanTradeSessionManager { get; init; } = null!;
+    // Null when FeatureFlags.CaravanDomainEnabled is off (systems not constructed).
+    public CaravanShrinePlacementHandler? CaravanShrinePlacementHandler { get; init; }
+    public CaravanShrineDestructionHandler? CaravanShrineDestructionHandler { get; init; }
+    public CaravanTradeSessionManager? CaravanTradeSessionManager { get; init; }
     public AltarPrayerHandler AltarPrayerHandler { get; init; } = null!;
     public FavorSystem FavorSystem { get; init; } = null!;
     public ActivityLogManager ActivityLogManager { get; init; } = null!;

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -12,6 +12,7 @@ using DivineAscension.Systems.Altar;
 using DivineAscension.Systems.Altar.Pipeline;
 using DivineAscension.Systems.Altar.Pipeline.Steps;
 using DivineAscension.Systems.BuffSystem;
+using DivineAscension.Systems.Caravan;
 using DivineAscension.Systems.HolySite;
 using DivineAscension.Systems.Lectern;
 using DivineAscension.Systems.Interfaces;
@@ -203,6 +204,16 @@ public static class DivineAscensionSystemInitializer
             worldService,
             messengerService);
         caravanShrineDestructionHandler.Initialize();
+
+        // Player-to-player trade table hosted at caravan shrines (#433). Server-authoritative
+        // session state + sync; subscribes to the trade request packets and player disconnect.
+        var caravanTradeSessionManager = new CaravanTradeSessionManager(
+            LoggingService.Instance.CreateLogger("CaravanTradeSessionManager"),
+            networkService,
+            worldService,
+            eventService,
+            messengerService);
+        caravanTradeSessionManager.Initialize();
 
         // NOTE: AltarPrayerHandler initialized after FavorSystem (needs IFavorSystem and IActivityLogManager)
 
@@ -546,6 +557,7 @@ public static class DivineAscensionSystemInitializer
             AltarDestructionHandler = altarDestructionHandler,
             CaravanShrinePlacementHandler = caravanShrinePlacementHandler,
             CaravanShrineDestructionHandler = caravanShrineDestructionHandler,
+            CaravanTradeSessionManager = caravanTradeSessionManager,
             AltarPrayerHandler = altarPrayerHandler,
             FavorSystem = favorSystem,
             ActivityLogManager = activityLogManager,
@@ -597,6 +609,7 @@ public class InitializationResult
     public AltarDestructionHandler AltarDestructionHandler { get; init; } = null!;
     public CaravanShrinePlacementHandler CaravanShrinePlacementHandler { get; init; } = null!;
     public CaravanShrineDestructionHandler CaravanShrineDestructionHandler { get; init; } = null!;
+    public CaravanTradeSessionManager CaravanTradeSessionManager { get; init; } = null!;
     public AltarPrayerHandler AltarPrayerHandler { get; init; } = null!;
     public FavorSystem FavorSystem { get; init; } = null!;
     public ActivityLogManager ActivityLogManager { get; init; } = null!;

--- a/DivineAscension/Systems/Networking/Client/DivineAscensionNetworkClient.cs
+++ b/DivineAscension/Systems/Networking/Client/DivineAscensionNetworkClient.cs
@@ -5,11 +5,13 @@ using DivineAscension.API.Interfaces;
 using DivineAscension.GUI.State;
 using DivineAscension.GUI.Utilities;
 using DivineAscension.Network;
+using DivineAscension.Network.Caravan;
 using DivineAscension.Network.Civilization;
 using DivineAscension.Network.Diplomacy;
 using DivineAscension.Network.HolySite;
 using DivineAscension.Systems.Networking.Interfaces;
 using Vintagestory.API.Client;
+using Vintagestory.API.MathTools;
 using GuiDialog = DivineAscension.GUI.GuiDialog;
 
 namespace DivineAscension.Systems.Networking.Client;
@@ -107,6 +109,9 @@ public class DivineAscensionNetworkClient : IClientNetworkHandler
         _clientChannel.SetMessageHandler<OpenMenuPacket>(OnOpenMenu);
         _clientChannel.SetMessageHandler<CloseMenuPacket>(OnCloseMenu);
 
+        // Caravan trade table (#433)
+        _clientChannel.SetMessageHandler<TradeStateSyncPacket>(OnTradeStateSync);
+
         _clientChannel.RegisterMessageType(typeof(PlayerReligionDataPacket));
     }
 
@@ -142,6 +147,7 @@ public class DivineAscensionNetworkClient : IClientNetworkHandler
         LeaderboardReceived = null;
         OpenMenuRequested = null;
         CloseMenuRequested = null;
+        TradeStateReceived = null;
     }
 
     #endregion
@@ -1367,6 +1373,71 @@ public class DivineAscensionNetworkClient : IClientNetworkHandler
     private void OnCloseMenu(CloseMenuPacket packet)
     {
         CloseMenuRequested?.Invoke(packet);
+    }
+
+    #endregion
+
+    #region Caravan trade table (#433)
+
+    /// <summary>
+    ///     Authoritative trade-session snapshot received from the server. The trade dialog
+    ///     opens on the first sync and closes when <c>Phase == Closed</c>.
+    /// </summary>
+    public event Action<TradeStateSyncPacket>? TradeStateReceived;
+
+    private void OnTradeStateSync(TradeStateSyncPacket packet)
+    {
+        TradeStateReceived?.Invoke(packet);
+    }
+
+    /// <summary>Request to sit down at the trade table hosted by the shrine at <paramref name="shrinePos" />.</summary>
+    public void SendOpenTradeRequest(BlockPos shrinePos)
+    {
+        if (!IsNetworkAvailable() || shrinePos == null) return;
+        _clientChannel?.SendPacket(new OpenTradeRequestPacket
+        {
+            ShrineX = shrinePos.X,
+            ShrineY = shrinePos.Y,
+            ShrineZ = shrinePos.Z
+        });
+    }
+
+    /// <summary>Replace the local player's offer at the given shrine's table.</summary>
+    public void SendOfferUpdate(BlockPos shrinePos, List<TradeOfferSlot> offer)
+    {
+        if (!IsNetworkAvailable() || shrinePos == null) return;
+        _clientChannel?.SendPacket(new OfferUpdatePacket
+        {
+            ShrineX = shrinePos.X,
+            ShrineY = shrinePos.Y,
+            ShrineZ = shrinePos.Z,
+            Offer = offer ?? new List<TradeOfferSlot>()
+        });
+    }
+
+    /// <summary>Seal or un-seal the local player's offer.</summary>
+    public void SendSetReady(BlockPos shrinePos, bool ready)
+    {
+        if (!IsNetworkAvailable() || shrinePos == null) return;
+        _clientChannel?.SendPacket(new SetReadyPacket
+        {
+            ShrineX = shrinePos.X,
+            ShrineY = shrinePos.Y,
+            ShrineZ = shrinePos.Z,
+            Ready = ready
+        });
+    }
+
+    /// <summary>Leave the trade table; tears the session down for both parties.</summary>
+    public void SendCancelTrade(BlockPos shrinePos)
+    {
+        if (!IsNetworkAvailable() || shrinePos == null) return;
+        _clientChannel?.SendPacket(new CancelTradePacket
+        {
+            ShrineX = shrinePos.X,
+            ShrineY = shrinePos.Y,
+            ShrineZ = shrinePos.Z
+        });
     }
 
     #endregion

--- a/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
@@ -114,6 +114,8 @@ public class ReligionNetworkHandler : IServerNetworkHandler
     {
         var domains = Enum.GetValues<DeityDomain>()
             .Where(d => d != DeityDomain.None)
+            // Caravan domain is gated until debugged/balanced (see FeatureFlags).
+            .Where(d => Configuration.FeatureFlags.CaravanDomainEnabled || d != DeityDomain.Caravan)
             .Select(d => d.ToString())
             .ToList();
 
@@ -407,8 +409,10 @@ public class ReligionNetworkHandler : IServerNetworkHandler
             {
                 message = LocalizationService.Instance.Get(LocalizationKeys.NET_RELIGION_ALREADY_IN_RELIGION);
             }
-            else if (!Enum.TryParse<DeityDomain>(packet.Domain, out var domain) || domain == DeityDomain.None)
+            else if (!Enum.TryParse<DeityDomain>(packet.Domain, out var domain) || domain == DeityDomain.None ||
+                     (!Configuration.FeatureFlags.CaravanDomainEnabled && domain == DeityDomain.Caravan))
             {
+                // Reject gated domains server-side too — never trust the client to omit them.
                 message = LocalizationService.Instance.Get(LocalizationKeys.NET_RELIGION_INVALID_DEITY);
             }
             else if (string.IsNullOrWhiteSpace(packet.DeityName))

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1547,5 +1547,20 @@
   "caravanshrine.error.foreign_holysite": "You cannot place a Caravan Shrine inside another religion's holy site.",
   "caravanshrine.placed": "Caravan Shrine placed. May the road carry you far.",
   "caravanshrine.granted": "The road provides — a Caravan Shrine has been added to your inventory.",
-  "caravanshrine.returned": "Caravan Shrine returned to your inventory."
+  "caravanshrine.returned": "Caravan Shrine returned to your inventory.",
+  "caravantrade.title": "Bill of Barter",
+  "caravantrade.intro": "Two travelers meet at the wayside shrine and lay out their wares. Lay items on the table, then seal your offer when the bargain is fair.",
+  "caravantrade.awaiting_partner": "Awaiting a trader…",
+  "caravantrade.your_pack": "Your pack — click an entry to lay it on the table:",
+  "caravantrade.switcheroo_note": "Any hand reaching for the table breaks the other's seal.",
+  "caravantrade.sealed": "sealed",
+  "caravantrade.pondering": "pondering",
+  "caravantrade.seal": "Seal my offer",
+  "caravantrade.unseal": "Unseal my offer",
+  "caravantrade.leave": "Leave the table",
+  "caravantrade.cancelled": "The trade was called off.",
+  "caravantrade.partner_left": "Your trading partner left the table.",
+  "caravantrade.error.too_far": "You are too far from the shrine to trade here.",
+  "caravantrade.error.full": "This trade table is already occupied by two traders.",
+  "caravantrade.error.busy": "Finish your current trade before starting another."
 }


### PR DESCRIPTION
## Summary

Adds the Caravan domain — patron deity, exploration + NPC-trade favor sources, the portable trade-table shrine block, two-player shrine trade table, and the `trade_hub` civilization milestone (#433).

The domain still needs debugging and playtesting, so rather than diverge on a long-lived branch it lands in mainline **gated behind a single compile-time flag** (`FeatureFlags.CaravanDomainEnabled`, default `false`). The domain is fully inert at runtime; flip the flag and rebuild to enable.

## What's gated when off
- Blessing deity selector hides the Caravan tab (5 tabs, not 6)
- Religion-create domain list (server-authoritative) omits Caravan; create handler also rejects it server-side (no client trust)
- `DomainHelper.DomainNames` drops Caravan → civ-browse filters and other consumers inherit the gate
- Shrine placement/destruction + trade-session servers not constructed
- Milestone manager ignores NPC-trade events; `trade_hub` dropped from the loaded milestone set

## Left live (harmless)
- Caravan favor trackers still build — no Caravan worshippers exist, so awards no-op
- Shrine block stays registered but creative-inventory-only
- Enum keeps `Caravan = 5` so fixtures and persistence are unaffected

## Testing
Full suite green (2469 passed). `DomainHelperTests` updated to be flag-aware.

## Enabling later
Set `FeatureFlags.CaravanDomainEnabled = true` and rebuild; the doc comment on the flag lists every gate it controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)