### PR TITLE
feat(traits): PlayerTraitService foundation (#559)

### DIFF
--- a/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataManagerTests.cs
@@ -744,7 +744,7 @@ public class PlayerProgressionDataManagerTests
         Assert.Equal(150, loadedData.GetFavor(DeityDomain.Craft));
         Assert.Equal(200, loadedData.GetTotalFavorEarned(DeityDomain.Craft));
         _mockLogger.Verify(
-            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v8"))),
+            l => l.Debug(It.Is<string>(s => s.Contains("Loaded data") && s.Contains("player-uid") && s.Contains("v9"))),
             Times.Once()
         );
     }

--- a/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerProgressionDataTests.cs
@@ -34,7 +34,7 @@ public class PlayerProgressionDataTests
         Assert.Equal(0, data.GetFavor(DeityDomain.Craft));
         Assert.Equal(0, data.GetTotalFavorEarned(DeityDomain.Craft));
         Assert.Equal(0f, data.GetAccumulatedFractionalFavor(DeityDomain.Craft));
-        Assert.Equal(8, data.DataVersion); // v8: DiscoveredTraderEntityIds (Caravan trader bonus)
+        Assert.Equal(9, data.DataVersion); // v9: GrantedTraitCodes (#559 PlayerTraitService)
         Assert.Equal(0, data.DiscoveredChunkCount);
         Assert.Equal(0, data.DiscoveredTraderCount);
         Assert.Empty(data.UnlockedBlessings);

