### PR TITLE
feat(ui): drive UiScale.Factor from VS GUIScale setting (#590)

### DIFF
--- a/DivineAscension.Tests/GUI/UI/Utilities/UiScaleTests.cs
+++ b/DivineAscension.Tests/GUI/UI/Utilities/UiScaleTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using DivineAscension.GUI.UI.Utilities;
+using Vintagestory.API.Config;
 
 namespace DivineAscension.Tests.GUI.UI.Utilities;
 
@@ -65,5 +66,56 @@ public class UiScaleTests
         UiScale.Factor = 2.0f;
         UiScale.Factor = bad;
         Assert.Equal(2.0f, UiScale.Factor);
+    }
+
+    [Fact]
+    public void SyncFromGameSettings_AppliesGuiScale()
+    {
+        var original = RuntimeEnv.GUIScale;
+        try
+        {
+            RuntimeEnv.GUIScale = 1.5f;
+            UiScale.SyncFromGameSettings();
+            Assert.Equal(1.5f, UiScale.Factor);
+        }
+        finally
+        {
+            RuntimeEnv.GUIScale = original;
+        }
+    }
+
+    [Fact]
+    public void SyncFromGameSettings_ClampsOutOfRangeGuiScale()
+    {
+        var original = RuntimeEnv.GUIScale;
+        try
+        {
+            RuntimeEnv.GUIScale = 10f;
+            UiScale.SyncFromGameSettings();
+            Assert.Equal(UiScale.MaxFactor, UiScale.Factor);
+        }
+        finally
+        {
+            RuntimeEnv.GUIScale = original;
+        }
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    public void SyncFromGameSettings_IgnoresNonPositiveGuiScale(float bogus)
+    {
+        var original = RuntimeEnv.GUIScale;
+        try
+        {
+            UiScale.Factor = 2.0f;
+            RuntimeEnv.GUIScale = bogus;
+            UiScale.SyncFromGameSettings();
+            Assert.Equal(2.0f, UiScale.Factor); // unchanged
+        }
+        finally
+        {
+            RuntimeEnv.GUIScale = original;
+        }
     }
 }

--- a/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
+++ b/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
@@ -98,6 +98,7 @@ public class CaravanTradeDialog : ModSystem
             return CallbackGUIStatus.Closed;
         }
 
+        UiScale.SyncFromGameSettings();
         DrawWindow();
         return CallbackGUIStatus.GrabMouse;
     }

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -294,6 +294,7 @@ public partial class GuiDialog : ModSystem
             PlayPageTurn();
         }
 
+        UiScale.SyncFromGameSettings();
         DrawWindow();
 
         return CallbackGUIStatus.GrabMouse;
@@ -319,6 +320,8 @@ public partial class GuiDialog : ModSystem
 
         // Update notification timer
         _manager.NotificationManager.Update(deltaSeconds);
+
+        UiScale.SyncFromGameSettings();
 
         // Toast anchors to the bottom-right of the full viewport.
         var windowWidth = _viewport.Size.X;

--- a/DivineAscension/GUI/UI/Utilities/UiScale.cs
+++ b/DivineAscension/GUI/UI/Utilities/UiScale.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using Vintagestory.API.Config;
 
 namespace DivineAscension.GUI.UI.Utilities;
 
@@ -57,4 +58,19 @@ internal static class UiScale
     ///     rounding each component independently.
     /// </summary>
     public static Vector2 Scaled(Vector2 baseValue) => new(Scaled(baseValue.X), Scaled(baseValue.Y));
+
+    /// <summary>
+    ///     Mirror the player's chosen GUI scale onto <see cref="Factor" />. ImGui
+    ///     renders independently of VS's GuiElement system, so
+    ///     <see cref="RuntimeEnv.GUIScale" /> — the live value vanilla uses to scale
+    ///     its own GUI — is not applied to our dialogs automatically. Call this each
+    ///     frame before drawing so changing the setting takes effect without
+    ///     reopening. Non-positive values (uninitialised / bogus) are ignored;
+    ///     <see cref="Factor" /> clamps the rest to its supported range.
+    /// </summary>
+    public static void SyncFromGameSettings()
+    {
+        var scale = RuntimeEnv.GUIScale;
+        if (scale > 0f) Factor = scale;
+    }
 }


### PR DESCRIPTION
Sub-issue of the global UI-scale epic (#584). Depends on #586 + #587 (merged). Resolves the epic's open question: **scale source = VS `ClientSettings`/`RuntimeEnv.GUIScale`** (reuse the game's existing setting; no new UI).

## What

`UiScale.SyncFromGameSettings()` mirrors `RuntimeEnv.GUIScale` — the live value vanilla uses to scale its own GUI — onto `UiScale.Factor`. ImGui renders independently of VS's GuiElement system, so our dialogs didn't pick up the player's GUI-scale choice automatically; this wires them to it.

- Called each frame before drawing, from **both** ImGui dialogs: `GuiDialog` (main + notification overlay) and `CaravanTradeDialog`. Re-reading per frame means the setting takes effect without reopening — no settings-watcher key to depend on.
- Non-positive / uninitialised values ignored; `Factor`'s existing clamp `[0.5, 4.0]` handles the rest.
- Logic centralised on `UiScale` (not duplicated per dialog); the VS read is the only untested line, the clamp/guard behaviour is covered.

## Visible effect

With #587 already scaling fonts, **text now tracks the GUIScale setting** — this is the first PR where scaling is observable in-game.

## Known intermediate state (until #589)

Layout offsets are still raw pixels, so at non-default GUIScale the dialog is bigger-text-in-old-boxes (roomy/cramped) until the layout pass (#589) lands. Consistent with the epic's staged plan. If you'd rather not expose that to players with non-1.0 GUIScale, hold this merge until #589 — otherwise it's safe and self-contained.

## Tests

Added `SyncFromGameSettings` cases (applies value, clamps out-of-range, ignores non-positive) by toggling `RuntimeEnv.GUIScale`. Full suite: **2499 passed**. Build clean.

Closes #590