### PR TITLE
feat(ui): scale Cinzel serif sizes in the chrome (#588)

### DIFF
--- a/DivineAscension.Tests/Services/UI/CinzelFontSystemTests.cs
+++ b/DivineAscension.Tests/Services/UI/CinzelFontSystemTests.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Services.UI;
+
+namespace DivineAscension.Tests.Services.UI;
+
+/// <summary>
+///     Unit tests for <see cref="CinzelFontSystem.NearestBakedSize" /> — the pure
+///     size-snapping used so UI-scaled serif sizes resolve to a baked atlas size.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class CinzelFontSystemTests
+{
+    [Theory]
+    [InlineData(6)]
+    [InlineData(18)]
+    [InlineData(24)]
+    [InlineData(36)]
+    [InlineData(60)]
+    public void NearestBakedSize_ReturnsExactBakedSizeUnchanged(int baked)
+    {
+        Assert.Equal(baked, CinzelFontSystem.NearestBakedSize(baked));
+    }
+
+    [Theory]
+    [InlineData(26, 24)] // closer to 24 than 30
+    [InlineData(28, 30)] // closer to 30
+    [InlineData(20, 18)] // closer to 18 than 24
+    [InlineData(40, 36)] // closer to 36 than 48
+    public void NearestBakedSize_SnapsToNearest(int requested, int expected)
+    {
+        Assert.Equal(expected, CinzelFontSystem.NearestBakedSize(requested));
+    }
+
+    [Theory]
+    [InlineData(21, 18)] // |18-21| == |24-21|; lower (first-encountered) wins
+    [InlineData(27, 24)] // |24-27| == |30-27|; lower wins
+    public void NearestBakedSize_TieBreaksToSmaller(int requested, int expected)
+    {
+        Assert.Equal(expected, CinzelFontSystem.NearestBakedSize(requested));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(-10)]
+    public void NearestBakedSize_BelowLadder_ClampsToSmallest(int requested)
+    {
+        Assert.Equal(6, CinzelFontSystem.NearestBakedSize(requested));
+    }
+
+    [Theory]
+    [InlineData(72)]
+    [InlineData(100)]
+    public void NearestBakedSize_AboveLadder_ClampsToLargest(int requested)
+    {
+        Assert.Equal(60, CinzelFontSystem.NearestBakedSize(requested));
+    }
+}

--- a/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
@@ -74,9 +74,7 @@ internal static class TitleStripRenderer
         {
             titleFont = cinzelTitle.Value;
             titleFontSize = titleFont.FontSize;
-            ImGui.PushFont(titleFont);
-            titleSize = ImGui.CalcTextSize(TitleText);
-            ImGui.PopFont();
+            titleSize = TextRenderer.MeasureBakedSerif(titleFont, TitleText);
         }
         else
         {

--- a/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Layout/TitleStripRenderer.cs
@@ -65,14 +65,15 @@ internal static class TitleStripRenderer
         // Bold when the atlas baked it, default font otherwise — measure with
         // the font we'll actually draw with so the right diamond hugs the
         // glyph metrics rather than drifting.
-        var cinzelTitle = CinzelFontSystem.GetBold(TitleFontSize);
+        var cinzelTitle = CinzelFontSystem.GetBold(
+            CinzelFontSystem.NearestBakedSize((int)UiScale.Scaled(TitleFontSize)));
         ImGuiNET.ImFontPtr titleFont;
         float titleFontSize;
         Vector2 titleSize;
         if (cinzelTitle.HasValue)
         {
             titleFont = cinzelTitle.Value;
-            titleFontSize = TitleFontSize;
+            titleFontSize = titleFont.FontSize;
             ImGui.PushFont(titleFont);
             titleSize = ImGui.CalcTextSize(TitleText);
             ImGui.PopFont();

--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
@@ -159,9 +159,10 @@ internal static class SidebarRenderer
         // the chevron + label line stays vertically centred). Item labels
         // below intentionally stay in the default font for legibility.
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        var cinzelChapter = CinzelFontSystem.GetRegular(ChapterFontSize);
+        var cinzelChapter = CinzelFontSystem.GetRegular(
+            CinzelFontSystem.NearestBakedSize((int)UiScale.Scaled(ChapterFontSize)));
         var labelFont = cinzelChapter ?? ImGui.GetFont();
-        var labelSize = cinzelChapter.HasValue ? ChapterFontSize : ImGui.GetFontSize();
+        var labelSize = cinzelChapter.HasValue ? cinzelChapter.Value.FontSize : ImGui.GetFontSize();
         var textX = chevronX + ChapterChevronSize / 2f + ChapterChevronPadding;
         var textY = cursor.Y + (GroupHeaderHeight - labelSize) / 2f;
         drawList.AddText(labelFont, labelSize, new Vector2(textX, textY), textColor, group.Label);
@@ -255,9 +256,10 @@ internal static class SidebarRenderer
         var verse = verseIndex >= 0 && verseIndex < LowerRomanVerse.Length
             ? LowerRomanVerse[verseIndex]
             : string.Empty;
-        var cinzelVerse = CinzelFontSystem.GetRegular(VerseFontSize);
+        var cinzelVerse = CinzelFontSystem.GetRegular(
+            CinzelFontSystem.NearestBakedSize((int)UiScale.Scaled(VerseFontSize)));
         var verseFont = cinzelVerse ?? ImGui.GetFont();
-        var verseFontSize = cinzelVerse.HasValue ? VerseFontSize : ImGui.GetFontSize();
+        var verseFontSize = cinzelVerse.HasValue ? cinzelVerse.Value.FontSize : ImGui.GetFontSize();
         var verseX = bulletCx + ItemBulletHalfSize + ItemBulletPadding;
         var verseY = cursor.Y + (ItemHeight - verseFontSize) / 2f;
         var verseWidth = 0f;
@@ -358,9 +360,10 @@ internal static class SidebarRenderer
                 var stampColor = ImGui.ColorConvertFloat4ToU32(item.IsDisabled
                     ? ColorPalette.Gold * 0.4f
                     : ColorPalette.Gold);
-                var cinzelStamp = CinzelFontSystem.GetRegular(VerseFontSize);
+                var cinzelStamp = CinzelFontSystem.GetRegular(
+                    CinzelFontSystem.NearestBakedSize((int)UiScale.Scaled(VerseFontSize)));
                 var stampFont = cinzelStamp ?? ImGui.GetFont();
-                var stampFontSize = cinzelStamp.HasValue ? VerseFontSize : ImGui.GetFontSize();
+                var stampFontSize = cinzelStamp.HasValue ? cinzelStamp.Value.FontSize : ImGui.GetFontSize();
                 var stampRawSize = ImGui.CalcTextSize(stamp);
                 var stampScale = stampFontSize / ImGui.GetFontSize();
                 var stampSize = new Vector2(stampRawSize.X * stampScale,

--- a/DivineAscension/GUI/UI/Renderers/Utilities/ChromeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/ChromeRenderer.cs
@@ -140,9 +140,9 @@ internal static class ChromeRenderer
         if (serif.HasValue)
         {
             var font = serif.Value;
-            ImGui.PushFont(font);
-            var glyphSize = ImGui.CalcTextSize(letterText);
-            ImGui.PopFont();
+            // Measure at the baked size (corrected for FontGlobalScale) so the
+            // glyph centres in the box instead of drifting top-left (#588).
+            var glyphSize = TextRenderer.MeasureBakedSerif(font, letterText);
             var glyphX = x + (DropCapSize - glyphSize.X) / 2f;
             var glyphY = y + (DropCapSize - glyphSize.Y) / 2f;
             drawList.AddText(font, font.FontSize, new Vector2(glyphX, glyphY), letterColor, letterText);

--- a/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
+++ b/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
@@ -55,9 +55,7 @@ public static class TextRenderer
         if (serif.HasValue)
         {
             var font = serif.Value;
-            ImGui.PushFont(font);
-            var width = ImGui.CalcTextSize(text).X;
-            ImGui.PopFont();
+            var width = MeasureBakedSerif(font, text).X;
             drawList.AddText(font, font.FontSize, new Vector2(x, y), textColor, text);
             return width;
         }
@@ -76,12 +74,28 @@ public static class TextRenderer
         var serif = CinzelFontSystem.GetRegular(CinzelFontSystem.NearestBakedSize((int)fontSize));
         if (serif.HasValue)
         {
-            ImGui.PushFont(serif.Value);
-            var width = ImGui.CalcTextSize(text).X;
-            ImGui.PopFont();
-            return width;
+            return MeasureBakedSerif(serif.Value, text).X;
         }
         return ImGui.CalcTextSize(text).X * (fontSize / ImGui.GetFontSize());
+    }
+
+    /// <summary>
+    ///     Measure <paramref name="text" /> in <paramref name="font" /> at its baked
+    ///     size, removing the <c>FontGlobalScale</c> inflation that
+    ///     <see cref="ImGui.CalcTextSize(string)" /> applies while a font is pushed.
+    ///     The result matches an explicit-size <c>AddText(font, font.FontSize, …)</c>
+    ///     draw, which ignores the global scale. Without this correction, serif
+    ///     glyphs drawn at a baked size are over-measured by <c>UiScale.Factor</c>
+    ///     under <see cref="UiScale.BeginFontScale" />, pulling centred or
+    ///     right-anchored layout toward the top-left (#588).
+    /// </summary>
+    public static Vector2 MeasureBakedSerif(ImGuiNET.ImFontPtr font, string text)
+    {
+        ImGui.PushFont(font);
+        var size = ImGui.CalcTextSize(text);
+        ImGui.PopFont();
+        var globalScale = ImGui.GetIO().FontGlobalScale;
+        return globalScale > 0f ? size / globalScale : size;
     }
 
     /// <summary>

--- a/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
+++ b/DivineAscension/GUI/UI/Utilities/TextRenderer.cs
@@ -51,7 +51,7 @@ public static class TextRenderer
         Vector4? color = null)
     {
         var textColor = ImGui.ColorConvertFloat4ToU32(color ?? ColorPalette.White);
-        var serif = CinzelFontSystem.GetRegular(NearestBakedSize((int)fontSize));
+        var serif = CinzelFontSystem.GetRegular(CinzelFontSystem.NearestBakedSize((int)fontSize));
         if (serif.HasValue)
         {
             var font = serif.Value;
@@ -73,7 +73,7 @@ public static class TextRenderer
     /// </summary>
     public static float MeasureSerifLabel(string text, float fontSize)
     {
-        var serif = CinzelFontSystem.GetRegular(NearestBakedSize((int)fontSize));
+        var serif = CinzelFontSystem.GetRegular(CinzelFontSystem.NearestBakedSize((int)fontSize));
         if (serif.HasValue)
         {
             ImGui.PushFont(serif.Value);
@@ -82,24 +82,6 @@ public static class TextRenderer
             return width;
         }
         return ImGui.CalcTextSize(text).X * (fontSize / ImGui.GetFontSize());
-    }
-
-    private static int NearestBakedSize(int requested)
-    {
-        // VSImGui's default font sizes (FontManager.Sizes).
-        ReadOnlySpan<int> baked = stackalloc int[] { 6, 8, 10, 14, 18, 24, 30, 36, 48, 60 };
-        var best = baked[0];
-        var bestDelta = int.MaxValue;
-        foreach (var s in baked)
-        {
-            var delta = System.Math.Abs(s - requested);
-            if (delta < bestDelta)
-            {
-                best = s;
-                bestDelta = delta;
-            }
-        }
-        return best;
     }
 
     /// <summary>

--- a/DivineAscension/Services/UI/CinzelFontSystem.cs
+++ b/DivineAscension/Services/UI/CinzelFontSystem.cs
@@ -120,8 +120,32 @@ public class CinzelFontSystem : ModSystem
     }
 
     // VSImGui generates fonts at sizes registered in FontManager.Sizes
-    // (defaults: 6, 8, 10, 14, 18, 24, 30, 36, 48, 60). Lookup returns null
-    // until the atlas is built so callers can fall back to the default font.
+    // (defaults below). Lookup returns null until the atlas is built so callers
+    // can fall back to the default font.
+    public static readonly int[] BakedSizes = { 6, 8, 10, 14, 18, 24, 30, 36, 48, 60 };
+
+    /// <summary>
+    ///     Snap a requested pixel size (e.g. a UI-scaled base size) to the nearest
+    ///     size the atlas actually baked. Callers draw crisply at that size rather
+    ///     than upscaling one baked glyph. Single source of truth for the ladder —
+    ///     shared by the serif text helpers and the chrome's direct callers.
+    /// </summary>
+    public static int NearestBakedSize(int requested)
+    {
+        var best = BakedSizes[0];
+        var bestDelta = int.MaxValue;
+        foreach (var s in BakedSizes)
+        {
+            var delta = Math.Abs(s - requested);
+            if (delta < bestDelta)
+            {
+                best = s;
+                bestDelta = delta;
+            }
+        }
+        return best;
+    }
+
     public static ImFontPtr? GetRegular(int size) => Lookup(RegularName, size);
 
     public static ImFontPtr? GetBold(int size) => Lookup(BoldName, size);


### PR DESCRIPTION
Part of epic #584. Last chrome piece — makes serif chapter/title labels scale with the UI.

## Problem

The chrome's serif labels requested **fixed** baked sizes (`ChapterFontSize` 18, `TitleFontSize` 24, verse 13) directly from `CinzelFontSystem`, bypassing `UiScale`. So at GUIScale > 1 they stayed small inside the already-scaled chrome (#589) and matching implicit text (#601) — the last "small text in big box" holdout.

## Fix

Route the chrome's **direct** Cinzel callers through `UiScale.Scaled()` snapped to the nearest baked atlas size, and draw at the resolved font's actual `FontSize` (crisp baked glyph, not an upscaled one):

```
GetRegular(CinzelFontSystem.NearestBakedSize((int)UiScale.Scaled(baseSize)))
```

Covers: title strip title, sidebar chapter header, sidebar verse numerals, collapsed-strip stamps.

Centralised the bake ladder + `NearestBakedSize` onto `CinzelFontSystem` (single source of truth) and removed the private duplicate in `TextRenderer`. `DrawSerifLabel`/`MeasureSerifLabel` already scaled (they snap the scaled `FontSizes` value), so content-pane serif headings were already covered — this was only the direct callers.

## Why snap-to-nearest (not bake exact scaled sizes)

The atlas bakes once at startup; snapping handles **runtime** GUIScale changes with no rebake. The ladder (`6/8/10/14/18/24/30/36/48/60`) hits exactly at ×2 (18→36, 24→48) and within a few px at ×1.25/×1.5 — crisp over exact. Stepping on serif headings is imperceptible vs. the blur of upscaling one glyph.

## Out of scope (deferred)

The **drop-cap** glyph (`ChromeRenderer`) is sized to a fixed layout box in content panes whose geometry isn't scaled yet — scaling the glyph alone would overflow the box. It scales with its layout area (#599/#600).

## Tests

`NearestBakedSize` is now a pure function — added 16 cases (exact, nearest, tie-break-to-smaller, clamp below/above ladder). Full suite: **2515 passed**. Build clean.

## Manual test

GUIScale 1 vs 2 (Settings → Graphics → GUI Scale), reopen (Shift+G): "Divine Ascension" title and sidebar "Chapter I" headers now grow with the UI. After this, the whole **chrome** is fully scaled; only leaf content-pane layout remains (#595–600).

Closes #588