### PR TITLE
revert: manual v5.0.0 bump — let release workflow drive

### DIFF
--- a/DivineAscension/Properties/AssemblyInfo.cs
+++ b/DivineAscension/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using Vintagestory.API.Common;
 [assembly: ModInfo("Divine Ascension", "divineascension",
     Description =
         "A religious-themed PvP mod featuring competing deities with unique abilities and favor-based progression system.",
-    Version = "5.0.0",
+    Version = "4.25.0",
     Authors = new[] { "Valinnar" },
     Side = "Universal")]
 

--- a/DivineAscension/modinfo.json
+++ b/DivineAscension/modinfo.json
@@ -2,7 +2,7 @@
   "type": "code",
   "name": "Divine Ascension",
   "modid": "divineascension",
-  "version": "5.0.0",
+  "version": "4.25.0",
   "authors": [
     "Valinnar"
   ],


### PR DESCRIPTION
Reverts #571.

## Why

The manual \`feat(release): bump mod to 5.0.0\` commit landed via #571 alongside a \`BREAKING CHANGE:\` footer. The release workflow read that footer + the still-current modinfo (5.0.0) and opened #572 to bump to 6.0.0 — exactly one major too far. #572 was closed, but the workflow will keep generating that same 6.0.0 PR until either (a) a v5 tag exists or (b) the BREAKING commit moves out of the unbumped range.

Reverting the manual bump puts modinfo back to 4.25.0. The original commit (and its BREAKING footer) stays in history, so the workflow will scan since \`v4.25.0\`, detect BREAKING, and open a clean \`release/v5.0.0\` PR — which, when merged, runs the proper release pipeline (tag, build, package, GitHub release).

## Test plan

- [x] \`git revert\` clean, no conflicts
- [ ] On merge: workflow opens \`release/v5.0.0\` PR (auto)
- [ ] On that PR merging: tag \`v5.0.0\` + GitHub release published (auto)