### PR TITLE
feat(ui): scale window + chrome layout; establish Scaled() convention (#589)

### DIFF
--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -388,10 +388,15 @@ public partial class GuiDialog : ModSystem
         // Applied only on first use; user-driven resizes within a session and
         // restored sizes across sessions stick from then on.
         var uiPrefs = _divineAscensionModSystem?.Config.UiPrefs;
-        var prefsW = uiPrefs?.WindowWidth ?? WindowBaseWidth;
-        var prefsH = uiPrefs?.WindowHeight ?? WindowBaseHeight;
-        if (prefsW <= 0) prefsW = WindowBaseWidth;
-        if (prefsH <= 0) prefsH = WindowBaseHeight;
+        // Defaults represent the base (1.0-scale) size, so scale them by the
+        // current UI scale. A persisted size is already in real pixels (whatever
+        // the user resized to at their scale) — never re-scale it.
+        var defaultW = (int)UiScale.Scaled(WindowBaseWidth);
+        var defaultH = (int)UiScale.Scaled(WindowBaseHeight);
+        var prefsW = uiPrefs?.WindowWidth ?? defaultW;
+        var prefsH = uiPrefs?.WindowHeight ?? defaultH;
+        if (prefsW <= 0) prefsW = defaultW;
+        if (prefsH <= 0) prefsH = defaultH;
         var initialW = Math.Min(prefsW, (int)window.OuterWidth - 128);
         var initialH = Math.Min(prefsH, (int)window.OuterHeight - 128);
 
@@ -403,8 +408,8 @@ public partial class GuiDialog : ModSystem
 
         // Clamp interactive resize to the game window. Min keeps the dialog
         // usable; max prevents drag-resizing off-screen and out of bounds.
-        const float minW = 800f;
-        const float minH = 500f;
+        var minW = UiScale.Scaled(800f);
+        var minH = UiScale.Scaled(500f);
         var maxW = MathF.Max(minW, (float)window.OuterWidth - 32f);
         var maxH = MathF.Max(minH, (float)window.OuterHeight - 32f);
         ImGui.SetNextWindowSizeConstraints(new Vector2(minW, minH), new Vector2(maxW, maxH));

--- a/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
+++ b/DivineAscension/GUI/UI/Layout/MainLayoutCoordinator.cs
@@ -23,12 +23,14 @@ namespace DivineAscension.GUI.UI.Layout;
 [ExcludeFromCodeCoverage]
 internal static class MainLayoutCoordinator
 {
-    private const float OuterPadding = 16f;
-    private const float SidebarWidth = 240f;
-    private const float SidebarCollapsedWidth = 40f;
-    private const float Gap = 8f;
-    private const float TopChromeHeight = 32f;
-    private const float PageFooterGap = 6f;
+    // Layout metrics are authored at base (1.0) scale and returned scaled by
+    // UiScale.Factor so the chrome grows proportionally with the fonts (#589).
+    private static float OuterPadding => UiScale.Scaled(16f);
+    private static float SidebarWidth => UiScale.Scaled(240f);
+    private static float SidebarCollapsedWidth => UiScale.Scaled(40f);
+    private static float Gap => UiScale.Scaled(8f);
+    private static float TopChromeHeight => UiScale.Scaled(32f);
+    private static float PageFooterGap => UiScale.Scaled(6f);
 
     public static void Draw(
         GuiDialogManager manager,

--- a/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
@@ -19,11 +19,12 @@ namespace DivineAscension.GUI.UI.Layout;
 internal static class TitleStripRenderer
 {
     private const string TitleText = "Divine Ascension";
-    private const float Padding = 12f;
-    private const float CloseButtonSize = 24f;
-    private const float IdentityGap = 12f;
-    private const float OrnamentHalfSize = 5f;
-    private const float OrnamentGap = 8f;
+    // Geometry authored at base (1.0) scale, returned scaled by UiScale.Factor (#589).
+    private static float Padding => UiScale.Scaled(12f);
+    private static float CloseButtonSize => UiScale.Scaled(24f);
+    private static float IdentityGap => UiScale.Scaled(12f);
+    private static float OrnamentHalfSize => UiScale.Scaled(5f);
+    private static float OrnamentGap => UiScale.Scaled(8f);
     private const string Ellipsis = "…";
     private const string IdentitySeparator = " · ";
 
@@ -50,7 +51,7 @@ internal static class TitleStripRenderer
             new Vector2(rect.X, rect.Bottom),
             new Vector2(rect.Right, rect.Bottom),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.5f),
-            1f);
+            UiScale.Scaled(1f));
 
         // Close button anchored at the right edge of the strip.
         var closeY = rect.Y + (rect.H - CloseButtonSize) / 2f;

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/PageTurnFooterRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/PageTurnFooterRenderer.cs
@@ -20,15 +20,16 @@ namespace DivineAscension.GUI.UI.Renderers.Sidebar;
 [ExcludeFromCodeCoverage]
 internal static class PageTurnFooterRenderer
 {
-    public const float FooterHeight = 56f;
+    // Geometry authored at base (1.0) scale, returned scaled by UiScale.Factor (#589).
+    public static float FooterHeight => UiScale.Scaled(56f);
 
-    private const float ButtonWidth = 140f;
-    private const float ButtonHeight = 26f;
-    private const float ButtonChevronSize = 9f;
-    private const float ButtonChevronPadding = 10f;
-    private const float IndicatorBaseline = 38f;
-    private const float IndicatorSidePadding = 12f;
-    private const float IndicatorLineGap = 8f;
+    private static float ButtonWidth => UiScale.Scaled(140f);
+    private static float ButtonHeight => UiScale.Scaled(26f);
+    private static float ButtonChevronSize => UiScale.Scaled(9f);
+    private static float ButtonChevronPadding => UiScale.Scaled(10f);
+    private static float IndicatorBaseline => UiScale.Scaled(38f);
+    private static float IndicatorSidePadding => UiScale.Scaled(12f);
+    private static float IndicatorLineGap => UiScale.Scaled(8f);
 
     /// <summary>
     ///     Draw the page-turn footer.
@@ -56,7 +57,7 @@ internal static class PageTurnFooterRenderer
     {
         var label = LocalizationService.Instance.Get(LocalizationKeys.SIDEBAR_PAGE_TURN_PREVIOUS);
         var nextLabel = LocalizationService.Instance.Get(LocalizationKeys.SIDEBAR_PAGE_TURN_NEXT);
-        var rowY = footer.Y + 4f;
+        var rowY = footer.Y + UiScale.Scaled(4f);
 
         if (DrawTurnButton("##da-pageturn-prev", new Vector2(footer.X, rowY),
                 label, pos.Previous.HasValue, ChromeRenderer.ChevronDirection.Left))
@@ -163,11 +164,11 @@ internal static class PageTurnFooterRenderer
 
         if (leftEnd > leftStart)
         {
-            drawList.AddLine(new Vector2(leftStart, y), new Vector2(leftEnd, y), lineColor, 1f);
+            drawList.AddLine(new Vector2(leftStart, y), new Vector2(leftEnd, y), lineColor, UiScale.Scaled(1f));
         }
         if (rightStart < rightEnd)
         {
-            drawList.AddLine(new Vector2(rightStart, y), new Vector2(rightEnd, y), lineColor, 1f);
+            drawList.AddLine(new Vector2(rightStart, y), new Vector2(rightEnd, y), lineColor, UiScale.Scaled(1f));
         }
     }
 

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
@@ -19,20 +19,23 @@ namespace DivineAscension.GUI.UI.Renderers.Sidebar;
 [ExcludeFromCodeCoverage]
 internal static class SidebarRenderer
 {
-    private const float ToggleStripHeight = 28f;
-    private const float GroupHeaderHeight = 22f;
-    private const float ItemHeight = 24f;
+    // Layout geometry authored at base (1.0) scale, returned scaled by
+    // UiScale.Factor (#589). Font sizes below stay unscaled here — chapter labels
+    // use baked Cinzel sizes (#588) and verse/item labels the implicit font (#601).
+    private static float ToggleStripHeight => UiScale.Scaled(28f);
+    private static float GroupHeaderHeight => UiScale.Scaled(22f);
+    private static float ItemHeight => UiScale.Scaled(24f);
     private const int ChapterFontSize = 18;
     private const int VerseFontSize = 13;
-    private const float ItemIndent = 12f;
-    private const float ChapterChevronSize = 9f;
-    private const float ChapterChevronPadding = 6f;
-    private const float ItemBulletHalfSize = 3f;
-    private const float ItemBulletActiveHalfSize = 4f;
-    private const float ItemBulletPadding = 6f;
-    private const float ItemVerseGap = 8f;
-    private const float ActiveRibbonWidth = 2.5f;
-    private const float CollapsedStripIconSize = 32f;
+    private static float ItemIndent => UiScale.Scaled(12f);
+    private static float ChapterChevronSize => UiScale.Scaled(9f);
+    private static float ChapterChevronPadding => UiScale.Scaled(6f);
+    private static float ItemBulletHalfSize => UiScale.Scaled(3f);
+    private static float ItemBulletActiveHalfSize => UiScale.Scaled(4f);
+    private static float ItemBulletPadding => UiScale.Scaled(6f);
+    private static float ItemVerseGap => UiScale.Scaled(8f);
+    private static float ActiveRibbonWidth => UiScale.Scaled(2.5f);
+    private static float CollapsedStripIconSize => UiScale.Scaled(32f);
 
     private static readonly string[] LowerRomanVerse =
     {
@@ -75,10 +78,11 @@ internal static class SidebarRenderer
         // sidebar from the content pane, like the gutter of a bound book.
         var spineDrawList = ImGui.GetWindowDrawList();
         var spineColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.35f);
+        var spineX = rect.X + rect.W - UiScale.Scaled(0.5f);
         spineDrawList.AddLine(
-            new Vector2(rect.X + rect.W - 0.5f, rect.Y),
-            new Vector2(rect.X + rect.W - 0.5f, rect.Y + rect.H),
-            spineColor, 1f);
+            new Vector2(spineX, rect.Y),
+            new Vector2(spineX, rect.Y + rect.H),
+            spineColor, UiScale.Scaled(1f));
 
         ImGui.EndChild();
         ImGui.PopStyleColor(2);
@@ -103,17 +107,17 @@ internal static class SidebarRenderer
         var direction = vm.IsCollapsed
             ? ChromeRenderer.ChevronDirection.Right
             : ChromeRenderer.ChevronDirection.Left;
-        const float chevronSize = 9f;
+        var chevronSize = UiScale.Scaled(9f);
         var cy = cursor.Y + ToggleStripHeight / 2f;
         var cx = cursor.X + availWidth / 2f;
         ChromeRenderer.DrawChevron(drawList, cx, cy, chevronSize, direction);
 
         // Hairline rule under the toggle strip separates the chrome from the
         // first chapter heading.
-        var ruleY = cursor.Y + ToggleStripHeight - 1f;
+        var ruleY = cursor.Y + ToggleStripHeight - UiScale.Scaled(1f);
         var ruleColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.35f);
         drawList.AddLine(new Vector2(cursor.X, ruleY),
-            new Vector2(cursor.X + availWidth, ruleY), ruleColor, 1f);
+            new Vector2(cursor.X + availWidth, ruleY), ruleColor, UiScale.Scaled(1f));
     }
 
     private static void DrawGroups(SidebarViewModel vm, List<SidebarEvent> events)
