### PR TITLE
refactor(domain): single source of truth for DeityDomain enumeration + metadata

### DIFF
--- a/DivineAscension.Tests/Models/CivilizationEthosDeriverTests.cs
+++ b/DivineAscension.Tests/Models/CivilizationEthosDeriverTests.cs
@@ -14,6 +14,7 @@ public class CivilizationEthosDeriverTests
     [InlineData(DeityDomain.Wild, CivilizationEthos.Mystic, LocalizationKeys.CIVILIZATION_EPITHET_WILD)]
     [InlineData(DeityDomain.Harvest, CivilizationEthos.Ascetic, LocalizationKeys.CIVILIZATION_EPITHET_HARVEST)]
     [InlineData(DeityDomain.Stone, CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_STONE)]
+    [InlineData(DeityDomain.Caravan, CivilizationEthos.Mercantile, LocalizationKeys.CIVILIZATION_EPITHET_CARAVAN)]
     [InlineData(DeityDomain.None, CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_DEFAULT)]
     public void Derive_MapsDomainToEthosAndEpithetKey(
         DeityDomain domain, CivilizationEthos expectedEthos, string expectedKey)

--- a/DivineAscension.Tests/Models/Enum/DeityDomainRegistryTests.cs
+++ b/DivineAscension.Tests/Models/Enum/DeityDomainRegistryTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DivineAscension.Models.Enum;
+
+namespace DivineAscension.Tests.Models.Enum;
+
+/// <summary>
+///     Guard tests for the single-source-of-truth domain enumeration + metadata
+///     registry (#558). The <see cref="Registry_CoversEveryRealDomain"/> test is
+///     the load-bearing one: it fails CI the moment a new <see cref="DeityDomain"/>
+///     value is added without a matching <see cref="DeityDomainRegistry"/> entry,
+///     before the "everything shows Unknown" bug can ship.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class DeityDomainRegistryTests
+{
+    [Fact]
+    public void All_ExcludesNone_AndCoversEveryEnumValue()
+    {
+        Assert.DoesNotContain(DeityDomain.None, DeityDomains.All);
+
+        var expected = System.Enum.GetValues<DeityDomain>().Where(d => d != DeityDomain.None);
+        Assert.Equal(expected, DeityDomains.All);
+    }
+
+    [Fact]
+    public void AllCodes_AreLowercaseAndParallelToAll()
+    {
+        Assert.Equal(DeityDomains.All.Count, DeityDomains.AllCodes.Count);
+        for (var i = 0; i < DeityDomains.All.Count; i++)
+            Assert.Equal(DeityDomains.All[i].ToString().ToLowerInvariant(), DeityDomains.AllCodes[i]);
+    }
+
+    [Fact]
+    public void Selectable_IsSubsetOfAll()
+    {
+        Assert.All(DeityDomains.Selectable, d => Assert.Contains(d, DeityDomains.All));
+    }
+
+    [Fact]
+    public void Registry_CoversEveryRealDomain()
+    {
+        foreach (var domain in DeityDomains.All)
+        {
+            // Must not throw — a real domain without an entry is the bug this guards.
+            var meta = DeityDomainRegistry.Get(domain);
+            Assert.Equal(domain, meta.Domain);
+        }
+
+        Assert.Equal(DeityDomains.All.Count, DeityDomainRegistry.All.Count);
+    }
+
+    [Fact]
+    public void Registry_EntriesAreFullyPopulated()
+    {
+        foreach (var meta in DeityDomainRegistry.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(meta.ShortCode), $"{meta.Domain} ShortCode");
+            Assert.False(string.IsNullOrWhiteSpace(meta.NameLocKey), $"{meta.Domain} NameLocKey");
+            Assert.False(string.IsNullOrWhiteSpace(meta.TitleLocKey), $"{meta.Domain} TitleLocKey");
+            Assert.False(string.IsNullOrWhiteSpace(meta.DescriptionLocKey), $"{meta.Domain} DescriptionLocKey");
+            Assert.False(string.IsNullOrWhiteSpace(meta.EpithetLocKey), $"{meta.Domain} EpithetLocKey");
+            Assert.False(string.IsNullOrWhiteSpace(meta.FeastPatronLocKey), $"{meta.Domain} FeastPatronLocKey");
+            Assert.NotEmpty(meta.PrestigeActivityKeywords);
+            Assert.InRange(meta.HolyDay.Month, 1, 12);
+            Assert.True(meta.HolyDay.Day >= 1, $"{meta.Domain} HolyDay.Day");
+        }
+    }
+
+    [Fact]
+    public void ShortCodes_AreUnique()
+    {
+        var codes = DeityDomainRegistry.All.Select(m => m.ShortCode).ToList();
+        Assert.Equal(codes.Count, codes.Distinct().Count());
+    }
+
+    [Fact]
+    public void Get_ThrowsForNone()
+    {
+        Assert.Throws<ArgumentException>(() => DeityDomainRegistry.Get(DeityDomain.None));
+    }
+
+    [Fact]
+    public void TryGet_FalseForNone()
+    {
+        Assert.False(DeityDomainRegistry.TryGet(DeityDomain.None, out _));
+    }
+}

--- a/DivineAscension.Tests/Systems/SacredCalendarTests.cs
+++ b/DivineAscension.Tests/Systems/SacredCalendarTests.cs
@@ -29,7 +29,11 @@ public class SacredCalendarTests
     [Fact]
     public void DomainHolyDay_HasOneEntryPerDomain()
     {
-        Assert.Equal(5, FeastDay.DomainHolyDay.Count);
+        // Sourced from DeityDomainRegistry (#558) — one entry per real domain.
+        Assert.Equal(DeityDomains.All.Count, FeastDay.DomainHolyDay.Count);
+        foreach (var domain in DeityDomains.All)
+            Assert.True(FeastDay.DomainHolyDay.ContainsKey(domain), $"missing holy day for {domain}");
+
         Assert.Equal((2, 1), FeastDay.DomainHolyDay[DeityDomain.Craft]);
         Assert.Equal((4, 15), FeastDay.DomainHolyDay[DeityDomain.Wild]);
         Assert.Equal((7, 4), FeastDay.DomainHolyDay[DeityDomain.Conquest]);

--- a/DivineAscension/Commands/FavorCommands.cs
+++ b/DivineAscension/Commands/FavorCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DivineAscension.API.Interfaces;
@@ -345,11 +346,7 @@ public class FavorCommands
         return TextCommandResult.Success(sb.ToString());
     }
 
-    private static readonly DeityDomain[] AllDeities =
-    {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
-        DeityDomain.Harvest, DeityDomain.Stone, DeityDomain.Caravan
-    };
+    private static readonly IReadOnlyList<DeityDomain> AllDeities = DeityDomains.All;
 
     /// <summary>
     ///     Reads `args[startIndex]` and `args[startIndex+1]` as two optional positional words and

