### PR TITLE
feat(ui): scale all font sizes through UiScale.Factor (#587)

### DIFF
--- a/DivineAscension/GUI/UI/Components/Inputs/Dropdown.cs
+++ b/DivineAscension/GUI/UI/Components/Inputs/Dropdown.cs
@@ -43,8 +43,9 @@ internal static class Dropdown
         float height,
         string selectedText,
         bool isOpen,
-        float fontSize = FontSizes.Body)
+        float fontSize = -1f)
     {
+        if (fontSize < 0f) fontSize = FontSizes.Body;
         var dropdownStart = new Vector2(x, y);
         var dropdownEnd = new Vector2(x + width, y + height);
 
@@ -214,9 +215,10 @@ internal static class Dropdown
         string[] items,
         int selectedIndex,
         float itemHeight = 40f,
-        float fontSize = FontSizes.Body,
+        float fontSize = -1f,
         int maxVisibleItems = 8)
     {
+        if (fontSize < 0f) fontSize = FontSizes.Body;
         var mousePos = ImGui.GetMousePos();
         var menuTop = y + height + 2f;
         var menuStart = new Vector2(x, menuTop);

--- a/DivineAscension/GUI/UI/Renderers/Components/CivilizationTableRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/CivilizationTableRenderer.cs
@@ -190,7 +190,7 @@ internal static class CivilizationTableRenderer
         float tableWidth, float nameColumnWidth, float religionsColumnWidth, float descriptionColumnWidth)
     {
         var headerColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
-        const float fontSize = TableHeader;
+        var fontSize = TableHeader;
 
         // Column 1: "Name" — sigil column is hidden (see #385), so the name
         // text area now spans the full Name column.

--- a/DivineAscension/GUI/UI/Utilities/FontSizes.cs
+++ b/DivineAscension/GUI/UI/Utilities/FontSizes.cs
@@ -3,40 +3,54 @@ namespace DivineAscension.GUI.UI.Utilities;
 /// <summary>
 ///     Centralized font size definitions for all UI components.
 ///     Ensures consistent typography across all overlays and dialogs.
+///
+///     Each member returns its base (1.0-scale) size multiplied by
+///     <see cref="UiScale.Factor" /> via <see cref="UiScale.Scaled(float)" />, so
+///     all text grows proportionally on high-resolution / high-DPI screens (#587).
+///     The base sizes below are the unscaled source of truth; at the default
+///     <see cref="UiScale.Factor" /> of 1.0 every member returns its base value.
+///
+///     These are properties rather than consts so the live scale is applied at
+///     read time. Consequently they cannot be used as default parameter values or
+///     other compile-time constants — pass the value explicitly (or use a nullable
+///     sentinel resolved in the method body).
 /// </summary>
 internal static class FontSizes
 {
     // Page/Window level
     /// <summary>Top-level screen titles (e.g., "Create Religion", "Blessing Info")</summary>
-    public const float PageTitle = 20f;
+    public static float PageTitle => UiScale.Scaled(20f);
 
     // Section level
     /// <summary>Major section headers (e.g., activity sections, civilization sections)</summary>
-    public const float SectionHeader = 18f;
+    public static float SectionHeader => UiScale.Scaled(18f);
 
     /// <summary>Table column headers, detail section titles, religion names</summary>
-    public const float TableHeader = 17f;
+    public static float TableHeader => UiScale.Scaled(17f);
 
     /// <summary>Field labels, requirement headers, ritual details</summary>
-    public const float SubsectionLabel = 16f;
+    public static float SubsectionLabel => UiScale.Scaled(16f);
 
     // Content level
     /// <summary>Primary body text, table data, list items</summary>
-    public const float Body = 15f;
+    public static float Body => UiScale.Scaled(15f);
 
     /// <summary>Info text, descriptions, metadata</summary>
-    public const float Secondary = 14f;
+    public static float Secondary => UiScale.Scaled(14f);
 
     /// <summary>Hints, timestamps, minor labels</summary>
-    public const float Small = 14f;
+    public static float Small => UiScale.Scaled(14f);
 
     /// <summary>Tier labels, very small text</summary>
-    public const float Compact = 14f;
+    public static float Compact => UiScale.Scaled(14f);
 
     /// <summary>Densely packed summary text (cross-deity counts, micro badges)</summary>
-    public const float Micro = 12f;
+    public static float Micro => UiScale.Scaled(12f);
 
     // Spacing helpers
-    /// <summary>Pixels added between wrapped text lines (line-height = fontSize + LinePadding).</summary>
-    public const float LinePadding = 6f;
+    /// <summary>
+    ///     Pixels added between wrapped text lines (line-height = fontSize + LinePadding).
+    ///     Scales with the font so line spacing tracks text growth.
+    /// </summary>
+    public static float LinePadding => UiScale.Scaled(6f);
 }

--- a/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
+++ b/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
@@ -27,9 +27,10 @@ public static class TextRenderer
         string text,
         float x,
         float y,
-        float fontSize = FontSizes.SubsectionLabel,
+        float fontSize = -1f,
         Vector4? color = null)
     {
+        if (fontSize < 0f) fontSize = FontSizes.SubsectionLabel;
         var textColor = ImGui.ColorConvertFloat4ToU32(color ?? ColorPalette.White);
         drawList.AddText(ImGui.GetFont(), fontSize, new Vector2(x, y), textColor, text);
     }