@@ -165,7 +169,7 @@ internal static class SidebarRenderer
         // Chapter rule: ornament divider beneath the heading anchors the
         // chapter visually and breaks the three groups apart on the rail.
         var ruleWidth = ImGui.GetContentRegionAvail().X;
-        var ruleY = cursor.Y + GroupHeaderHeight - 3f;
+        var ruleY = cursor.Y + GroupHeaderHeight - UiScale.Scaled(3f);
         if (ruleWidth > 0f)
         {
             ChromeRenderer.DrawDivider(drawList, cursor.X, ruleY, ruleWidth);
@@ -277,9 +281,9 @@ internal static class SidebarRenderer
         {
             var badgeText = item.Badge.ToString();
             var badgeTextSize = ImGui.CalcTextSize(badgeText);
-            const float badgePadX = 5f;
-            const float badgePadY = 1f;
-            const float badgeRightMargin = 8f;
+            var badgePadX = UiScale.Scaled(5f);
+            var badgePadY = UiScale.Scaled(1f);
+            var badgeRightMargin = UiScale.Scaled(8f);
             var badgeW = badgeTextSize.X + badgePadX * 2f;
             var badgeH = badgeTextSize.Y + badgePadY * 2f;
             var badgeX = cursor.X + rowWidth - badgeRightMargin - badgeW;
@@ -291,8 +295,8 @@ internal static class SidebarRenderer
                 item.IsDisabled ? ColorPalette.Grey : ColorPalette.Gold);
             var bMin = new Vector2(badgeX, badgeY);
             var bMax = new Vector2(badgeX + badgeW, badgeY + badgeH);
-            drawList.AddRectFilled(bMin, bMax, badgeBgColor, 2f);
-            drawList.AddRect(bMin, bMax, badgeBorderColor, 2f, ImDrawFlags.None, 1f);
+            drawList.AddRectFilled(bMin, bMax, badgeBgColor, UiScale.Scaled(2f));
+            drawList.AddRect(bMin, bMax, badgeBorderColor, UiScale.Scaled(2f), ImDrawFlags.None, UiScale.Scaled(1f));
             drawList.AddText(new Vector2(badgeX + badgePadX, badgeY + badgePadY),
                 badgeTextColor, badgeText);
         }