--- a/DivineAscension/Constants/LocalizationKeys.cs
+++ b/DivineAscension/Constants/LocalizationKeys.cs
@@ -869,6 +869,7 @@ public static class LocalizationKeys
     public const string FEAST_PATRON_CONQUEST_NAME = "divineascension:feast.patron.conquest.name";
     public const string FEAST_PATRON_HARVEST_NAME = "divineascension:feast.patron.harvest.name";
     public const string FEAST_PATRON_STONE_NAME = "divineascension:feast.patron.stone.name";
+    public const string FEAST_PATRON_CARAVAN_NAME = "divineascension:feast.patron.caravan.name";
     public const string FEAST_FIRED_CHRONICLE_FOUNDING = "divineascension:feast.fired.chronicle.founding";
     public const string FEAST_FIRED_CHRONICLE_PATRON = "divineascension:feast.fired.chronicle.patron";
     public const string FEAST_FIRED_CHRONICLE_CUSTOM = "divineascension:feast.fired.chronicle.custom";
@@ -1098,6 +1099,10 @@ public static class LocalizationKeys
     public const string DOMAIN_WILD_TITLE = "divineascension:deity.domain.wild.title";
     public const string DOMAIN_WILD_DESCRIPTION = "divineascension:deity.domain.wild.description";
 
+    public const string DOMAIN_CONQUEST_NAME = "divineascension:deity.domain.conquest.name";
+    public const string DOMAIN_CONQUEST_TITLE = "divineascension:deity.domain.conquest.title";
+    public const string DOMAIN_CONQUEST_DESCRIPTION = "divineascension:deity.domain.conquest.description";
+
     public const string DOMAIN_HARVEST_NAME = "divineascension:deity.domain.harvest.name";
     public const string DOMAIN_HARVEST_TITLE = "divineascension:deity.domain.harvest.title";
     public const string DOMAIN_HARVEST_DESCRIPTION = "divineascension:deity.domain.harvest.description";
@@ -1105,6 +1110,10 @@ public static class LocalizationKeys
     public const string DOMAIN_STONE_NAME = "divineascension:deity.domain.stone.name";
     public const string DOMAIN_STONE_TITLE = "divineascension:deity.domain.stone.title";
     public const string DOMAIN_STONE_DESCRIPTION = "divineascension:deity.domain.stone.description";
+
+    public const string DOMAIN_CARAVAN_NAME = "divineascension:deity.domain.caravan.name";
+    public const string DOMAIN_CARAVAN_TITLE = "divineascension:deity.domain.caravan.title";
+    public const string DOMAIN_CARAVAN_DESCRIPTION = "divineascension:deity.domain.caravan.description";
 
     public const string DOMAIN_UNKNOWN_NAME = "divineascension:deity.domain.unknown.name";
     public const string DOMAIN_LABEL = "divineascension:deity.domain_label";
@@ -2192,6 +2201,7 @@ public static class LocalizationKeys
     public const string CIVILIZATION_EPITHET_WILD = "divineascension:civilization.epithet.wild";
     public const string CIVILIZATION_EPITHET_HARVEST = "divineascension:civilization.epithet.harvest";
     public const string CIVILIZATION_EPITHET_STONE = "divineascension:civilization.epithet.stone";
+    public const string CIVILIZATION_EPITHET_CARAVAN = "divineascension:civilization.epithet.caravan";
     public const string CIVILIZATION_EPITHET_DEFAULT = "divineascension:civilization.epithet.default";
 
     // Header row labels for the civ info chapter.

--- a/DivineAscension/Extensions/EnumLocalizationExtensions.cs
+++ b/DivineAscension/Extensions/EnumLocalizationExtensions.cs
@@ -52,14 +52,9 @@ public static class EnumLocalizationExtensions
     /// <returns>Localized domain name</returns>
     public static string ToLocalizedString(this DeityDomain deity)
     {
-        return deity switch
-        {
-            DeityDomain.Craft => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_CRAFT_NAME),
-            DeityDomain.Wild => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_WILD_NAME),
-            DeityDomain.Harvest => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_HARVEST_NAME),
-            DeityDomain.Stone => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_STONE_NAME),
-            _ => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_UNKNOWN_NAME)
-        };
+        return DeityDomainRegistry.TryGet(deity, out var meta)
+            ? LocalizationService.Instance.Get(meta.NameLocKey)
+            : LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_UNKNOWN_NAME);
     }
 
     /// <summary>
@@ -71,14 +66,9 @@ public static class EnumLocalizationExtensions
     public static string ToLocalizedStringWithTitle(this DeityDomain deity)
     {
         var name = deity.ToLocalizedString();
-        var title = deity switch
-        {
-            DeityDomain.Craft => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_CRAFT_TITLE),
-            DeityDomain.Wild => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_WILD_TITLE),
-            DeityDomain.Harvest => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_HARVEST_TITLE),
-            DeityDomain.Stone => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_STONE_TITLE),
-            _ => ""
-        };
+        var title = DeityDomainRegistry.TryGet(deity, out var meta)
+            ? LocalizationService.Instance.Get(meta.TitleLocKey)
+            : "";
 
         return string.IsNullOrEmpty(title) ? name : $"{name} - {title}";
     }
@@ -90,13 +80,8 @@ public static class EnumLocalizationExtensions
     /// <returns>Localized domain description</returns>
     public static string ToLocalizedDescription(this DeityDomain deity)
     {
-        return deity switch
-        {
-            DeityDomain.Craft => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_CRAFT_DESCRIPTION),
-            DeityDomain.Wild => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_WILD_DESCRIPTION),
-            DeityDomain.Harvest => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_HARVEST_DESCRIPTION),
-            DeityDomain.Stone => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_STONE_DESCRIPTION),
-            _ => LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_UNKNOWN_NAME)
-        };
+        return DeityDomainRegistry.TryGet(deity, out var meta)
+            ? LocalizationService.Instance.Get(meta.DescriptionLocKey)
+            : LocalizationService.Instance.Get(LocalizationKeys.DOMAIN_UNKNOWN_NAME);
     }
 }

--- a/DivineAscension/GUI/GuiDialogHandlers.cs
+++ b/DivineAscension/GUI/GuiDialogHandlers.cs
@@ -155,11 +155,7 @@ public partial class GuiDialog
 
         // Preload blessing textures for every deity to prevent stuttering when switching tabs.
         var allBlessings = playerBlessings.Concat(religionBlessings).ToList();
