### PR TITLE
fix(cooking): stop cookingYield from duplicating firepit cookware and smelt outputs

### DIFF
--- a/DivineAscension.Tests/Systems/Patches/CookingPatchesTests.cs
+++ b/DivineAscension.Tests/Systems/Patches/CookingPatchesTests.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Systems.Patches;
+using Vintagestory.API.Common;
+using Xunit;
+
+namespace DivineAscension.Tests.Systems.Patches;
+
+/// <summary>
+///     Regression coverage for the firepit duplication exploit: the cookingYield
+///     bonus must only ever scale genuine food outputs, and must never mint extra
+///     items when there is no bonus.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class CookingPatchesTests
+{
+    private static ItemStack CreateStack(string code, int stackSize, bool isFood)
+    {
+        var item = new Item
+        {
+            Code = new AssetLocation("game", code)
+        };
+        if (isFood) item.NutritionProps = new FoodNutritionProperties();
+
+        return new ItemStack(item) { StackSize = stackSize };
+    }
+
+    [Fact]
+    public void IsScalableFoodOutput_WithCookwareContainer_ReturnsFalse()
+    {
+        // A single cooking pot / cauldron / crucible carries no NutritionProps and
+        // must never be eligible for scaling -- this is the dupe at its root.
+        var pot = CreateStack("claypot-cooked", 1, isFood: false);
+
+        Assert.False(CookingPatches.IsScalableFoodOutput(pot));
+    }
+
+    [Fact]
+    public void IsScalableFoodOutput_WithFoodStack_ReturnsTrue()
+    {
+        var cookedMeat = CreateStack("bushmeat-cooked", 1, isFood: true);
+
+        Assert.True(CookingPatches.IsScalableFoodOutput(cookedMeat));
+    }
+
+    [Fact]
+    public void IsScalableFoodOutput_WithNullOrEmpty_ReturnsFalse()
+    {
+        Assert.False(CookingPatches.IsScalableFoodOutput(null));
+        Assert.False(CookingPatches.IsScalableFoodOutput(CreateStack("bushmeat-cooked", 0, isFood: true)));
+    }
+
+    [Theory]
+    [InlineData(1, 1.0f, 1)] // no bonus, single item stays single (never minted)
+    [InlineData(1, 0.5f, 1)] // sub-1.0 multiplier never shrinks the stack
+    [InlineData(4, 1.0f, 4)] // no bonus, stack unchanged
+    public void ComputeScaledStackSize_WithoutBonus_DoesNotIncrease(int stackSize, float yield, int expected)
+    {
+        Assert.Equal(expected, CookingPatches.ComputeScaledStackSize(stackSize, yield));
+    }
+
+    [Theory]
+    [InlineData(1, 1.6f, 2)] // maxed Harvest: a single cooked food becomes two -- intended reward
+    [InlineData(2, 1.6f, 3)]
+    [InlineData(10, 1.25f, 13)] // Baker's Touch only
+    public void ComputeScaledStackSize_WithBonus_ScalesFood(int stackSize, float yield, int expected)
+    {
+        Assert.Equal(expected, CookingPatches.ComputeScaledStackSize(stackSize, yield));
+    }
+}

--- a/DivineAscension/Systems/Patches/CookingPatches.cs
+++ b/DivineAscension/Systems/Patches/CookingPatches.cs
@@ -46,13 +46,40 @@ public static class CookingPatches
         }
     }
 
-    // Scale a cooked output stack by the player's cookingYield blessing stat.
+    // Scale a cooked food output stack by the player's cookingYield blessing stat.
     // Multiplier is a WeightedSum stat with base 1.0, so >1.0 means a bonus.
+    //
+    // The bonus must ONLY ever touch genuine food outputs. Earlier this scaled
+    // whatever collectible changed in a firepit slot, which also caught the
+    // cookware containers themselves (cooking pots, cauldrons) and non-food
+    // smelting outputs (crucibles, ore -> metal). Because only StackSize was
+    // bumped, the rounding turned a single item into two -- duplicating the
+    // container (and the meal stored in its attributes) or the smelted metal.
+    // See the firepit duplication exploit report.
     internal static void ApplyCookingYield(IServerPlayer player, ItemStack stack)
     {
+        if (!IsScalableFoodOutput(stack)) return;
+
         var yield = player.Entity?.Stats?.GetBlended(VintageStoryStats.CookingYield) ?? 1f;
-        if (yield <= 1f || stack.StackSize <= 0) return;
-        stack.StackSize = Math.Max(stack.StackSize, (int)Math.Round(stack.StackSize * yield));
+        stack.StackSize = ComputeScaledStackSize(stack.StackSize, yield);
+    }
+
+    // A stack may only be scaled if it is real food (carries nutrition props).
+    // Containers (cooking pots, cauldrons), crucibles and smelting outputs have
+    // no NutritionProps and are therefore never multiplied.
+    internal static bool IsScalableFoodOutput(ItemStack? stack)
+    {
+        return stack is { StackSize: > 0 } && stack.Collectible?.NutritionProps != null;
+    }
+
+    // Never shrink the stack and never let rounding mint extra items when there
+    // is no bonus. With a bonus, round the scaled amount to the nearest whole.
+    internal static int ComputeScaledStackSize(int currentStackSize, float yield)
+    {
+        if (yield <= 1f || currentStackSize <= 0) return currentStackSize;
+
+        var scaled = (int)Math.Round(currentStackSize * yield, MidpointRounding.AwayFromZero);
+        return Math.Max(currentStackSize, scaled);
     }
 
     // Track last interacting player via exact decompiled method


### PR DESCRIPTION
The cookingYield blessing scaled the stack size of whatever collectible
changed in a firepit slot. That also caught cookware containers (cooking
pots, cauldrons) and non-food smelting outputs (crucibles, ore -> metal),
and because only StackSize was bumped, Math.Round turned a single item
into two -- duplicating the container along with the meal stored in its
attributes, or the smelted metal.

Gate ApplyCookingYield on genuine food outputs (Collectible.NutritionProps
!= null) so containers, crucibles and smelt outputs can never be scaled.
Split the food check and the stack-size math into pure helpers and add
regression tests asserting a single non-food item never duplicates and
that the no-bonus case never mints items.

The OnMealCooked favor event still fires unconditionally, so Harvest
favor attribution is unchanged.

Fixes #576

https://claude.ai/code/session_018nrf3BUMUoPfBmEgxNgCmY