### PR TITLE
fix: load on VS 1.22.2 (lower game dependency floor)

### DIFF
--- a/DivineAscension/modinfo.json
+++ b/DivineAscension/modinfo.json
@@ -9,7 +9,7 @@
   "description": "Deity-driven religions and civilizations for Vintage Story. Create and manage religions tied to deities, earn Favor and Religion Prestige, unlock blessing trees with gameplay effects, and coordinate multi-religion civilizations. Includes PvP hooks, persistence/network sync, and in-game UI.",
   "side": "Universal",
   "dependencies": {
-    "game": "1.22.3",
+    "game": "1.22.2",
     "vsimgui": "0.0.6"
   }
 }


### PR DESCRIPTION
## Problem

Users on Vintage Story **1.22.2** can't load the mod — it errors that 1.22.3 is required. With 1.22.3 only just released, most modpacks/servers are still on 1.22.2.

## Cause

`modinfo.json` declares `"game": "1.22.3"`, which VS treats as a **minimum-version gate**. The bump was gratuitous: the cooking duplication fix (#576) lives entirely in the mod's own `CookingPatches.cs` and uses only pre-existing API (`Collectible.NutritionProps`). Nothing in the mod needs 1.22.3.

## Fix

Lower the floor to `"game": "1.22.2"`. The mod now loads on **both** 1.22.2 and 1.22.3 with no code changes. Build compiles cleanly; the dup fix is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)