### PR TITLE
feat(ui): scale implicit-font text via FontGlobalScale (#601)

### DIFF
--- a/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
+++ b/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
@@ -105,6 +105,8 @@ public class CaravanTradeDialog : ModSystem
 
     private void DrawWindow()
     {
+        using var fontScale = UiScale.BeginFontScale();
+
         var width = MathF.Min(WindowWidth, _viewport.Size.X - 64f);
         var height = MathF.Min(WindowHeight, _viewport.Size.Y - 64f);
 

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -322,6 +322,7 @@ public partial class GuiDialog : ModSystem
         _manager.NotificationManager.Update(deltaSeconds);
 
         UiScale.SyncFromGameSettings();
+        using var fontScale = UiScale.BeginFontScale();
 
         // Toast anchors to the bottom-right of the full viewport.
         var windowWidth = _viewport.Size.X;
@@ -380,6 +381,10 @@ public partial class GuiDialog : ModSystem
     /// </summary>
     private void DrawWindow()
     {
+        // Scale implicit-font text + CalcTextSize in this window and its children
+        // with the UI scale; restored when the scope disposes at method end.
+        using var fontScale = UiScale.BeginFontScale();
+
         var window = _capi!.Gui.WindowBounds;
         var deltaTime = _stopwatch!.ElapsedMilliseconds / 1000f;
         _stopwatch.Restart();

--- a/DivineAscension/GUI/UI/Utilities/UiScale.cs
+++ b/DivineAscension/GUI/UI/Utilities/UiScale.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using ImGuiNET;
 using Vintagestory.API.Config;
 
 namespace DivineAscension.GUI.UI.Utilities;
@@ -72,5 +73,44 @@ internal static class UiScale
     {
         var scale = RuntimeEnv.GUIScale;
         if (scale > 0f) Factor = scale;
+    }
+
+    /// <summary>
+    ///     Apply <see cref="Factor" /> to ImGui's global font scale for the
+    ///     duration of the returned scope, then restore the previous value on
+    ///     dispose. Use with <c>using</c> around a dialog's draw so all
+    ///     <em>implicit-font</em> text (3-arg <c>AddText</c>, <c>ImGui.Button</c>/
+    ///     <c>Text</c>/<c>Selectable</c>) and <c>CalcTextSize</c> measurements in
+    ///     that window — and its child windows — scale with the UI.
+    ///
+    ///     <para>
+    ///     Explicit-size <c>AddText(font, size, …)</c> ignores the global scale, so
+    ///     text already sized via <see cref="FontSizes" /> (which is scaled by
+    ///     <see cref="Factor" />) is not double-scaled. Width ratios of the form
+    ///     <c>fontSize / ImGui.GetFontSize()</c> are unaffected: both terms move
+    ///     by the same factor and cancel.
+    ///     </para>
+    ///
+    ///     <para>
+    ///     The scale is context-global, so saving and restoring keeps it from
+    ///     leaking onto other VSImGui windows (debug tools, other mods) drawn in
+    ///     the same frame.
+    ///     </para>
+    /// </summary>
+    public static FontScaleScope BeginFontScale() => new(_factor);
+
+    /// <summary>RAII scope that sets and restores <c>io.FontGlobalScale</c>. See <see cref="BeginFontScale" />.</summary>
+    public readonly ref struct FontScaleScope
+    {
+        private readonly float _previous;
+
+        internal FontScaleScope(float scale)
+        {
+            var io = ImGui.GetIO();
+            _previous = io.FontGlobalScale;
+            io.FontGlobalScale = scale;
+        }
+
+        public void Dispose() => ImGui.GetIO().FontGlobalScale = _previous;
     }
 }


### PR DESCRIPTION
Part of epic #584. Fixes the text-scaling gap discovered during the #589 foundation.

## Problem

#587 scaled **explicit-size** text (`AddText(font, size, …)` via `FontSizes`). But the dialog also draws **implicit-font** text — `AddText(pos, color, text)` (~56 sites) and `ImGui.Button`/`Text`/`Selectable` (~12 sites) — which uses the current font at its atlas size and so ignored `UiScale`. At GUIScale > 1 it stayed small inside the now-scaled chrome (#589): big page-turn buttons with tiny labels, etc.

## Fix

Wrap each dialog's draw in `UiScale.BeginFontScale()` — a `using`-scope that sets `io.FontGlobalScale = Factor` and restores the previous value on dispose.

- **One global lever** covers all three top-level windows **and** their child windows (sidebar, blessing tree, notification feed). `SetWindowFontScale` does *not* inherit into `BeginChild`, so it would have needed 6 sites + Dropdown rework.
- **Save/restore** keeps the context-global scale from leaking onto other VSImGui windows (debug tools, other mods) drawn in the same frame.

Touched: `UiScale` (new `BeginFontScale`/`FontScaleScope`), `GuiDialog` (main + notification overlay), `CaravanTradeDialog`.

## Why it's safe (verified by tracing each interaction)

- **No double-scaling:** explicit-size `AddText(font, size, …)` ignores `FontGlobalScale`, so `FontSizes`-scaled text is untouched.
- **Ratio math self-normalizes:** every `fontSize / ImGui.GetFontSize()` caller (TextRenderer wrap, tooltips, sidebar verse/stamp, ChromeRenderer drop-cap) stays correct — `CalcTextSize` (numerator) and `GetFontSize()` (denominator) both move by Factor and cancel. Traced the Cinzel-fixed and default-fallback branches; both hold.
- **Dropdown:** its per-window `SetWindowFontScale` multiplies cleanly on top of the global, so its text now scales too; resetting `FontWindowScale` to `1f` remains correct (global scale is a separate slot).

## Out of scope

Cinzel baked-font labels (chapter headers, "Divine Ascension" title) are explicit-size draws and stay fixed until baked scaled sizes land — **#588**.

## Tests

`FontScaleScope` calls `ImGui.GetIO()` (needs cimgui native, unavailable headless), so it's verified by build + manual in-game, not a unit test — consistent with other ImGui glue. Existing `UiScale` math tests unchanged. Full suite: **2499 passed**, build clean.

## Manual test

At GUIScale 1 vs 2 (Settings → Graphics → GUI Scale), reopen dialog (Shift+G): sidebar item labels, page-turn button text, dropdowns, and ImGui buttons should now grow with the UI. Chapter/title serif labels still fixed (expected — #588).

Closes #601