### PR TITLE
feat(release): bump mod to 5.0.0

### DIFF
--- a/DivineAscension/Properties/AssemblyInfo.cs
+++ b/DivineAscension/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using Vintagestory.API.Common;
 [assembly: ModInfo("Divine Ascension", "divineascension",
     Description =
         "A religious-themed PvP mod featuring competing deities with unique abilities and favor-based progression system.",
-    Version = "4.25.0",
+    Version = "5.0.0",
     Authors = new[] { "Valinnar" },
     Side = "Universal")]
 

--- a/DivineAscension/modinfo.json
+++ b/DivineAscension/modinfo.json
@@ -2,7 +2,7 @@
   "type": "code",
   "name": "Divine Ascension",
   "modid": "divineascension",
-  "version": "4.25.0",
+  "version": "5.0.0",
   "authors": [
     "Valinnar"
   ],


### PR DESCRIPTION
## Summary

Bumps \`modinfo.json\` and \`AssemblyInfo.cs\` from \`4.25.0\` to \`5.0.0\`.

The 4.x line accumulated breaking changes (Pantheon 2.0 save-data rewrite with \`PlayerProgressionData\` DataVersion progression 4 → 8, Caravan-domain gating, the \`DeityDomains\` single-source-of-truth refactor, Sacred Calendar and Chronicler additions, role/permission model changes, the religion-uid-vs-player-uid founder fix, etc.) without any individual \`feat!\` / \`refactor!\` markers to trigger the major rev. This commit explicitly closes the 4.x line and starts 5.x.

## Notes

- Commit uses \`feat(release):\` + \`BREAKING CHANGE:\` footer instead of the \`feat!:\` shorthand — the repo's commitlint version rejects the bang form (parses as empty subject). The footer-based form is semantically equivalent for semantic-release-style tooling.

## Test plan

- [x] \`dotnet build\` clean
- [x] \`dotnet test\` — 2478 passing (verified on the revert base)