@@ -321,9 +325,9 @@ internal static class SidebarRenderer
                 if (dividerWidth > 0f)
                 {
                     ChromeRenderer.DrawDivider(drawList, dividerOrigin.X,
-                        dividerOrigin.Y + 4f, dividerWidth);
+                        dividerOrigin.Y + UiScale.Scaled(4f), dividerWidth);
                 }
-                ImGui.Dummy(new Vector2(0f, 12f));
+                ImGui.Dummy(new Vector2(0f, UiScale.Scaled(12f)));
             }
 
             for (var i = 0; i < group.Items.Count; i++)
@@ -373,7 +377,7 @@ internal static class SidebarRenderer
                         new Vector2(rowOrigin.X, rowOrigin.Y),
                         new Vector2(rowOrigin.X + CollapsedStripIconSize,
                             rowOrigin.Y + CollapsedStripIconSize),
-                        borderColor, 2f, ImDrawFlags.None, 1.5f);
+                        borderColor, UiScale.Scaled(2f), ImDrawFlags.None, UiScale.Scaled(1.5f));
                 }
 
                 if (item.Badge > 0)
@@ -381,9 +385,9 @@ internal static class SidebarRenderer
                     // Small diamond in the top-right corner signals unread
                     // letters / pending work — matches the chapter bullet style.
                     ChromeRenderer.DrawDiamond(drawList,
-                        rowOrigin.X + CollapsedStripIconSize - 5f,
-                        rowOrigin.Y + 5f,
-                        3f, ColorPalette.Gold);
+                        rowOrigin.X + CollapsedStripIconSize - UiScale.Scaled(5f),
+                        rowOrigin.Y + UiScale.Scaled(5f),
+                        UiScale.Scaled(3f), ColorPalette.Gold);
                 }
 
                 if (isHovered)