-        foreach (var domain in new[]
-                 {
-                     DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
-                     DeityDomain.Caravan
-                 })
+        foreach (var domain in DeityDomains.All)
             BlessingIconLoader.PreloadDeityTextures(
                 allBlessings.Where(b => b.Domain == domain).ToList(), domain);
         _logger?.Debug(

--- a/DivineAscension/GUI/Managers/BlessingStateManager.cs
+++ b/DivineAscension/GUI/Managers/BlessingStateManager.cs
@@ -20,11 +20,7 @@ namespace DivineAscension.GUI.Managers;
 /// </summary>
 public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISoundManager soundManager)
 {
-    private static readonly DeityDomain[] AllDeities =
-    {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
-        DeityDomain.Caravan
-    };
+    private static readonly IReadOnlyList<DeityDomain> AllDeities = DeityDomains.All;
 
     private readonly ICoreClientAPI _coreClientApi = api ?? throw new ArgumentNullException(nameof(api));
 
@@ -656,7 +652,7 @@ public class BlessingStateManager(ICoreClientAPI api, IUiService uiService, ISou
         Dictionary<DeityDomain, int> totalFavorEarnedByDeity,
         int discipleThreshold, int zealotThreshold, int championThreshold, int avatarThreshold)
     {
-        var list = new List<DeityBlessingSummary>(AllDeities.Length);
+        var list = new List<DeityBlessingSummary>(AllDeities.Count);
         foreach (var domain in AllDeities)
         {
             var rank = favorRanksByDeity.GetValueOrDefault(domain);

--- a/DivineAscension/GUI/UI/Adapters/Civilizations/FakeCivilizationProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/Civilizations/FakeCivilizationProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using DivineAscension.Models.Enum;
 
 namespace DivineAscension.GUI.UI.Adapters.Civilizations;
@@ -41,11 +42,11 @@ internal sealed class FakeCivilizationProvider : ICivilizationProvider
         "freemasonry", "cursed-star"
     };
 
+    // Mirrors the domains a player can actually worship (Caravan appears only
+    // when its feature flag is on) — sourced from the SST so a new domain shows
+    // up in dev previews automatically (#558).
     private static readonly string[] Deities =
-    {
-        nameof(DeityDomain.Craft), nameof(DeityDomain.Wild),
-        nameof(DeityDomain.Harvest), nameof(DeityDomain.Stone)
-    };
+        DeityDomains.Selectable.Select(d => d.ToString()).ToArray();
 
     private static readonly string[] ReligionPrefixes =
     {

--- a/DivineAscension/GUI/UI/Adapters/ReligionInvites/FakeReligionInvitesProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/ReligionInvites/FakeReligionInvitesProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using DivineAscension.GUI.Models.Religion.Invites;
 using DivineAscension.Models.Enum;
 
@@ -37,11 +38,9 @@ internal sealed class FakeReligionInvitesProvider : IReligionInvitesProvider
         "A long missive that runs well past the comfortable single line so the truncation and ellipsis behaviour can be reviewed in the styled preview without a server."
     };
 
-    private static readonly DeityDomain[] Domains =
-    {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
-        DeityDomain.Harvest, DeityDomain.Stone
-    };
+    // Mirrors the domains a player can actually worship (Caravan appears only
+    // when its feature flag is on) — sourced from the SST (#558).
+    private static readonly DeityDomain[] Domains = DeityDomains.Selectable.ToArray();
 
     private IReadOnlyList<InviteData> _cache = Array.Empty<InviteData>();
     private int _count = 4;

--- a/DivineAscension/GUI/UI/Adapters/ReligionMembers/FakeReligionMemberProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/ReligionMembers/FakeReligionMemberProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using DivineAscension.Models.Enum;
 
 namespace DivineAscension.GUI.UI.Adapters.ReligionMembers;
@@ -24,7 +25,7 @@ internal sealed class FakeReligionMemberProvider : IReligionMemberProvider
     };
 
     private static readonly string[] Deities =
-        { nameof(DeityDomain.Craft), nameof(DeityDomain.Wild), nameof(DeityDomain.Harvest), nameof(DeityDomain.Stone) };
+        DeityDomains.Selectable.Select(d => d.ToString()).ToArray();
 
     private IReadOnlyList<MemberVM> _cache = Array.Empty<MemberVM>();
     private int _count = 250;

--- a/DivineAscension/GUI/UI/Adapters/Religions/FakeReligionProvider.cs
+++ b/DivineAscension/GUI/UI/Adapters/Religions/FakeReligionProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using DivineAscension.Models.Enum;
 
 namespace DivineAscension.GUI.UI.Adapters.Religions;
@@ -25,7 +26,7 @@ internal sealed class FakeReligionProvider : IReligionProvider
     };
 
     private static readonly string[] Deities =
-        { nameof(DeityDomain.Craft), nameof(DeityDomain.Wild), nameof(DeityDomain.Harvest), nameof(DeityDomain.Stone) };
+        DeityDomains.Selectable.Select(d => d.ToString()).ToArray();
 
     private static readonly string[] DeityNames =
     {

--- a/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
@@ -65,14 +65,6 @@ internal static class CrossDeitySummaryRenderer
         }
     }
 
-    private static string DomainShort(DeityDomain d) => d switch
-    {
-        DeityDomain.Craft => "C",
-        DeityDomain.Wild => "W",
-        DeityDomain.Conquest => "Q",
-        DeityDomain.Harvest => "H",
-        DeityDomain.Stone => "S",
-        DeityDomain.Caravan => "R",
-        _ => "?"
-    };
+    private static string DomainShort(DeityDomain d) =>
+        DeityDomainRegistry.TryGet(d, out var meta) ? meta.ShortCode : "?";
 }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
@@ -1,6 +1,6 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
-using DivineAscension.Configuration;
 using DivineAscension.GUI.UI.Renderers.Utilities;
 using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models.Enum;
@@ -21,21 +21,11 @@ internal static class DeitySelectorRenderer
     private const float PatronBorderThickness = 2.5f;
     private const float ActiveBorderThickness = 2f;
     public const float Height = TabSize + 4f;
-    public const int TabCount = FeatureFlags.CaravanDomainEnabled ? 6 : 5;
-    public const float StripWidth = TabCount * TabSize + (TabCount - 1) * TabSpacing;
-
-    // Caravan is appended only when its domain is enabled (see FeatureFlags). Keep the
-    // count above (TabCount) in sync with this array's length.
-    private static readonly DeityDomain[] Order = FeatureFlags.CaravanDomainEnabled
-        ? new[]
-        {
-            DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone,
-            DeityDomain.Caravan
-        }
-        : new[]
-        {
-            DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest, DeityDomain.Harvest, DeityDomain.Stone
-        };
+    // The selectable domains drive both the tab order and the count; Caravan is
+    // included only when its feature flag is on (see DeityDomains.Selectable).
+    private static readonly IReadOnlyList<DeityDomain> Order = DeityDomains.Selectable;
+    public static readonly int TabCount = Order.Count;
+    public static readonly float StripWidth = TabCount * TabSize + (TabCount - 1) * TabSpacing;
 
     /// <summary>
     ///     Draw the deity selector. Returns the deity the user clicked this frame, or null.
@@ -49,7 +39,7 @@ internal static class DeitySelectorRenderer
         DeityDomain? requested = null;
         var cursorX = x;
 
