### PR TITLE
feat(ui): add UiScale.Factor lever + Scaled() helper (#586)

### DIFF
--- a/DivineAscension.Tests/GUI/UI/Utilities/UiScaleTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Utilities/UiScaleTests.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using DivineAscension.GUI.UI.Utilities;
+
+namespace DivineAscension.Tests.GUI.UI.Utilities;
+
+/// <summary>
+///     Unit tests for the <see cref="UiScale" /> global scale lever.
+///     Each test restores <see cref="UiScale.Factor" /> to the 1.0 default so the
+///     shared static state does not bleed across cases.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class UiScaleTests
+{
+    public UiScaleTests() => UiScale.Factor = 1.0f;
+
+    [Fact]
+    public void DefaultFactor_IsOne()
+    {
+        Assert.Equal(1.0f, UiScale.Factor);
+    }
+
+    [Fact]
+    public void Scaled_AtFactorOne_IsNoOp()
+    {
+        Assert.Equal(15f, UiScale.Scaled(15f));
+        Assert.Equal(0f, UiScale.Scaled(0f));
+        Assert.Equal(new Vector2(12f, 20f), UiScale.Scaled(new Vector2(12f, 20f)));
+    }
+
+    [Fact]
+    public void Scaled_Float_MultipliesAndRoundsToNearestPixel()
+    {
+        UiScale.Factor = 1.5f;
+
+        Assert.Equal(23f, UiScale.Scaled(15f)); // 22.5 -> 23
+        Assert.Equal(21f, UiScale.Scaled(14f)); // 21.0
+        Assert.Equal(2f, UiScale.Scaled(1f));   // 1.5 -> 2
+    }
+
+    [Fact]
+    public void Scaled_Vector2_RoundsEachComponentIndependently()
+    {
+        UiScale.Factor = 1.5f;
+
+        Assert.Equal(new Vector2(23f, 21f), UiScale.Scaled(new Vector2(15f, 14f)));
+    }
+
+    [Fact]
+    public void Factor_ClampsToRange()
+    {
+        UiScale.Factor = 99f;
+        Assert.Equal(UiScale.MaxFactor, UiScale.Factor);
+
+        UiScale.Factor = 0.01f;
+        Assert.Equal(UiScale.MinFactor, UiScale.Factor);
+    }
+
+    [Theory]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void Factor_RejectsNonFinite_KeepsPreviousValue(float bad)
+    {
+        UiScale.Factor = 2.0f;
+        UiScale.Factor = bad;
+        Assert.Equal(2.0f, UiScale.Factor);
+    }
+}

--- a/DivineAscension/GUI/UI/Utilities/UiScale.cs
+++ b/DivineAscension/GUI/UI/Utilities/UiScale.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Numerics;
+
+namespace DivineAscension.GUI.UI.Utilities;
+
+/// <summary>
+///     Global UI scale lever. All font sizes and layout offsets in the dialog
+///     are authored at a base (1.0) scale; <see cref="Scaled(float)" /> multiplies
+///     them through <see cref="Factor" /> so the whole UI grows proportionally on
+///     high-resolution / high-DPI screens.
+///
+///     This type is intentionally just the lever — call sites are converted to
+///     route through <see cref="Scaled(float)" /> in follow-up work. The scale
+///     source (VS <c>ClientSettings.GUIScale</c> vs. a dedicated mod slider) is
+///     wired separately; until then <see cref="Factor" /> stays at 1.0, making
+///     every <see cref="Scaled(float)" /> call a no-op.
+///
+///     Scaling the <em>inputs</em> to layout (positions, sizes, font sizes) — not
+///     the rendered output — keeps drawn geometry and manual hit-rects consistent,
+///     so mouse clicks stay aligned. See epic #584 / spike #585 for why a single
+///     post-render viewport transform is not viable.
+/// </summary>
+internal static class UiScale
+{
+    /// <summary>Smallest accepted scale; below this the UI is unusably small.</summary>
+    public const float MinFactor = 0.5f;
+
+    /// <summary>Largest accepted scale; above this the dialog overflows most screens.</summary>
+    public const float MaxFactor = 4.0f;
+
+    private static float _factor = 1.0f;
+
+    /// <summary>
+    ///     Current UI scale multiplier. Defaults to 1.0 (no scaling). Assignments
+    ///     are clamped to [<see cref="MinFactor" />, <see cref="MaxFactor" />];
+    ///     NaN/infinity are rejected and leave the previous value unchanged.
+    /// </summary>
+    public static float Factor
+    {
+        get => _factor;
+        set
+        {
+            if (float.IsNaN(value) || float.IsInfinity(value)) return;
+            _factor = Math.Clamp(value, MinFactor, MaxFactor);
+        }
+    }
+
+    /// <summary>
+    ///     Scale a base (1.0-scale) pixel value by the current <see cref="Factor" />,
+    ///     rounded to the nearest whole pixel to keep text and edges crisp.
+    /// </summary>
+    public static float Scaled(float baseValue) =>
+        MathF.Round(baseValue * _factor, MidpointRounding.AwayFromZero);
+
+    /// <summary>
+    ///     Scale a base (1.0-scale) 2D offset/size by the current <see cref="Factor" />,
+    ///     rounding each component independently.
+    /// </summary>
+    public static Vector2 Scaled(Vector2 baseValue) => new(Scaled(baseValue.X), Scaled(baseValue.Y));
+}


### PR DESCRIPTION
Foundation sub-issue of the global UI-scale epic (#584).

## What

A single global multiplier that font sizes and layout offsets will route through, so the Divine Ascension dialog grows proportionally on high-res / high-DPI screens (fixing "text too small on some screens").

- `UiScale.Factor` — defaults to **1.0** (no-op), clamps to `[0.5, 4.0]`, rejects NaN/infinity (keeps previous value).
- `Scaled(float)` / `Scaled(Vector2)` — multiply by `Factor`, round **away-from-zero** to whole pixels to keep text and edges crisp.

## Why scale inputs, not output

Spike #585 established that a single post-render viewport transform is not viable (clip rects don't scale; manual `GetMousePos`-vs-rect hit-testing would desync clicks). Scaling the *inputs* to layout keeps drawn geometry and hit-rects aligned.

## Scope

Lever only — **no call sites converted**, so at the default `Factor = 1.0` this is a behavioral no-op and safe to merge standalone. Follow-ups:
- #587 — route font sizes through `Scaled()`
- #588 — scaled Cinzel bake sizes
- #589 — scale-aware layout
- #590 — wire the scale source (`ClientSettings.GUIScale` vs slider)

## Tests

`UiScaleTests` — 8 cases (default, no-op at 1.0, float + Vector2 rounding, clamp, non-finite rejection). All pass; full solution builds clean.

Closes #586