### PR TITLE
feat(ui): scale ImGui style metrics with the UI (#605)

### DIFF
--- a/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
+++ b/DivineAscension/GUI/Caravan/CaravanTradeDialog.cs
@@ -106,6 +106,7 @@ public class CaravanTradeDialog : ModSystem
     private void DrawWindow()
     {
         using var fontScale = UiScale.BeginFontScale();
+        using var styleScale = UiScale.BeginStyleScale();
 
         var width = MathF.Min(WindowWidth, _viewport.Size.X - 64f);
         var height = MathF.Min(WindowHeight, _viewport.Size.Y - 64f);

--- a/DivineAscension/GUI/GuiDialog.cs
+++ b/DivineAscension/GUI/GuiDialog.cs
@@ -323,6 +323,7 @@ public partial class GuiDialog : ModSystem
 
         UiScale.SyncFromGameSettings();
         using var fontScale = UiScale.BeginFontScale();
+        using var styleScale = UiScale.BeginStyleScale();
 
         // Toast anchors to the bottom-right of the full viewport.
         var windowWidth = _viewport.Size.X;
@@ -384,6 +385,7 @@ public partial class GuiDialog : ModSystem
         // Scale implicit-font text + CalcTextSize in this window and its children
         // with the UI scale; restored when the scope disposes at method end.
         using var fontScale = UiScale.BeginFontScale();
+        using var styleScale = UiScale.BeginStyleScale();
 
         var window = _capi!.Gui.WindowBounds;
         var deltaTime = _stopwatch!.ElapsedMilliseconds / 1000f;

--- a/DivineAscension/GUI/UI/Utilities/UiScale.cs
+++ b/DivineAscension/GUI/UI/Utilities/UiScale.cs
@@ -113,4 +113,41 @@ internal static class UiScale
 
         public void Dispose() => ImGui.GetIO().FontGlobalScale = _previous;
     }
+
+    /// <summary>
+    ///     Scale ImGui's spacing/size style metrics by <see cref="Factor" /> for the
+    ///     duration of the returned scope. Native widgets (Button, Checkbox,
+    ///     InputText, Selectable, scrollbars) size their frames from font size PLUS
+    ///     these metrics, and <see cref="BeginFontScale" /> only scales the font —
+    ///     so without this, scaled text sits in unscaled frames with tight spacing.
+    ///
+    ///     <para>
+    ///     Reads the live base values (whatever VSImGui set) and pushes them times
+    ///     <see cref="Factor" />, then pops on dispose — no global mutation, no
+    ///     cumulative drift across frames. Use with <c>using</c> alongside
+    ///     <see cref="BeginFontScale" /> at the top of a dialog draw. Rounding radii
+    ///     are intentionally left alone (the dialog zeroes window/frame rounding).
+    ///     </para>
+    /// </summary>
+    public static StyleScaleScope BeginStyleScale() => new(_factor);
+
+    /// <summary>RAII scope that pushes scaled style vars and pops them. See <see cref="BeginStyleScale" />.</summary>
+    public readonly ref struct StyleScaleScope
+    {
+        private const int PushedCount = 7;
+
+        internal StyleScaleScope(float scale)
+        {
+            var s = ImGui.GetStyle();
+            ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, s.FramePadding * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, s.ItemSpacing * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.ItemInnerSpacing, s.ItemInnerSpacing * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.CellPadding, s.CellPadding * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.IndentSpacing, s.IndentSpacing * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.ScrollbarSize, s.ScrollbarSize * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.GrabMinSize, s.GrabMinSize * scale);
+        }
+
+        public void Dispose() => ImGui.PopStyleVar(PushedCount);
+    }
 }


### PR DESCRIPTION
Part of epic #584. Foundational gap found during the controls-scaling audit — every native ImGui widget depends on it, so it lands before the leaf-area control work (#599, #595–600) to avoid reworking those twice.

## Problem

`io.FontGlobalScale` (#601) scales native-widget *text* and `CalcTextSize`, but ImGui's **style metrics** stayed at their unscaled defaults — no `PushStyleVar` for them, no `ScaleAllSizes`. Native widgets size their frames from font size **plus** these metrics, so at GUIScale > 1 they showed big text in small frames with tight spacing: `Button`/`Checkbox`/`InputText`/`Selectable`, scrollbars, `SameLine`/`Indent` gaps.

## Fix

`UiScale.BeginStyleScale()` — a `using`-scope that reads the **live base** style (whatever VSImGui set) and pushes `FramePadding`, `ItemSpacing`, `ItemInnerSpacing`, `CellPadding`, `IndentSpacing`, `ScrollbarSize`, `GrabMinSize` × `Factor`, popping on dispose. Applied alongside `BeginFontScale()` in the three dialog draws (main, notification overlay, caravan).

### Why `PushStyleVar`, not `ScaleAllSizes`

`ScaleAllSizes` mutates the global style multiplicatively and isn't cleanly reversible → would compound every frame and need a base-snapshot + restore. `PushStyleVar`/`PopStyleVar` is scoped, auto-restoring, and reads the base fresh each frame → no global mutation, no cumulative drift. Push/pop ordering is LIFO-correct with the dialogs' existing window-style pushes (verified).

### Notes

- Rounding radii intentionally untouched (the dialog already zeroes window/frame rounding; other roundings are cosmetic).
- At **Factor 1.0** the pushed values equal the base → default-scale users see **no change**; only GUIScale > 1 is affected.
- As a bonus, `NotificationFeedRenderer`'s manual layout that reads `style.FramePadding/ItemSpacing` now auto-scales (it reads the pushed values).

## Tests

`BeginStyleScale` calls ImGui (needs cimgui native, unavailable headless) → verified by build + manual, consistent with `BeginFontScale`. Full suite: **2515 passed**, build clean.

## Manual test

GUIScale 1 vs 2: native controls (notification overlay "Clear" button + checkbox, text-input fields in create forms) should now have frame padding and spacing proportional to their text, not cramped.

Closes #605