-        for (var i = 0; i < Order.Length; i++)
+        for (var i = 0; i < Order.Count; i++)
         {
             var domain = Order[i];
             var isPatron = patronDomain != DeityDomain.None && domain == patronDomain;

--- a/DivineAscension/GUI/UI/Utilities/DeityInfoHelper.cs
+++ b/DivineAscension/GUI/UI/Utilities/DeityInfoHelper.cs
@@ -20,43 +20,12 @@ internal static class DeityInfoHelper
     /// <summary>
     /// Get deity information by type
     /// </summary>
-    // todo: localize the strings in this text.
+    // todo: localize the strings in this text (TooltipDescription lives in DeityDomainRegistry).
     public static DomainInfo? GetDeityInfo(DeityDomain deityDomain)
     {
-        return deityDomain switch
-        {
-            DeityDomain.Craft => new DomainInfo(
-                Name: "Craft",
-                Description:
-                "The domain of the Forge and Craft. Followers are rewarded for their dedication to metalworking, smithing, and the creation of tools and weapons. Those who shape raw materials into works of utility and art earn the favor of this domain."
-            ),
-            DeityDomain.Wild => new DomainInfo(
-                Name: "Wild",
-                Description:
-                "The domain of the Hunt and Wild. Followers are rewarded for patience, precision, and tracking. Those who master the hunt and live in harmony with the wilderness earn the favor of this domain."
-            ),
-            DeityDomain.Conquest => new DomainInfo(
-                Name: "Conquest",
-                Description:
-                "The domain of Domination and Victory. Followers are rewarded for martial prowess, defeating enemies, and expanding their dominance through strength. Those who prove their superiority in combat and claim victory earn the favor of this domain."
-            ),
-            DeityDomain.Harvest => new DomainInfo(
-                Name: "Harvest",
-                Description:
-                "The domain of Agriculture and Light. Followers are rewarded for cultivation and nurturing growth through light and warmth. Those who tend the land and bring forth abundance earn the favor of this domain."
-            ),
-            DeityDomain.Stone => new DomainInfo(
-                Name: "Stone",
-                Description:
-                "The domain of Earth and Stone. Followers are rewarded for the transformative art of working with clay and earth. Those who shape pottery, form clay, and honor the elements of the ground earn the favor of this domain."
-            ),
-            DeityDomain.Caravan => new DomainInfo(
-                Name: "Caravan",
-                Description:
-                "The domain of Trade and Wayfaring. Followers are rewarded for honest exchange and miles travelled under open sky. Those who barter with strangers, carry goods between distant hearths, and walk the unmapped roads earn the favor of this domain."
-            ),
-            _ => null
-        };
+        return DeityDomainRegistry.TryGet(deityDomain, out var meta)
+            ? new DomainInfo(deityDomain.ToString(), meta.TooltipDescription)
+            : null;
     }
 }
 

--- a/DivineAscension/GUI/UI/Utilities/DomainHelper.cs
+++ b/DivineAscension/GUI/UI/Utilities/DomainHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Numerics;
 using DivineAscension.Models.Enum;
 
@@ -10,13 +11,16 @@ namespace DivineAscension.GUI.UI.Utilities;
 /// </summary>
 internal static class DomainHelper
 {
+    /// <summary>Faded-ink fallback colour for an unknown / None domain.</summary>
+    private static readonly Vector4 UnknownColor = new(0.659f, 0.580f, 0.447f, 1.0f); // #A89472
+
     /// <summary>
-    ///     All selectable domain names in order. Caravan is appended only when its
-    ///     domain is enabled (see <see cref="Configuration.FeatureFlags.CaravanDomainEnabled"/>).
+    ///     All selectable domain names in order. Caravan is included only when its
+    ///     domain is enabled (see <see cref="Configuration.FeatureFlags.CaravanDomainEnabled"/>),
+    ///     sourced from <see cref="DeityDomains.Selectable"/>.
     /// </summary>
-    public static readonly string[] DomainNames = Configuration.FeatureFlags.CaravanDomainEnabled
-        ? new[] { "Craft", "Wild", "Conquest", "Harvest", "Stone", "Caravan" }
-        : new[] { "Craft", "Wild", "Conquest", "Harvest", "Stone" };
+    public static readonly string[] DomainNames =
+        DeityDomains.Selectable.Select(d => d.ToString()).ToArray();
 
     /// <summary>
     ///     Legacy: All deity names (now domain names) - alias for DomainNames
@@ -29,19 +33,7 @@ internal static class DomainHelper
     ///     saturated UI colour — they sit on the parchment page next to
     ///     the gold / lapis / vermilion accent inks without clashing.
     /// </summary>
-    public static Vector4 GetDomainColor(string domain)
-    {
-        return domain switch
-        {
-            "Craft" => new Vector4(0.698f, 0.416f, 0.165f, 1.0f), // #B26A2A copper — Forge & Craft
-            "Wild" => new Vector4(0.361f, 0.431f, 0.165f, 1.0f), // #5C6E2A olive — Hunt & Wild
-            "Conquest" => new Vector4(0.557f, 0.180f, 0.122f, 1.0f), // #8E2E1F dried-blood red — Domination & Victory
-            "Harvest" => new Vector4(0.627f, 0.463f, 0.157f, 1.0f), // #A07628 wheat ochre — Agriculture & Light
-            "Stone" => new Vector4(0.369f, 0.329f, 0.282f, 1.0f), // #5E5448 warm slate — Earth & Stone
-            "Caravan" => new Vector4(0.761f, 0.541f, 0.118f, 1.0f), // #C28A1E road ochre — Trade & Wayfaring
-            _ => new Vector4(0.659f, 0.580f, 0.447f, 1.0f) // #A89472 faded ink — Unknown
-        };
-    }
+    public static Vector4 GetDomainColor(string domain) => GetDeityColor(ParseDomain(domain));
 
     /// <summary>
     ///     Get the thematic color for a domain (by name string) - alias for GetDomainColor
@@ -62,53 +54,20 @@ internal static class DomainHelper
     ///     Get the thematic color for a domain (by enum). See
     ///     <see cref="GetDomainColor(string)" /> for the manuscript-ink rationale.
     /// </summary>
-    public static Vector4 GetDeityColor(DeityDomain domain)
-    {
-        return domain switch
-        {
-            DeityDomain.Craft => new Vector4(0.698f, 0.416f, 0.165f, 1.0f), // #B26A2A copper
-            DeityDomain.Wild => new Vector4(0.361f, 0.431f, 0.165f, 1.0f), // #5C6E2A olive
-            DeityDomain.Conquest => new Vector4(0.557f, 0.180f, 0.122f, 1.0f), // #8E2E1F dried-blood red
-            DeityDomain.Harvest => new Vector4(0.627f, 0.463f, 0.157f, 1.0f), // #A07628 wheat ochre
-            DeityDomain.Stone => new Vector4(0.369f, 0.329f, 0.282f, 1.0f), // #5E5448 warm slate
-            DeityDomain.Caravan => new Vector4(0.761f, 0.541f, 0.118f, 1.0f), // #C28A1E road ochre
-            _ => new Vector4(0.659f, 0.580f, 0.447f, 1.0f) // #A89472 faded ink
-        };
-    }
+    public static Vector4 GetDeityColor(DeityDomain domain) =>
+        DeityDomainRegistry.TryGet(domain, out var meta) ? meta.PrimaryColor : UnknownColor;
 
     /// <summary>
-    ///     Get the domain title/description (by domain name string)
+    ///     Get the domain title suffix (by domain name string), e.g. "of the Craft".
     /// </summary>
-    public static string GetDomainTitle(string domain)
-    {
-        return domain switch
-        {
-            "Craft" => "of the Craft",
-            "Wild" => "of the Wild",
-            "Conquest" => "of Conquest",
-            "Harvest" => "of the Harvest",
-            "Stone" => "of the Stone",
-            "Caravan" => "of the Caravan",
-            _ => "Unknown Domain"
-        };
-    }
+    public static string GetDomainTitle(string domain) =>
+        DeityDomainRegistry.TryGet(ParseDomain(domain), out var meta) ? meta.TitleSuffix : "Unknown Domain";
 
     /// <summary>
-    ///     Get the domain title/description (by enum)
+    ///     Get the full domain title (by enum), e.g. "Domain of the Craft".
     /// </summary>
-    public static string GetDeityTitle(DeityDomain domain)
-    {
-        return domain switch
-        {
-            DeityDomain.Craft => "Domain of the Craft",
-            DeityDomain.Wild => "Domain of the Wild",
-            DeityDomain.Conquest => "Domain of Conquest",
-            DeityDomain.Harvest => "Domain of the Harvest",
-            DeityDomain.Stone => "Domain of the Stone",
-            DeityDomain.Caravan => "Domain of the Caravan",
-            _ => "Unknown Domain"
-        };
-    }
+    public static string GetDeityTitle(DeityDomain domain) =>
+        DeityDomainRegistry.TryGet(domain, out var meta) ? $"Domain {meta.TitleSuffix}" : "Unknown Domain";
 
     /// <summary>
     ///     Convert domain name string to DeityDomain enum

--- a/DivineAscension/Models/CivilizationEthosDeriver.cs
+++ b/DivineAscension/Models/CivilizationEthosDeriver.cs
@@ -16,14 +16,8 @@ public static class CivilizationEthosDeriver
     /// </summary>
     public static (CivilizationEthos Ethos, string EpithetLocKey) Derive(DeityDomain patronDomain)
     {
-        return patronDomain switch
-        {
-            DeityDomain.Craft => (CivilizationEthos.Mercantile, LocalizationKeys.CIVILIZATION_EPITHET_CRAFT),
-            DeityDomain.Conquest => (CivilizationEthos.Martial, LocalizationKeys.CIVILIZATION_EPITHET_CONQUEST),
-            DeityDomain.Wild => (CivilizationEthos.Mystic, LocalizationKeys.CIVILIZATION_EPITHET_WILD),
-            DeityDomain.Harvest => (CivilizationEthos.Ascetic, LocalizationKeys.CIVILIZATION_EPITHET_HARVEST),
-            DeityDomain.Stone => (CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_STONE),
-            _ => (CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_DEFAULT)
-        };
+        return DeityDomainRegistry.TryGet(patronDomain, out var meta)
+            ? (meta.Ethos, meta.EpithetLocKey)
+            : (CivilizationEthos.Sovereign, LocalizationKeys.CIVILIZATION_EPITHET_DEFAULT);
     }
 }