### PR DESCRIPTION
**Foundation PR** for the layout-scaling pass (#589), part of epic #584. Depends on #586/#587/#590 (merged).

## What

Window sizing + dialog chrome now grow with `UiScale.Factor`, and this PR sets the convention the per-area sub-issues (#595–#600) follow.

- **Window** (`GuiDialog`): default size + min constraints scale by Factor; a **persisted** size is left untouched (already real pixels at the user's scale — never re-scaled).
- **Chrome geometry** (`MainLayoutCoordinator`, `TitleStripRenderer`, `SidebarRenderer`, `PageTurnFooterRenderer`): named layout consts → scaled `static` properties (mirrors the #587 `FontSizes` pattern, zero use-site churn); inline pixel offsets, radii, line thicknesses → `UiScale.Scaled(...)`.

## Convention (for the area PRs)

- Scale: layout offsets, sizes, padding, radii, line thicknesses.
- **Leave alone:** `/2f` centring divisors, `*2f` doublers, color alphas, `0f`.
- **Font sizes are out of scope here** — chapter labels use baked Cinzel sizes (#588), item/verse + button labels use the implicit font (#601); local font consts (e.g. `ChapterFontSize`) stay unscaled until those land.

## Scope decisions worth noting

Two things surfaced and were split out rather than folded in:
- **#588** (baked Cinzel sizes) — scaling chapter font sizes without baked scaled sizes would drop the serif face to the default font.
- **#601** (new) — implicit-font text (~56 `AddText(pos,color,text)` + ~12 `ImGui.Button/Text/Selectable`) doesn't scale; needs a `SetWindowFontScale` decision with `CalcTextSize`/ratio audit. Distinct from layout.

## Intermediate state

At GUIScale > 1 the chrome frame is now proportional, but leaf content pages and implicit-font text lag until #595–#600 and #588/#601. Consistent with the staged epic plan.

## Tests

Full suite: **2499 passed**. Build clean. Diff verified to scale no centring divisors/doublers.

Refs #589