### PR TITLE
feat(religion): grant da_member VS trait on membership (#560)

### DIFF
--- a/DivineAscension.Tests/Systems/ReligionMembershipTraitTests.cs
+++ b/DivineAscension.Tests/Systems/ReligionMembershipTraitTests.cs
@@ -1,0 +1,167 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Tests.Systems;
+
+/// <summary>
+///     Integration tests for the religion-membership ↔ <see cref="PlayerTraitService"/>
+///     wiring introduced in #560. Exercises the real <see cref="ReligionManager"/> and
+///     <see cref="PlayerTraitService"/> end-to-end through fakes; verifies that
+///     <c>PlayerProgressionData.GrantedTraitCodes</c> tracks <c>da_member</c> across
+///     join, leave, disband, and cascade-revoke on religion deletion.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ReligionMembershipTraitTests
+{
+    private readonly FakeEventService _eventService;
+    private readonly FakeWorldService _worldService;
+    private readonly PlayerProgressionDataManager _ppdm;
+    private readonly PlayerTraitService _traits;
+    private readonly ReligionManager _religionManager;
+
+    public ReligionMembershipTraitTests()
+    {
+        var logger = new Mock<ILogger>();
+        var loggerWrapper = new Mock<ILoggerWrapper>();
+        _eventService = new FakeEventService();
+        var persistence = new FakePersistenceService();
+        _worldService = new FakeWorldService();
+
+        _religionManager = new ReligionManager(logger.Object, _eventService, persistence, _worldService);
+
+        var religionManagerInterface = new Mock<IReligionManager>();
+        _ppdm = new PlayerProgressionDataManager(loggerWrapper.Object, _eventService, persistence,
+            _worldService, religionManagerInterface.Object, new GameBalanceConfig(), new FakeTimeService());
+
+        _traits = new PlayerTraitService(loggerWrapper.Object, _eventService, _worldService, _ppdm, sapi: null);
+        _religionManager.SetPlayerTraitService(_traits);
+    }
+
+    private static Mock<IServerPlayer> MakePlayer(string uid, string name = "TestPlayer")
+    {
+        var mock = new Mock<IServerPlayer>();
+        mock.Setup(p => p.PlayerUID).Returns(uid);
+        mock.Setup(p => p.PlayerName).Returns(name);
+        return mock;
+    }
+
+    [Fact]
+    public void SetPlayerTraitService_Null_Throws()
+    {
+        var fresh = new ReligionManager(new Mock<ILogger>().Object, new FakeEventService(),
+            new FakePersistenceService(), new FakeWorldService());
+        Assert.Throws<System.ArgumentNullException>(() => fresh.SetPlayerTraitService(null!));
+    }
+
+    [Fact]
+    public void CreateReligion_GrantsMembershipTraitToFounder()
+    {
+        var founder = MakePlayer("founder-uid");
+        _worldService.AddPlayer(founder.Object);
+
+        _religionManager.CreateReligion("Test", DeityDomain.Craft, "Deity", "founder-uid", true);
+
+        Assert.Contains(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("founder-uid").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void AddMember_GrantsMembershipTrait()
+    {
+        var p = MakePlayer("joiner-uid");
+        _worldService.AddPlayer(p.Object);
+        var religion = _religionManager.CreateReligion("Test", DeityDomain.Craft, "Deity", "founder", true);
+
+        _religionManager.AddMember(religion.ReligionUID, "joiner-uid");
+
+        Assert.Contains(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("joiner-uid").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void AddMember_Idempotent_DoesNotDuplicateTrait()
+    {
+        var p = MakePlayer("p-uid");
+        _worldService.AddPlayer(p.Object);
+        var religion = _religionManager.CreateReligion("Test", DeityDomain.Craft, "Deity", "founder", true);
+
+        _religionManager.AddMember(religion.ReligionUID, "p-uid");
+        _religionManager.AddMember(religion.ReligionUID, "p-uid");
+
+        var codes = _ppdm.GetOrCreatePlayerData("p-uid").GrantedTraitCodes;
+        Assert.Single(codes, TraitCodes.Member);
+    }
+
+    [Fact]
+    public void RemoveMember_RevokesMembershipTrait()
+    {
+        var p = MakePlayer("p-uid");
+        _worldService.AddPlayer(p.Object);
+        var religion = _religionManager.CreateReligion("Test", DeityDomain.Craft, "Deity", "founder", true);
+        _religionManager.AddMember(religion.ReligionUID, "p-uid");
+
+        _religionManager.RemoveMember(religion.ReligionUID, "p-uid");
+
+        Assert.DoesNotContain(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("p-uid").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void DeleteReligion_CascadeRevokesTraitFromEveryMember()
+    {
+        var founder = MakePlayer("founder-uid", "Founder");
+        var m1 = MakePlayer("m1-uid", "Member1");
+        var m2 = MakePlayer("m2-uid", "Member2");
+        _worldService.AddPlayer(founder.Object);
+        _worldService.AddPlayer(m1.Object);
+        _worldService.AddPlayer(m2.Object);
+
+        var religion = _religionManager.CreateReligion("Test", DeityDomain.Craft, "Deity", "founder-uid", true);
+        _religionManager.AddMember(religion.ReligionUID, "founder-uid");
+        _religionManager.AddMember(religion.ReligionUID, "m1-uid");
+        _religionManager.AddMember(religion.ReligionUID, "m2-uid");
+
+        Assert.Contains(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("founder-uid").GrantedTraitCodes);
+        Assert.Contains(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("m1-uid").GrantedTraitCodes);
+        Assert.Contains(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("m2-uid").GrantedTraitCodes);
+
+        var deleted = _religionManager.DeleteReligion(religion.ReligionUID, "founder-uid");
+
+        Assert.True(deleted);
+        Assert.DoesNotContain(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("founder-uid").GrantedTraitCodes);
+        Assert.DoesNotContain(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("m1-uid").GrantedTraitCodes);
+        Assert.DoesNotContain(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("m2-uid").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void RemoveMember_OfflinePlayer_StillRevokesTrait()
+    {
+        // Player never added to FakeWorldService → GetPlayerByUID returns null → offline path.
+        var religion = _religionManager.CreateReligion("Test", DeityDomain.Craft, "Deity", "founder", true);
+        _religionManager.AddMember(religion.ReligionUID, "offline-uid");
+        Assert.Contains(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("offline-uid").GrantedTraitCodes);
+
+        _religionManager.RemoveMember(religion.ReligionUID, "offline-uid");
+
+        Assert.DoesNotContain(TraitCodes.Member, _ppdm.GetOrCreatePlayerData("offline-uid").GrantedTraitCodes);
+    }
+
+    [Fact]
+    public void ReligionManager_WithoutTraitServiceWired_DoesNotCrashOnAddMember()
+    {
+        var bare = new ReligionManager(new Mock<ILogger>().Object, new FakeEventService(),
+            new FakePersistenceService(), _worldService);
+        var p = MakePlayer("solo-uid");
+        _worldService.AddPlayer(p.Object);
+        var religion = bare.CreateReligion("Test", DeityDomain.Craft, "Deity", "founder", true);
+
+        var ex = Record.Exception(() => bare.AddMember(religion.ReligionUID, "solo-uid"));
+
+        Assert.Null(ex);
+    }
+}

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -391,6 +391,9 @@ public static class DivineAscensionSystemInitializer
             api);
         playerTraitService.Initialize();
 
+        // Back-wire: religion membership grants/revokes the da_member trait (#560).
+        religionManager.SetPlayerTraitService(playerTraitService);
+
         // CRITICAL: Must be called AFTER BlessingEffectSystem is initialized
         religionPrestigeManager.SetBlessingSystems(blessingRegistry, blessingEffectSystem);
 

--- a/DivineAscension/Systems/PlayerTraitService.cs
+++ b/DivineAscension/Systems/PlayerTraitService.cs
@@ -65,17 +65,19 @@ public class PlayerTraitService : IDisposable
     public bool GrantTrait(IServerPlayer player, string code)
     {
         if (player == null) throw new ArgumentNullException(nameof(player));
-        if (string.IsNullOrWhiteSpace(code)) return false;
+        return GrantTraitInternal(player.PlayerUID, player, code);
+    }
 
-        var data = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
-        var added = data.AddGrantedTraitCode(code);
-
-        SyncExtraTraitsAttribute(player, data);
-        ReapplyCharacterClass(player);
-
-        if (added)
-            _logger.Notification($"[DivineAscension] Granted trait '{code}' to {player.PlayerUID}");
-        return added;
+    /// <summary>
+    ///     Grants a trait code by player UID. Used for offline-safe paths (cascade
+    ///     revoke on religion disband etc.). When the player is online, stats are
+    ///     re-applied live; when offline, the next <c>PlayerJoin</c> picks it up.
+    /// </summary>
+    public bool GrantTrait(string playerUID, string code)
+    {
+        if (string.IsNullOrWhiteSpace(playerUID)) return false;
+        var player = _worldService.GetPlayerByUID(playerUID);
+        return GrantTraitInternal(playerUID, player, code);
     }
 
     /// <summary>
@@ -84,16 +86,52 @@ public class PlayerTraitService : IDisposable
     public bool RevokeTrait(IServerPlayer player, string code)
     {
         if (player == null) throw new ArgumentNullException(nameof(player));
+        return RevokeTraitInternal(player.PlayerUID, player, code);
+    }
+
+    /// <summary>
+    ///     Revokes a trait code by player UID. Offline-safe; see <see cref="GrantTrait(string, string)"/>.
+    /// </summary>
+    public bool RevokeTrait(string playerUID, string code)
+    {
+        if (string.IsNullOrWhiteSpace(playerUID)) return false;
+        var player = _worldService.GetPlayerByUID(playerUID);
+        return RevokeTraitInternal(playerUID, player, code);
+    }
+
+    private bool GrantTraitInternal(string playerUID, IServerPlayer? player, string code)
+    {
         if (string.IsNullOrWhiteSpace(code)) return false;
 
-        var data = _playerProgressionDataManager.GetOrCreatePlayerData(player.PlayerUID);
+        var data = _playerProgressionDataManager.GetOrCreatePlayerData(playerUID);
+        var added = data.AddGrantedTraitCode(code);
+
+        if (player != null)
+        {
+            SyncExtraTraitsAttribute(player, data);
+            ReapplyCharacterClass(player);
+        }
+
+        if (added)
+            _logger.Notification($"[DivineAscension] Granted trait '{code}' to {playerUID}");
+        return added;
+    }
+
+    private bool RevokeTraitInternal(string playerUID, IServerPlayer? player, string code)
+    {
+        if (string.IsNullOrWhiteSpace(code)) return false;
+
+        var data = _playerProgressionDataManager.GetOrCreatePlayerData(playerUID);
         var removed = data.RemoveGrantedTraitCode(code);
 
-        SyncExtraTraitsAttribute(player, data);
-        ReapplyCharacterClass(player);
+        if (player != null)
+        {
+            SyncExtraTraitsAttribute(player, data);
+            ReapplyCharacterClass(player);
+        }
 
         if (removed)
-            _logger.Notification($"[DivineAscension] Revoked trait '{code}' from {player.PlayerUID}");
+            _logger.Notification($"[DivineAscension] Revoked trait '{code}' from {playerUID}");
         return removed;
     }
 

--- a/DivineAscension/Systems/ReligionManager.cs
+++ b/DivineAscension/Systems/ReligionManager.cs
@@ -29,6 +29,7 @@ public class ReligionManager : IReligionManager
     private readonly IWorldService _worldService;
     private readonly ReligionChronicler _chronicler;
     private ReligionWorldData _inviteData = new();
+    private PlayerTraitService? _playerTraitService;
 
     public ReligionManager(
         ILogger logger,
@@ -45,6 +46,16 @@ public class ReligionManager : IReligionManager
 
 
     internal IReadOnlyDictionary<string, string> PlayerToReligionIndex => _playerToReligionIndex;
+
+    /// <summary>
+    ///     Late binds the <see cref="PlayerTraitService"/> so membership grants/revokes
+    ///     the <c>da_member</c> VS character trait (#560). Called by the system initializer
+    ///     after the trait service is constructed.
+    /// </summary>
+    public void SetPlayerTraitService(PlayerTraitService playerTraitService)
+    {
+        _playerTraitService = playerTraitService ?? throw new ArgumentNullException(nameof(playerTraitService));
+    }
 
     /// <summary>
     ///     Event fired when a religion is deleted (either manually or automatically)
@@ -122,6 +133,10 @@ public class ReligionManager : IReligionManager
         // Store in dictionary (thread-safe)
         _religions[religionUID] = religion;
         _playerToReligionIndex.TryAdd(founderUID, religionUID);
+
+        // Grant the membership VS trait to the founder (#560). CreateReligion
+        // bypasses AddMember, so it must grant the trait directly.
+        _playerTraitService?.GrantTrait(founderUID, TraitCodes.Member);
 
         // Chronicle: the founding is the first permanent entry (#373).
         _chronicler.RecordFounded(religion);
@@ -223,6 +238,10 @@ public class ReligionManager : IReligionManager
         // Save immediately to prevent data loss
         Save(religion);
 
+        // Grant the membership VS trait (#560). Offline-safe — the UID overload
+        // mutates persisted player data even if the player isn't online.
+        _playerTraitService?.GrantTrait(playerUID, TraitCodes.Member);
+
         // Fire member added event
         OnMemberAdded?.Invoke(religionUID, playerUID);
     }
@@ -244,6 +263,9 @@ public class ReligionManager : IReligionManager
         {
             _playerToReligionIndex.TryRemove(playerUID, out _);
             _logger.Debug($"[DivineAscension] Removed player {playerUID} from religion {religion.ReligionName}");
+
+            // Revoke the membership VS trait (#560).
+            _playerTraitService?.RevokeTrait(playerUID, TraitCodes.Member);
 
             // Fire member removed event before potential religion deletion
             OnMemberRemoved?.Invoke(religionUID, playerUID);
@@ -697,7 +719,9 @@ public class ReligionManager : IReligionManager
         _logger.Notification(
             $"[DivineAscension] Deleting religion {religion.ReligionName} with {memberCount} member(s)...");
 
-        // Remove all members from the index before deleting religion (thread-safe)
+        // Remove all members from the index before deleting religion (thread-safe).
+        // Snapshot member list first so we can also cascade-revoke their membership
+        // trait (#560) — religion.MemberUIDs is cleared as part of deletion below.
         var removedCount = 0;
         foreach (var memberUID in religion.MemberUIDs.ToList())
         {
@@ -706,6 +730,8 @@ public class ReligionManager : IReligionManager
                 removedCount++;
                 _logger.Debug($"[DivineAscension] Removed player {memberUID} from index during religion deletion");
             }
+
+            _playerTraitService?.RevokeTrait(memberUID, TraitCodes.Member);
         }
 
         _logger.Notification(

--- a/DivineAscension/Systems/TraitCodes.cs
+++ b/DivineAscension/Systems/TraitCodes.cs
@@ -1,0 +1,17 @@
+namespace DivineAscension.Systems;
+
+/// <summary>
+///     Canonical Vintage Story character-trait codes granted by Divine Ascension.
+///     Mirrors entries declared in <c>assets/divineascension/config/traits.json</c>.
+/// </summary>
+public static class TraitCodes
+{
+    /// <summary>Granted to every player while they are a member of a religion (#560).</summary>
+    public const string Member = "da_member";
+
+    /// <summary>Reserved for blessing-tier integration (#561). Not yet wired.</summary>
+    public const string Blessed = "da_blessed";
+
+    /// <summary>Reserved for favor-tier integration (#562). Not yet wired.</summary>
+    public const string Favored = "da_favored";
+}


### PR DESCRIPTION
Slice 2 of #537. Depends on #559 (merged). First consumer of `PlayerTraitService`.

## Summary

- `ReligionManager.SetPlayerTraitService` back-wire (mirrors `PvPManager.SetCivilizationBonusSystem` late-binding pattern at `DivineAscensionSystemInitializer.cs:362`).
- `CreateReligion` grants `da_member` to the founder — founder setup bypasses `AddMember`, so the grant has to live there too.
- `AddMember` grants, `RemoveMember` revokes, `DeleteReligion` cascade-revokes from every member before clearing the religion.
- `PlayerTraitService` gains UID-based `Grant/Revoke` overloads. Cascade revoke happens server-side regardless of who's online; live entity sync only runs when the player is online, and offline players pick up the change on their next `PlayerJoin` via the existing `extraTraits` re-apply path.
- New `TraitCodes` constants (`Member` / `Blessed` / `Favored`) centralise the codes declared in `assets/divineascension/config/traits.json` from #559. `Blessed` / `Favored` reserved for #561 / #562.

## Test plan

- [x] `dotnet test` — 2496 passing (8 new in `ReligionMembershipTraitTests`):
  - Founder gets `da_member` on `CreateReligion`
  - Joiner gets `da_member` on `AddMember` (idempotent, no duplicate on double-join attempt)
  - `RemoveMember` revokes, even for offline players
  - `DeleteReligion` cascade-revokes from founder + every member
  - `SetPlayerTraitService(null)` throws
  - `ReligionManager` without `SetPlayerTraitService` wired still works (defensive null check)
- [ ] In-game smoke (manual): create religion, verify `da_member` in `/charsel` traits tab. Have a second player join + leave. Disband and confirm trait gone for everyone.

Closes #560
Refs #537