--- a/DivineAscension.Tests/Systems/PlayerTraitServiceTests.cs
+++ b/DivineAscension.Tests/Systems/PlayerTraitServiceTests.cs
@@ -1,0 +1,190 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using DivineAscension.Configuration;
+using DivineAscension.Services;
+using DivineAscension.Systems;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using ProtoBuf;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Tests.Systems;
+
+/// <summary>
+///     Tests for <see cref="PlayerTraitService"/> — issue #559 foundation.
+///     Verifies grant/revoke updates the granted-codes store, idempotency,
+///     event-handler registration, and ProtoBuf round-trip for the new field.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class PlayerTraitServiceTests
+{
+    private readonly FakeEventService _eventService;
+    private readonly FakePersistenceService _persistenceService;
+    private readonly Mock<ILoggerWrapper> _logger;
+    private readonly Mock<IReligionManager> _religionManager;
+    private readonly PlayerProgressionDataManager _ppdm;
+    private readonly PlayerTraitService _sut;
+
+    public PlayerTraitServiceTests()
+    {
+        _logger = new Mock<ILoggerWrapper>();
+        _eventService = new FakeEventService();
+        _persistenceService = new FakePersistenceService();
+        _religionManager = new Mock<IReligionManager>();
+        var worldService = new FakeWorldService();
+        var timeService = new FakeTimeService();
+        var config = new GameBalanceConfig();
+
+        _ppdm = new PlayerProgressionDataManager(_logger.Object, _eventService, _persistenceService,
+            worldService, _religionManager.Object, config, timeService);
+
+        _sut = new PlayerTraitService(_logger.Object, _eventService, worldService, _ppdm, sapi: null);
+    }
+
+    private static Mock<IServerPlayer> MakePlayer(string uid)
+    {
+        var mock = new Mock<IServerPlayer>();
+        mock.Setup(p => p.PlayerUID).Returns(uid);
+        // Entity left null — SyncExtraTraitsAttribute and ReapplyCharacterClass early-return,
+        // which is acceptable: the data-layer behavior is what's tested here.
+        return mock;
+    }
+
+    [Fact]
+    public void Initialize_RegistersPlayerJoinAndSaveGameLoadedHandlers()
+    {
+        _sut.Initialize();
+
+        Assert.Equal(1, _eventService.PlayerJoinCallbackCount);
+        Assert.Equal(1, _eventService.SaveGameLoadedCallbackCount);
+    }
+
+    [Fact]
+    public void GrantTrait_AddsCodeToPlayerData()
+    {
+        var player = MakePlayer("uid-1");
+
+        var added = _sut.GrantTrait(player.Object, "da_member");
+
+        Assert.True(added);
+        Assert.Contains("da_member", _ppdm.GetOrCreatePlayerData("uid-1").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void GrantTrait_IsIdempotent()
+    {
+        var player = MakePlayer("uid-2");
+
+        var first = _sut.GrantTrait(player.Object, "da_blessed");
+        var second = _sut.GrantTrait(player.Object, "da_blessed");
+
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Single(_ppdm.GetOrCreatePlayerData("uid-2").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void RevokeTrait_RemovesCodeFromPlayerData()
+    {
+        var player = MakePlayer("uid-3");
+        _sut.GrantTrait(player.Object, "da_favored");
+
+        var removed = _sut.RevokeTrait(player.Object, "da_favored");
+
+        Assert.True(removed);
+        Assert.Empty(_ppdm.GetOrCreatePlayerData("uid-3").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void RevokeTrait_AbsentCode_ReturnsFalse()
+    {
+        var player = MakePlayer("uid-4");
+
+        var removed = _sut.RevokeTrait(player.Object, "da_member");
+
+        Assert.False(removed);
+    }
+
+    [Fact]
+    public void HasGrantedTrait_ReflectsGrantState()
+    {
+        var player = MakePlayer("uid-5");
+
+        Assert.False(_sut.HasGrantedTrait("uid-5", "da_member"));
+
+        _sut.GrantTrait(player.Object, "da_member");
+        Assert.True(_sut.HasGrantedTrait("uid-5", "da_member"));
+
+        _sut.RevokeTrait(player.Object, "da_member");
+        Assert.False(_sut.HasGrantedTrait("uid-5", "da_member"));
+    }
+
+    [Fact]
+    public void GrantTrait_NullOrEmptyCode_NoOps()
+    {
+        var player = MakePlayer("uid-6");
+
+        Assert.False(_sut.GrantTrait(player.Object, ""));
+        Assert.False(_sut.GrantTrait(player.Object, "   "));
+        Assert.Empty(_ppdm.GetOrCreatePlayerData("uid-6").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesEventHandlers()
+    {
+        _sut.Initialize();
+        Assert.Equal(1, _eventService.PlayerJoinCallbackCount);
+        Assert.Equal(1, _eventService.SaveGameLoadedCallbackCount);
+
+        _sut.Dispose();
+
+        Assert.Equal(0, _eventService.PlayerJoinCallbackCount);
+        Assert.Equal(0, _eventService.SaveGameLoadedCallbackCount);
+    }
+
+    /// <summary>
+    ///     ProtoBuf round-trip — adding a new tagged field must not break loading older
+    ///     payloads (they simply deserialize with an empty granted-codes set).
+    /// </summary>
+    [Fact]
+    public void PlayerProgressionData_GrantedTraitCodes_RoundTripViaProtoBuf()
+    {
+        var original = new PlayerProgressionData("uid-7");
+        original.AddGrantedTraitCode("da_member");
+        original.AddGrantedTraitCode("da_blessed");
+
+        using var ms = new MemoryStream();
+        Serializer.Serialize(ms, original);
+        ms.Position = 0;
+        var restored = Serializer.Deserialize<PlayerProgressionData>(ms);
+
+        Assert.Equal(9, restored.DataVersion);
+        Assert.Equal(2, restored.GrantedTraitCodes.Count);
+        Assert.Contains("da_member", restored.GrantedTraitCodes);
+        Assert.Contains("da_blessed", restored.GrantedTraitCodes);
+    }
+
+    /// <summary>
+    ///     Round-trip via the persistence layer (mirrors how the manager saves/loads).
+    ///     Granted codes survive a save → load cycle.
+    /// </summary>
+    [Fact]
+    public void GrantedTraitCodes_SurvivePersistenceRoundTrip()
+    {
+        var player = MakePlayer("uid-8");
+        _sut.GrantTrait(player.Object, "da_member");
+        _sut.GrantTrait(player.Object, "da_favored");
+        _ppdm.SaveAllPlayerData();
+
+        // Drop in-memory state and reload from the (fake) persistence store.
+        var reloaded = new PlayerProgressionDataManager(_logger.Object, _eventService, _persistenceService,
+            new FakeWorldService(), _religionManager.Object, new GameBalanceConfig(), new FakeTimeService());
+        reloaded.LoadPlayerData("uid-8");
+
+        var data = reloaded.GetOrCreatePlayerData("uid-8");
+        Assert.Contains("da_member", data.GrantedTraitCodes);
+        Assert.Contains("da_favored", data.GrantedTraitCodes);
+    }
+}

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -66,6 +66,7 @@ public class DivineAscensionModSystem : ModSystem
     private HashSet<string> _migratedReligionUIDs = new();
     private PlayerDataNetworkHandler? _playerDataNetworkHandler;
     private PlayerProgressionDataManager? _playerReligionDataManager;
+    private PlayerTraitService? _playerTraitService;
     private ReligionManager? _religionManager;
     private ReligionNetworkHandler? _religionNetworkHandler;
     private ICoreServerAPI? _sapi;
@@ -253,6 +254,7 @@ public class DivineAscensionModSystem : ModSystem
         _cooldownManager = result.CooldownManager;
         _religionManager = result.ReligionManager;
         _playerReligionDataManager = result.PlayerProgressionDataManager;
+        _playerTraitService = result.PlayerTraitService;
         _favorSystem = result.FavorSystem;
         _holySiteManager = result.HolySiteManager;
         _civilizationManager = result.CivilizationManager;
@@ -349,6 +351,7 @@ public class DivineAscensionModSystem : ModSystem
         _caravanTradeSessionManager?.Dispose();
         _altarPrayerHandler?.Dispose();
         _lecternInteractionHandler?.Dispose();
+        _playerTraitService?.Dispose();
         _playerReligionDataManager?.Dispose();
         _religionManager?.Dispose();
         _civilizationManager?.Dispose();

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -381,6 +381,16 @@ public static class DivineAscensionSystemInitializer
                 religionManager);
         blessingEffectSystem.Initialize();
 
+        // CRITICAL: Must be called AFTER BlessingEffectSystem is initialized (#559).
+        // Consumers (religion/blessing/favor) will back-wire in later slices (#560-#562).
+        var playerTraitService = new PlayerTraitService(
+            LoggingService.Instance.CreateLogger("PlayerTraitService"),
+            eventService,
+            worldService,
+            playerReligionDataManager,
+            api);
+        playerTraitService.Initialize();
+
         // CRITICAL: Must be called AFTER BlessingEffectSystem is initialized
         religionPrestigeManager.SetBlessingSystems(blessingRegistry, blessingEffectSystem);
 
@@ -574,6 +584,7 @@ public static class DivineAscensionSystemInitializer
             DiplomacyManager = diplomacyManager,
             BlessingRegistry = blessingRegistry,
             BlessingEffectSystem = blessingEffectSystem,
+            PlayerTraitService = playerTraitService,
             RoleManager = roleManager,
             AltarEventEmitter = altarEventEmitter,
             LecternEventEmitter = lecternEventEmitter,
@@ -627,6 +638,7 @@ public class InitializationResult
     public DiplomacyManager DiplomacyManager { get; init; } = null!;
     public BlessingRegistry BlessingRegistry { get; init; } = null!;
     public BlessingEffectSystem BlessingEffectSystem { get; init; } = null!;
+    public PlayerTraitService PlayerTraitService { get; init; } = null!;
     public RoleManager RoleManager { get; init; } = null!;
     public AltarEventEmitter AltarEventEmitter { get; init; } = null!;
     public LecternEventEmitter LecternEventEmitter { get; init; } = null!;

--- a/DivineAscension/Systems/PlayerProgressionData.cs
+++ b/DivineAscension/Systems/PlayerProgressionData.cs
@@ -90,7 +90,7 @@ public class PlayerProgressionData
     ///     Data version (internal bookkeeping only — Pantheon 2.0 no longer carries cross-version save migrations).
     /// </summary>
     [ProtoMember(104)]
-    public int DataVersion { get; set; } = 8;
+    public int DataVersion { get; set; } = 9;
 
     /// <summary>
     ///     Soft cap on tracked discovered chunks per player. Past this, <see cref="TryAddDiscoveredChunk"/>
@@ -641,6 +641,72 @@ public class PlayerProgressionData
             var domainKey = (int)domain;
             _committedBranchesSerializable.Remove(domainKey);
             _lockedBranchesSerializable.Remove(domainKey);
+        }
+    }
+
+    #endregion
+
+    #region Granted Trait Codes (#559)
+
+    /// <summary>
+    ///     VS character-trait codes granted to this player by Divine Ascension
+    ///     (religion membership, blessings, favor tiers — wired in by later slices).
+    ///     Mirrors what is written into <c>EntityPlayer.WatchedAttributes["extraTraits"]</c>;
+    ///     re-applied on player join so stats survive restart.
+    /// </summary>
+    [ProtoMember(121)] private HashSet<string> _grantedTraitCodes = new();
+
+    /// <summary>
+    ///     Snapshot of granted trait codes for thread-safe enumeration.
+    /// </summary>
+    [ProtoIgnore]
+    public IReadOnlyCollection<string> GrantedTraitCodes
+    {
+        get
+        {
+            lock (Lock)
+            {
+                return _grantedTraitCodes.ToList();
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Adds a granted trait code. Returns true if it was newly added. Thread-safe.
+    /// </summary>
+    public bool AddGrantedTraitCode(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+            return false;
+        lock (Lock)
+        {
+            return _grantedTraitCodes.Add(code);
+        }
+    }
+
+    /// <summary>
+    ///     Removes a granted trait code. Returns true if it was present. Thread-safe.
+    /// </summary>
+    public bool RemoveGrantedTraitCode(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+            return false;
+        lock (Lock)
+        {
+            return _grantedTraitCodes.Remove(code);
+        }
+    }
+
+    /// <summary>
+    ///     Whether the given trait code has been granted by Divine Ascension. Thread-safe.
+    /// </summary>
+    public bool HasGrantedTraitCode(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+            return false;
+        lock (Lock)
+        {
+            return _grantedTraitCodes.Contains(code);
         }
     }
 

--- a/DivineAscension/Systems/PlayerTraitService.cs
+++ b/DivineAscension/Systems/PlayerTraitService.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Services;
+using DivineAscension.Systems.Interfaces;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+using Vintagestory.GameContent;
+
+namespace DivineAscension.Systems;
+
+/// <summary>
+///     Server-authoritative grant/revoke of Vintage Story character-trait codes (#559).
+///     Wraps <c>EntityPlayer.WatchedAttributes["extraTraits"]</c> + <see cref="CharacterSystem"/>
+///     re-apply so DA can express stat payloads as vanilla traits instead of hand-rolled
+///     <c>entity.Stats.Set</c> calls.
+/// </summary>
+public class PlayerTraitService : IDisposable
+{
+    private const string ExtraTraitsAttr = "extraTraits";
+    private const string CharacterClassAttr = "characterClass";
+
+    private readonly IEventService _eventService;
+    private readonly ILoggerWrapper _logger;
+    private readonly IPlayerProgressionDataManager _playerProgressionDataManager;
+    private readonly ICoreServerAPI? _sapi;
+    private readonly IWorldService _worldService;
+
+    private CharacterSystem? _characterSystem;
+    private bool _characterSystemResolveAttempted;
+
+    public PlayerTraitService(
+        ILoggerWrapper logger,
+        IEventService eventService,
+        IWorldService worldService,
+        IPlayerProgressionDataManager playerProgressionDataManager,
+        ICoreServerAPI? sapi)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+        _playerProgressionDataManager = playerProgressionDataManager
+                                        ?? throw new ArgumentNullException(nameof(playerProgressionDataManager));
+        _sapi = sapi;
+    }
+
+    public void Initialize()
+    {
+        _logger.Notification("[DivineAscension] Initializing PlayerTraitService...");
+        _eventService.OnPlayerJoin(OnPlayerJoin);
+        _eventService.OnSaveGameLoaded(OnSaveGameLoaded);
+        _logger.Notification("[DivineAscension] PlayerTraitService initialized");
+    }
+
+    public void Dispose()
+    {
+        _eventService.UnsubscribePlayerJoin(OnPlayerJoin);
+        _eventService.UnsubscribeSaveGameLoaded(OnSaveGameLoaded);
+    }
+
+    /// <summary>
+    ///     Grants a trait code to the player. Idempotent. Returns true if the code
+    ///     was newly granted (false if already present).
+    /// </summary>
+    public bool GrantTrait(IServerPlayer player, string code)
+    {
+        if (player == null) throw new ArgumentNullException(nameof(player));
+        if (string.IsNullOrWhiteSpace(code)) return false;
+
+        var data = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
+        var added = data.AddGrantedTraitCode(code);
+
+        SyncExtraTraitsAttribute(player, data);
+        ReapplyCharacterClass(player);
+
+        if (added)
+            _logger.Notification($"[DivineAscension] Granted trait '{code}' to {player.PlayerUID}");
+        return added;
+    }
+
+    /// <summary>
+    ///     Revokes a trait code from the player. Returns true if the code was present.
+    /// </summary>
+    public bool RevokeTrait(IServerPlayer player, string code)
+    {
+        if (player == null) throw new ArgumentNullException(nameof(player));
+        if (string.IsNullOrWhiteSpace(code)) return false;
+
+        var data = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
+        var removed = data.RemoveGrantedTraitCode(code);
+
+        SyncExtraTraitsAttribute(player, data);
+        ReapplyCharacterClass(player);
+
+        if (removed)
+            _logger.Notification($"[DivineAscension] Revoked trait '{code}' from {player.PlayerUID}");
+        return removed;
+    }
+
+    /// <summary>
+    ///     Whether the given trait code has been granted to the player by Divine Ascension.
+    /// </summary>
+    public bool HasGrantedTrait(string playerUID, string code)
+    {
+        if (string.IsNullOrWhiteSpace(playerUID) || string.IsNullOrWhiteSpace(code))
+            return false;
+        var data = _playerProgressionDataManager.GetOrCreatePlayerData(playerUID);
+        return data.HasGrantedTraitCode(code);
+    }
+
+    /// <summary>
+    ///     Re-applies the granted trait codes for an already-online player. Used by the
+    ///     SaveGameLoaded hook so reload-while-online doesn't drop stats.
+    /// </summary>
+    public void ReapplyForPlayer(IServerPlayer player)
+    {
+        if (player == null) throw new ArgumentNullException(nameof(player));
+        var data = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
+        SyncExtraTraitsAttribute(player, data);
+        ReapplyCharacterClass(player);
+    }
+
+    private void OnPlayerJoin(IServerPlayer player)
+    {
+        // Defer one tick so vanilla CharacterSystem.Event_PlayerJoinServer (which
+        // sets the default class and applies vanilla trait stats) has already run.
+        if (_sapi != null)
+            _sapi.Event.EnqueueMainThreadTask(() => ReapplyForPlayer(player), "da-trait-reapply");
+        else
+            ReapplyForPlayer(player);
+    }
+
+    private void OnSaveGameLoaded()
+    {
+        foreach (var p in _worldService.GetAllOnlinePlayers())
+            ReapplyForPlayer(p);
+    }
+
+    private void SyncExtraTraitsAttribute(IServerPlayer player, PlayerProgressionData data)
+    {
+        var entity = player.Entity;
+        if (entity == null) return;
+
+        var attr = entity.WatchedAttributes;
+        var existing = attr.GetStringArray(ExtraTraitsAttr) ?? Array.Empty<string>();
+
+        // DA owns the "da_" prefix. Strip every existing DA code (we may be revoking one)
+        // and re-issue exactly the current granted set. Foreign codes are left untouched.
+        var desired = existing
+            .Where(c => !string.IsNullOrEmpty(c) && !c.StartsWith("da_", StringComparison.Ordinal))
+            .Concat(data.GrantedTraitCodes)
+            .Distinct()
+            .ToArray();
+
+        attr.SetStringArray(ExtraTraitsAttr, desired);
+    }
+
+    private void ReapplyCharacterClass(IServerPlayer player)
+    {
+        var charSys = ResolveCharacterSystem();
+        if (charSys == null) return;
+
+        var entity = player.Entity;
+        if (entity == null) return;
+
+        var classCode = entity.WatchedAttributes.GetString(CharacterClassAttr);
+        if (string.IsNullOrEmpty(classCode)) return;
+
+        try
+        {
+            charSys.setCharacterClass(entity, classCode, initializeGear: false);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[DivineAscension] Failed to re-apply character class for {player.PlayerUID}: {ex.Message}");
+        }
+    }
+
+    private CharacterSystem? ResolveCharacterSystem()
+    {
+        if (_characterSystem != null) return _characterSystem;
+        if (_characterSystemResolveAttempted) return null;
+        if (_sapi == null) return null;
+
+        _characterSystemResolveAttempted = true;
+        _characterSystem = _sapi.ModLoader.GetModSystem<CharacterSystem>();
+        if (_characterSystem == null)
+            _logger.Warning("[DivineAscension] CharacterSystem not loaded; trait stats won't apply");
+        return _characterSystem;
+    }
+}

--- a/DivineAscension/assets/divineascension/config/traits.json
+++ b/DivineAscension/assets/divineascension/config/traits.json
@@ -1,0 +1,17 @@
+[
+  {
+    "code": "da_member",
+    "type": "Positive",
+    "attributes": {}
+  },
+  {
+    "code": "da_blessed",
+    "type": "Positive",
+    "attributes": {}
+  },
+  {
+    "code": "da_favored",
+    "type": "Positive",
+    "attributes": {}
+  }
+]

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1562,5 +1562,8 @@
   "caravantrade.partner_left": "Your trading partner left the table.",
   "caravantrade.error.too_far": "You are too far from the shrine to trade here.",
   "caravantrade.error.full": "This trade table is already occupied by two traders.",
-  "caravantrade.error.busy": "Finish your current trade before starting another."
+  "caravantrade.error.busy": "Finish your current trade before starting another.",
+  "trait-da_member": "Member of a Holy Order",
+  "trait-da_blessed": "Blessed",
+  "trait-da_favored": "Favored"
 }


### PR DESCRIPTION
Slice 1 of #537. Foundation only — no consumers, zero user-visible change.

## Summary

- New \`PlayerTraitService\` (Grant/Revoke/HasGrantedTrait, idempotent, server-authoritative). Mutates \`EntityPlayer.WatchedAttributes[\"extraTraits\"]\` and lazily resolves \`CharacterSystem\` to call \`setCharacterClass(..., initializeGear:false)\` so vanilla \`applyTraitAttributes\` does the stat math.
- \`assets/divineascension/config/traits.json\` ships three placeholder DA codes (\`da_member\`, \`da_blessed\`, \`da_favored\`) plus \`en.json\` lang entries. Vanilla VS auto-discovers via \`api.Assets.GetMany<JToken>(api.Logger, \"config/traits\", null)\` — no patch to vanilla traits.json needed (confirmed by decompiling \`VSSurvivalMod.LoadTraits\`).
- \`PlayerProgressionData\` gains a thread-safe \`GrantedTraitCodes\` HashSet (\`ProtoMember(121)\`). \`DataVersion\` 8 → 9; older saves deserialize with an empty set.
- \`OnPlayerJoin\` re-applies via \`EnqueueMainThreadTask\` so it lands after vanilla \`CharacterSystem.Event_PlayerJoinServer\` (ServerRunPhase 5). \`OnSaveGameLoaded\` re-applies for already-online players.
- Wired into \`DivineAscensionSystemInitializer\` after \`BlessingEffectSystem\`, exposed on \`InitializationResult\`, disposed before the player-progression data manager.

## Deviations from issue

- Issue said \`DataVersion\` 4 → 5; actual was 8 (issue predated bumps). Now 8 → 9.
- DA owns the \`da_\` prefix on \`extraTraits\`. Sync replaces every existing \`da_*\` code with the current granted set and leaves foreign codes untouched.

## Test plan

- [x] \`dotnet test\` — 2479 passing (10 new in \`PlayerTraitServiceTests\`).
- [x] \`dotnet build DivineAscension.sln -c Debug\` clean (only pre-existing warnings).
- [ ] In-game smoke (manual): grant a trait via a temp dev path, verify it appears in \`/charsel\` traits tab, persists across rejoin and save/reload, foreign \`extraTraits\` entries (e.g. XSkills) left intact.
- [ ] Verify v8 save loads without crash, \`GrantedTraitCodes\` defaults empty.

Foundation only — consumer hooks land in #560 / #561 / #562. Follow-ups #563–#566 finish the course-correction.

Closes #559
Refs #537