--- a/DivineAscension/Models/Enum/DeityDomainRegistry.cs
+++ b/DivineAscension/Models/Enum/DeityDomainRegistry.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using DivineAscension.Constants;
+using Vintagestory.API.MathTools;
+
+namespace DivineAscension.Models.Enum;
+
+/// <summary>
+///     Immutable per-domain facts. Promotes the dozens of per-domain
+///     <c>switch</c> expressions scattered across the codebase (loc keys, colors,
+///     short codes, ethos, feast day, prayer particle color, prestige keywords)
+///     into a single record so a new <see cref="DeityDomain" /> is described in
+///     exactly one place (#558).
+/// </summary>
+/// <param name="Domain">The domain this metadata describes.</param>
+/// <param name="ShortCode">One-letter code for the cross-deity summary strip.</param>
+/// <param name="NameLocKey">Localization key for the domain's display name.</param>
+/// <param name="TitleLocKey">Localization key for the domain's title.</param>
+/// <param name="DescriptionLocKey">Localization key for the domain's description.</param>
+/// <param name="EpithetLocKey">Localization key for the founder epithet of a civ with this patron.</param>
+/// <param name="FeastPatronLocKey">Localization key for the auto-seeded patron feast name.</param>
+/// <param name="TitleSuffix">English title fragment, e.g. "of the Craft" (UI tooltips, not yet localized).</param>
+/// <param name="TooltipDescription">English long-form tooltip blurb (not yet localized).</param>
+/// <param name="PrimaryColor">Manuscript-ink accent color for this domain.</param>
+/// <param name="PrayerParticleRgba">ARGB-packed color for prayer particles at this domain's altars.</param>
+/// <param name="Ethos">Civilization ethos derived when this domain is the founder's patron.</param>
+/// <param name="HolyDay">Fixed patron's-day (in-game month/day) for the auto-seeded feast.</param>
+/// <param name="PrestigeActivityKeywords">Action-type substrings that earn prestige for this domain.</param>
+public record DeityDomainMetadata(
+    DeityDomain Domain,
+    string ShortCode,
+    string NameLocKey,
+    string TitleLocKey,
+    string DescriptionLocKey,
+    string EpithetLocKey,
+    string FeastPatronLocKey,
+    string TitleSuffix,
+    string TooltipDescription,
+    Vector4 PrimaryColor,
+    int PrayerParticleRgba,
+    CivilizationEthos Ethos,
+    (int Month, int Day) HolyDay,
+    IReadOnlyList<string> PrestigeActivityKeywords);
+
+/// <summary>
+///     The single source of truth for per-domain metadata. A real domain
+///     (everything in <see cref="DeityDomains.All" />) without an entry here
+///     throws on first lookup — much louder than the old default-case
+///     "Unknown" silent degrade. The <c>DeityDomainRegistry_CoversAllDomains</c>
+///     guard test fails CI the moment a new domain is added without an entry.
+/// </summary>
+public static class DeityDomainRegistry
+{
+    private static readonly Dictionary<DeityDomain, DeityDomainMetadata> Map = new()
+    {
+        [DeityDomain.Craft] = new DeityDomainMetadata(
+            DeityDomain.Craft, "C",
+            LocalizationKeys.DOMAIN_CRAFT_NAME, LocalizationKeys.DOMAIN_CRAFT_TITLE,
+            LocalizationKeys.DOMAIN_CRAFT_DESCRIPTION, LocalizationKeys.CIVILIZATION_EPITHET_CRAFT,
+            LocalizationKeys.FEAST_PATRON_CRAFT_NAME,
+            "of the Craft",
+            "The domain of the Forge and Craft. Followers are rewarded for their dedication to metalworking, smithing, and the creation of tools and weapons. Those who shape raw materials into works of utility and art earn the favor of this domain.",
+            new Vector4(0.698f, 0.416f, 0.165f, 1.0f), // #B26A2A copper — Forge & Craft
+            ColorUtil.ToRgba(255, 255, 60, 40), // red/orange for forging
+            CivilizationEthos.Mercantile, (2, 1),
+            new[] { "mining", "smithing", "smelting", "anvil" }),
+
+        [DeityDomain.Wild] = new DeityDomainMetadata(
+            DeityDomain.Wild, "W",
+            LocalizationKeys.DOMAIN_WILD_NAME, LocalizationKeys.DOMAIN_WILD_TITLE,
+            LocalizationKeys.DOMAIN_WILD_DESCRIPTION, LocalizationKeys.CIVILIZATION_EPITHET_WILD,
+            LocalizationKeys.FEAST_PATRON_WILD_NAME,
+            "of the Wild",
+            "The domain of the Hunt and Wild. Followers are rewarded for patience, precision, and tracking. Those who master the hunt and live in harmony with the wilderness earn the favor of this domain.",
+            new Vector4(0.361f, 0.431f, 0.165f, 1.0f), // #5C6E2A olive — Hunt & Wild
+            ColorUtil.ToRgba(255, 50, 220, 80), // green for nature
+            CivilizationEthos.Mystic, (4, 15),
+            new[] { "hunting", "foraging", "skinning", "exploration" }),
+
+        [DeityDomain.Conquest] = new DeityDomainMetadata(
+            DeityDomain.Conquest, "Q",
+            LocalizationKeys.DOMAIN_CONQUEST_NAME, LocalizationKeys.DOMAIN_CONQUEST_TITLE,
+            LocalizationKeys.DOMAIN_CONQUEST_DESCRIPTION, LocalizationKeys.CIVILIZATION_EPITHET_CONQUEST,
+            LocalizationKeys.FEAST_PATRON_CONQUEST_NAME,
+            "of Conquest",
+            "The domain of Domination and Victory. Followers are rewarded for martial prowess, defeating enemies, and expanding their dominance through strength. Those who prove their superiority in combat and claim victory earn the favor of this domain.",
+            new Vector4(0.557f, 0.180f, 0.122f, 1.0f), // #8E2E1F dried-blood red — Domination & Victory
+            ColorUtil.ToRgba(255, 140, 20, 30), // crimson/blood for battle
+            CivilizationEthos.Martial, (7, 4),
+            new[] { "combat", "battle", "fight", "discovered", "ruin", "patrol" }),
+
+        [DeityDomain.Harvest] = new DeityDomainMetadata(
+            DeityDomain.Harvest, "H",
+            LocalizationKeys.DOMAIN_HARVEST_NAME, LocalizationKeys.DOMAIN_HARVEST_TITLE,
+            LocalizationKeys.DOMAIN_HARVEST_DESCRIPTION, LocalizationKeys.CIVILIZATION_EPITHET_HARVEST,
+            LocalizationKeys.FEAST_PATRON_HARVEST_NAME,
+            "of the Harvest",
+            "The domain of Agriculture and Light. Followers are rewarded for cultivation and nurturing growth through light and warmth. Those who tend the land and bring forth abundance earn the favor of this domain.",
+            new Vector4(0.627f, 0.463f, 0.157f, 1.0f), // #A07628 wheat ochre — Agriculture & Light
+            ColorUtil.ToRgba(255, 255, 200, 50), // golden for crops
+            CivilizationEthos.Ascetic, (9, 12),
+            new[] { "harvest", "planting", "cooking" }),
+
+        [DeityDomain.Stone] = new DeityDomainMetadata(
+            DeityDomain.Stone, "S",
+            LocalizationKeys.DOMAIN_STONE_NAME, LocalizationKeys.DOMAIN_STONE_TITLE,
+            LocalizationKeys.DOMAIN_STONE_DESCRIPTION, LocalizationKeys.CIVILIZATION_EPITHET_STONE,
+            LocalizationKeys.FEAST_PATRON_STONE_NAME,
+            "of the Stone",
+            "The domain of Earth and Stone. Followers are rewarded for the transformative art of working with clay and earth. Those who shape pottery, form clay, and honor the elements of the ground earn the favor of this domain.",
+            new Vector4(0.369f, 0.329f, 0.282f, 1.0f), // #5E5448 warm slate — Earth & Stone
+            ColorUtil.ToRgba(255, 160, 140, 120), // brown/tan for earth
+            CivilizationEthos.Sovereign, (11, 1),
+            new[] { "pottery", "brick", "clay", "carving" }),
+
+        [DeityDomain.Caravan] = new DeityDomainMetadata(
+            DeityDomain.Caravan, "R",
+            LocalizationKeys.DOMAIN_CARAVAN_NAME, LocalizationKeys.DOMAIN_CARAVAN_TITLE,
+            LocalizationKeys.DOMAIN_CARAVAN_DESCRIPTION, LocalizationKeys.CIVILIZATION_EPITHET_CARAVAN,
+            LocalizationKeys.FEAST_PATRON_CARAVAN_NAME,
+            "of the Caravan",
+            "The domain of Trade and Wayfaring. Followers are rewarded for honest exchange and miles travelled under open sky. Those who barter with strangers, carry goods between distant hearths, and walk the unmapped roads earn the favor of this domain.",
+            new Vector4(0.761f, 0.541f, 0.118f, 1.0f), // #C28A1E road ochre — Trade & Wayfaring
+            ColorUtil.ToRgba(255, 200, 150, 40), // amber for road dust
+            CivilizationEthos.Mercantile, (6, 21),
+            new[] { "trade", "discovered chunk", "encountered trader" })
+    };
+
+    /// <summary>All registered metadata, in <see cref="DeityDomains.All" /> order.</summary>
+    public static readonly IReadOnlyList<DeityDomainMetadata> All =
+        DeityDomains.All.Select(d => Map[d]).ToArray();
+
+    /// <summary>
+    ///     Metadata for a domain. Throws for a real domain with no entry (a bug a
+    ///     guard test should already have caught) and for <see cref="DeityDomain.None" />.
+    /// </summary>
+    public static DeityDomainMetadata Get(DeityDomain domain) =>
+        Map.TryGetValue(domain, out var meta)
+            ? meta
+            : throw new ArgumentException($"DeityDomain {domain} has no registered metadata", nameof(domain));
+
+    /// <summary>
+    ///     Metadata for a domain, or false for <see cref="DeityDomain.None" /> / any
+    ///     unregistered value. Use on UI paths that legitimately receive None.
+    /// </summary>
+    public static bool TryGet(DeityDomain domain, out DeityDomainMetadata meta) =>
+        Map.TryGetValue(domain, out meta!);
+}