@@ -117,9 +118,10 @@ public static class TextRenderer
         float x,
         float y,
         float width,
-        float fontSize = FontSizes.Secondary,
+        float fontSize = -1f,
         Vector4? color = null)
     {
+        if (fontSize < 0f) fontSize = FontSizes.Secondary;
         // Use a lighter grey (0.8, 0.8, 0.8) for better contrast on dark backgrounds
         var defaultColor = new Vector4(0.8f, 0.8f, 0.8f, 1.0f);
         var textColor = ImGui.ColorConvertFloat4ToU32(color ?? defaultColor);
@@ -179,8 +181,9 @@ public static class TextRenderer
     /// <param name="width">Maximum width for wrapping</param>
     /// <param name="fontSize">Font size used when rendering (default FontSizes.Secondary)</param>
     /// <returns>Total height in pixels required to render the wrapped text</returns>
-    public static float MeasureWrappedHeight(string text, float width, float fontSize = FontSizes.Secondary)
+    public static float MeasureWrappedHeight(string text, float width, float fontSize = -1f)
     {
+        if (fontSize < 0f) fontSize = FontSizes.Secondary;
         // Mirror DrawInfoText: hard breaks then per-paragraph word wrap.
         var lines = 0;
         var lineHeight = fontSize + 6f;
@@ -235,8 +238,9 @@ public static class TextRenderer
         string text,
         float x,
         float y,
-        float fontSize = FontSizes.Body)
+        float fontSize = -1f)
     {
+        if (fontSize < 0f) fontSize = FontSizes.Body;
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Red);
         drawList.AddText(ImGui.GetFont(), fontSize, new Vector2(x, y), textColor, text);
     }
@@ -254,8 +258,9 @@ public static class TextRenderer
         string text,
         float x,
         float y,
-        float fontSize = FontSizes.Body)
+        float fontSize = -1f)
     {
+        if (fontSize < 0f) fontSize = FontSizes.Body;
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Green);
         drawList.AddText(ImGui.GetFont(), fontSize, new Vector2(x, y), textColor, text);
     }
@@ -273,8 +278,9 @@ public static class TextRenderer
         string text,
         float x,
         float y,
-        float fontSize = FontSizes.Body)
+        float fontSize = -1f)
     {
+        if (fontSize < 0f) fontSize = FontSizes.Body;
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Yellow);
         drawList.AddText(ImGui.GetFont(), fontSize, new Vector2(x, y), textColor, text);
     }


### PR DESCRIPTION
Sub-issue of the global UI-scale epic (#584). Depends on #586 (merged).

## What

`FontSizes` members change from `const` to **scaled properties** — each returns its base size × `UiScale.Factor` via `UiScale.Scaled()`. Every existing `FontSizes` use (~397 sites across the UI) now scales automatically, with **no call-site churn**.

This is a deliberate refinement of the sub-issue's original "edit 397 sites by hand" plan: routing through the property getter achieves the same result with a ~4-file diff and zero risk of missing a site.

## Behavioral no-op until scale source is wired

Base sizes remain the unscaled source of truth; at the default `Factor = 1.0` every member returns its base value. Safe to merge standalone — visible scaling only kicks in once #590 wires the source.

## Compile-time-const fix-ups

Properties can't be compile-time constants, so the handful of sites that used a `FontSizes` value as a **default parameter** now take a `-1f` sentinel resolved to the real default in the method body (font sizes are always positive); one local `const float = TableHeader` becomes `var`. 10 sites total — `TextRenderer` (5 draw helpers + `MeasureWrappedHeight`), `Dropdown` (×2), `CivilizationTableRenderer`.

## Correctness notes

- Wrap/measure math stays correct: width ratios (`fontSize / GetFontSize()`, `fontSize / FontSizes.Body`) are scale-invariant because numerator and the rendered `AddText` size scale together.
- `LinePadding` scales too, so line spacing tracks font growth.
- No `AddText` call passes a raw numeric font size (verified), so nothing escapes the scaling.

## Out of scope

Layout offsets written as raw pixel literals are still unscaled — the intentional intermediate state (bigger text, cramped layout) finished by #589.

## Tests

Full suite: **2495 passed**. No test asserts on `FontSizes` values. Build clean.

Closes #587