--- a/DivineAscension/Models/Enum/DeityDomains.cs
+++ b/DivineAscension/Models/Enum/DeityDomains.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using DivineAscension.Configuration;
+
+namespace DivineAscension.Models.Enum;
+
+/// <summary>
+///     Single source of truth for enumerating <see cref="DeityDomain" /> values.
+///     Adding a domain to the enum (plus a <see cref="DeityDomainRegistry" /> entry)
+///     propagates everywhere automatically — no more hand-maintained
+///     <c>{ Craft, Wild, ... }</c> arrays that silently drop a domain (#558).
+/// </summary>
+public static class DeityDomains
+{
+    /// <summary>
+    ///     All real domains (excludes <see cref="DeityDomain.None" />), in enum
+    ///     declaration (underlying-value) order. Use for data-completeness loops
+    ///     (packets, blessing preloads, asset loaders) that must cover every domain
+    ///     regardless of feature flags.
+    /// </summary>
+    public static readonly IReadOnlyList<DeityDomain> All =
+        System.Enum.GetValues<DeityDomain>().Where(d => d != DeityDomain.None).ToArray();
+
+    /// <summary>
+    ///     Lower-case codes used in JSON file names + asset paths (e.g. "craft").
+    ///     Parallel to <see cref="All" />.
+    /// </summary>
+    public static readonly IReadOnlyList<string> AllCodes =
+        All.Select(d => d.ToString().ToLowerInvariant()).ToArray();
+
+    /// <summary>
+    ///     Domains a player may currently select/worship: <see cref="All" /> minus any
+    ///     domain gated behind an off feature flag (Caravan when
+    ///     <see cref="FeatureFlags.CaravanDomainEnabled" /> is false). Use for UI
+    ///     selectors and player-facing choice lists.
+    /// </summary>
+    public static readonly IReadOnlyList<DeityDomain> Selectable =
+        All.Where(IsEnabled).ToArray();
+
+    /// <summary>
+    ///     Whether a domain is currently enabled for selection. Only Caravan is
+    ///     feature-gated today; every other real domain is always enabled.
+    /// </summary>
+    public static bool IsEnabled(DeityDomain domain) =>
+        domain != DeityDomain.Caravan || FeatureFlags.CaravanDomainEnabled;
+}

--- a/DivineAscension/Models/FeastDay.cs
+++ b/DivineAscension/Models/FeastDay.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using DivineAscension.Models.Enum;
 using ProtoBuf;
@@ -69,18 +70,13 @@ public class FeastDay
     [ProtoMember(7)] public int LastAdvanceFiredYear { get; set; }
 
     /// <summary>
-    ///     Fixed patron's-day per domain (#375). Defined here so the ticker, the
-    ///     religion manager, and tests share a single source of truth.
+    ///     Fixed patron's-day per domain (#375). Sourced from
+    ///     <see cref="DeityDomainRegistry"/> so the ticker, the religion manager,
+    ///     and tests share one source of truth (#558) — adding a domain to the
+    ///     registry seeds its patron feast automatically.
     /// </summary>
     public static readonly IReadOnlyDictionary<DeityDomain, (int Month, int Day)> DomainHolyDay =
-        new Dictionary<DeityDomain, (int Month, int Day)>
-        {
-            [DeityDomain.Craft] = (2, 1),
-            [DeityDomain.Wild] = (4, 15),
-            [DeityDomain.Conquest] = (7, 4),
-            [DeityDomain.Harvest] = (9, 12),
-            [DeityDomain.Stone] = (11, 1)
-        };
+        DeityDomainRegistry.All.ToDictionary(m => m.Domain, m => m.HolyDay);
 
     /// <summary>
     ///     Deterministic Guid for an auto-seeded feast on a given religion.

--- a/DivineAscension/Services/BlessingLoader.cs
+++ b/DivineAscension/Services/BlessingLoader.cs
@@ -17,7 +17,7 @@ namespace DivineAscension.Services;
 /// </summary>
 public class BlessingLoader : IBlessingLoader
 {
-    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone", "caravan" };
+    private static readonly IReadOnlyList<string> DomainFiles = DeityDomains.AllCodes;
 
     private readonly ICoreAPI _api;
     private readonly List<Blessing> _loadedBlessings = new();

--- a/DivineAscension/Services/OfferingLoader.cs
+++ b/DivineAscension/Services/OfferingLoader.cs
@@ -15,7 +15,7 @@ namespace DivineAscension.Services;
 /// </summary>
 public class OfferingLoader(ILoggerWrapper logger, IAssetManager assetManager) : IOfferingLoader
 {
-    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone", "caravan" };
+    private static readonly IReadOnlyList<string> DomainFiles = DeityDomains.AllCodes;
 
     private readonly IAssetManager
         _assetManager = assetManager ?? throw new ArgumentNullException(nameof(assetManager));

--- a/DivineAscension/Services/PrayerEffectsService.cs
+++ b/DivineAscension/Services/PrayerEffectsService.cs
@@ -131,15 +131,9 @@ public class PrayerEffectsService : IPrayerEffectsService
         };
 
         // Domain-based color (ARGB format: Alpha, Red, Green, Blue)
-        var color = domain switch
-        {
-            DeityDomain.Craft => ColorUtil.ToRgba(255, 255, 60, 40), // Red/orange for forging
-            DeityDomain.Wild => ColorUtil.ToRgba(255, 50, 220, 80), // Green for nature
-            DeityDomain.Conquest => ColorUtil.ToRgba(255, 140, 20, 30), // Crimson/blood for battle
-            DeityDomain.Harvest => ColorUtil.ToRgba(255, 255, 200, 50), // Golden for crops
-            DeityDomain.Stone => ColorUtil.ToRgba(255, 160, 140, 120), // Brown/tan for earth
-            _ => ColorUtil.ToRgba(255, 255, 255, 200) // White/silver default
-        };
+        var color = DeityDomainRegistry.TryGet(domain, out var meta)
+            ? meta.PrayerParticleRgba
+            : ColorUtil.ToRgba(255, 255, 255, 200); // White/silver default
 
         var particles = new SimpleParticleProperties
         {

--- a/DivineAscension/Services/RitualLoader.cs
+++ b/DivineAscension/Services/RitualLoader.cs
@@ -16,7 +16,7 @@ namespace DivineAscension.Services;
 /// </summary>
 public class RitualLoader(ILoggerWrapper logger, IAssetManager assetManager) : IRitualLoader
 {
-    private static readonly string[] DomainFiles = { "craft", "wild", "conquest", "harvest", "stone", "caravan" };
+    private static readonly IReadOnlyList<string> DomainFiles = DeityDomains.AllCodes;
 
     private readonly IAssetManager
         _assetManager = assetManager ?? throw new ArgumentNullException(nameof(assetManager));

--- a/DivineAscension/Systems/FavorSystem.cs
+++ b/DivineAscension/Systems/FavorSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Configuration;
 using DivineAscension.Constants;
@@ -318,46 +319,8 @@ public class FavorSystem : IFavorSystem
         if (actionLower.Contains("passive") || actionLower.Contains("devotion"))
             return false;
 
-        return deity switch
-        {
-            DeityDomain.Craft =>
-                actionLower.Contains("mining") ||
-                actionLower.Contains("smithing") ||
-                actionLower.Contains("smelting") ||
-                actionLower.Contains("anvil"),
-
-            DeityDomain.Wild =>
-                actionLower.Contains("hunting") ||
-                actionLower.Contains("foraging") ||
-                actionLower.Contains("skinning") ||
-                actionLower.Contains("exploration"),
-
-            DeityDomain.Conquest =>
-                actionLower.Contains("combat") ||
-                actionLower.Contains("battle") ||
-                actionLower.Contains("fight") ||
-                actionLower.Contains("discovered") ||
-                actionLower.Contains("ruin") ||
-                actionLower.Contains("patrol"),
-
-            DeityDomain.Harvest =>
-                actionLower.Contains("harvest") ||
-                actionLower.Contains("planting") ||
-                actionLower.Contains("cooking"),
-
-            DeityDomain.Stone =>
-                actionLower.Contains("pottery") ||
-                actionLower.Contains("brick") ||
-                actionLower.Contains("clay") ||
-                actionLower.Contains("carving"),
-
-            DeityDomain.Caravan =>
-                actionLower.Contains("trade") ||
-                actionLower.Contains("discovered chunk") ||
-                actionLower.Contains("encountered trader"),
-
-            _ => false
-        };
+        return DeityDomainRegistry.TryGet(deity, out var meta)
+               && meta.PrestigeActivityKeywords.Any(actionLower.Contains);
     }
 
     /// <summary>

--- a/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
@@ -22,11 +22,7 @@ namespace DivineAscension.Systems.Networking.Server;
 [ExcludeFromCodeCoverage]
 public class BlessingNetworkHandler : IServerNetworkHandler
 {
-    private static readonly DeityDomain[] AllDeities =
-    {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
-        DeityDomain.Harvest, DeityDomain.Stone, DeityDomain.Caravan
-    };
+    private static readonly IReadOnlyList<DeityDomain> AllDeities = DeityDomains.All;
 
     private readonly ILogger _logger;
     private readonly BlessingRegistry _blessingRegistry;

--- a/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
@@ -20,11 +20,7 @@ namespace DivineAscension.Systems.Networking.Server;
 [ExcludeFromCodeCoverage]
 public class PlayerDataNetworkHandler : IServerNetworkHandler
 {
-    private static readonly DeityDomain[] AllDeities =
-    {
-        DeityDomain.Craft, DeityDomain.Wild, DeityDomain.Conquest,
-        DeityDomain.Harvest, DeityDomain.Stone
-    };
+    private static readonly IReadOnlyList<DeityDomain> AllDeities = DeityDomains.All;
 
     private readonly IPlayerProgressionDataManager? _playerProgressionDataManager;
     private readonly IReligionManager? _religionManager;

--- a/DivineAscension/Systems/ReligionManager.cs
+++ b/DivineAscension/Systems/ReligionManager.cs
@@ -982,15 +982,9 @@ public class ReligionManager : IReligionManager
 
         if (FeastDay.DomainHolyDay.TryGetValue(religion.PatronDomain, out var patron))
         {
-            var patronKey = religion.PatronDomain switch
-            {
-                DeityDomain.Craft => LocalizationKeys.FEAST_PATRON_CRAFT_NAME,
-                DeityDomain.Wild => LocalizationKeys.FEAST_PATRON_WILD_NAME,
-                DeityDomain.Conquest => LocalizationKeys.FEAST_PATRON_CONQUEST_NAME,
-                DeityDomain.Harvest => LocalizationKeys.FEAST_PATRON_HARVEST_NAME,
-                DeityDomain.Stone => LocalizationKeys.FEAST_PATRON_STONE_NAME,
-                _ => null
-            };
+            var patronKey = DeityDomainRegistry.TryGet(religion.PatronDomain, out var meta)
+                ? meta.FeastPatronLocKey
+                : null;
             if (patronKey != null)
             {
                 feasts.Add(new FeastDay(


### PR DESCRIPTION
## Summary

Kills the two anti-patterns from #558 — hardcoded `DeityDomain[]` arrays and per-domain `switch` expressions with silently-degrading defaults — by introducing a single source of truth and routing every consumer through it.

**New (`Models/Enum/`):**
- `DeityDomains` — `All` (every real domain, for data-completeness loops), `AllCodes` (lowercase file-name codes), `Selectable` (feature-flag-gated; Caravan hidden while its flag is off).
- `DeityDomainMetadata` record + `DeityDomainRegistry` — one entry per domain holding loc keys, primary color, short code, prayer-particle rgba, civ ethos + epithet key, feast patron key, holy day, and prestige-activity keywords. `Get` throws for a real domain with no entry (loud, not silent); `TryGet` for `None`/UI paths.

**Migrated consumers:**
- *Category A/C arrays* → `DeityDomains.All`/`AllCodes`: blessing + player-data network handlers, `FavorCommands`, blessing-texture preload, deity selector (`Selectable`), and the three loader `DomainFiles`.
- *Category B switches* → registry lookups: `EnumLocalizationExtensions`, `CrossDeitySummaryRenderer`, `DeityInfoHelper`, `DomainHelper`, `CivilizationEthosDeriver`, `PrayerEffectsService`, `FavorSystem` prestige whitelist, `ReligionManager` feast key.
- *Category D* → `FeastDay.DomainHolyDay` now derives from the registry (adds the missing Caravan patron day).
- The four `Fake*` dev-data adapters now source from `DeityDomains.Selectable` (adds Conquest to previews; Caravan still flag-gated).

**Bug fixes folded in (root cause of #556/#557):**
- `PlayerDataNetworkHandler` now covers all domains (was missing Caravan, #557).
- Added missing `LocalizationKeys` constants for Conquest/Caravan domain name/title/description and Caravan feast + epithet — lang strings already existed, so the old defaults degraded to "Unknown" (#556).

**Out of scope:** `DomainGlyphRenderer` — that `switch` dispatches to distinct per-domain *drawing* code (hammer, leaf, crossed swords…), not data, so it isn't a registry candidate.

## Notes
- Caravan stays gated for shipping via `DeityDomains.Selectable`; only data-completeness loops use `All`.
- `DeityDomains.All` is in enum-value order (Caravan before Stone); irrelevant for the keyed/data loops it feeds. `Selectable` with the flag off reproduces the previous 5-domain order exactly.

## Test plan
- `dotnet build DivineAscension.sln -c Debug` — clean.
- `dotnet test` — **2478 passed, 0 failed.**
- New `DeityDomainRegistryTests` (8 tests) is the guard: it fails CI the moment a new `DeityDomain` value is added without a registry entry. Existing `CivilizationEthosDeriverTests` (added Caravan case) and `SacredCalendarTests` (now registry-driven) updated.

Closes #558