### PR TITLE
feat(ui): scale input-control layout (search/roster/diplomacy) (#599)

### DIFF
--- a/DivineAscension/GUI/UI/Components/Buttons/ButtonRenderer.cs
+++ b/DivineAscension/GUI/UI/Components/Buttons/ButtonRenderer.cs
@@ -67,16 +67,16 @@ internal static class ButtonRenderer
         }
 
         var bgColorU32 = ImGui.ColorConvertFloat4ToU32(bgColor);
-        drawList.AddRectFilled(buttonStart, buttonEnd, bgColorU32, 4f);
+        drawList.AddRectFilled(buttonStart, buttonEnd, bgColorU32, UiScale.Scaled(4f));
 
         // Issue #71: Use BorderColor from palette, consistent 2px border width
         var borderColor = ImGui.ColorConvertFloat4ToU32(enabled ? ColorPalette.Gold * 0.7f : ColorPalette.BorderColor);
-        drawList.AddRect(buttonStart, buttonEnd, borderColor, 4f, ImDrawFlags.None, 2f);
-        // Icon rendering constants
-        const float iconSize = 20f;
-        const float leftPadding = 8f;
-        const float iconSpacing = 6f;
-        const float rightPadding = 8f;
+        drawList.AddRect(buttonStart, buttonEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
+        // Icon rendering constants (scaled with the UI)
+        var iconSize = UiScale.Scaled(20f);
+        var leftPadding = UiScale.Scaled(8f);
+        var iconSpacing = UiScale.Scaled(6f);
+        var rightPadding = UiScale.Scaled(8f);
 
         if (directoryPath != "" && iconName != "")
         {

--- a/DivineAscension/GUI/UI/Components/Inputs/Dropdown.cs
+++ b/DivineAscension/GUI/UI/Components/Inputs/Dropdown.cs
@@ -20,8 +20,8 @@ internal static class Dropdown
     private static Vector2 _scrollAnchor;
     private static float _scrollY;
 
-    private const float ScrollbarGutterWidth = 6f;
-    private const float ScrollbarTrackPadding = 2f;
+    private static float ScrollbarGutterWidth => UiScale.Scaled(6f);
+    private static float ScrollbarTrackPadding => UiScale.Scaled(2f);
 
     /// <summary>
     ///     Draw a dropdown button (without the menu)
@@ -71,7 +71,7 @@ internal static class Dropdown
         var scaledTextSize = ImGui.CalcTextSize(selectedText);
         ImGui.SetWindowFontScale(1f);
 
-        var textPos = new Vector2(x + 12f, y + (height - scaledTextSize.Y) / 2);
+        var textPos = new Vector2(x + UiScale.Scaled(12f), y + (height - scaledTextSize.Y) / 2);
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.LightText);
 
         ImGui.SetWindowFontScale(fontScale);
@@ -79,23 +79,25 @@ internal static class Dropdown
         ImGui.SetWindowFontScale(1f);
 
         // Draw dropdown arrow
-        var arrowX = x + width - 20f;
+        var arrowX = x + width - UiScale.Scaled(20f);
         var arrowY = y + height / 2;
+        var arrowH = UiScale.Scaled(4f);
+        var arrowHalf = UiScale.Scaled(2f);
         var arrowColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
         if (isOpen)
             // Arrow pointing up when open
             drawList.AddTriangleFilled(
-                new Vector2(arrowX, arrowY - 4f),
-                new Vector2(arrowX - 4f, arrowY + 2f),
-                new Vector2(arrowX + 4f, arrowY + 2f),
+                new Vector2(arrowX, arrowY - arrowH),
+                new Vector2(arrowX - arrowH, arrowY + arrowHalf),
+                new Vector2(arrowX + arrowH, arrowY + arrowHalf),
                 arrowColor
             );
         else
             // Arrow pointing down when closed
             drawList.AddTriangleFilled(
-                new Vector2(arrowX - 4f, arrowY - 2f),
-                new Vector2(arrowX + 4f, arrowY - 2f),
-                new Vector2(arrowX, arrowY + 4f),
+                new Vector2(arrowX - arrowH, arrowY - arrowHalf),
+                new Vector2(arrowX + arrowH, arrowY - arrowHalf),
+                new Vector2(arrowX, arrowY + arrowH),
                 arrowColor
             );
 
@@ -214,13 +216,14 @@ internal static class Dropdown
         float height,
         string[] items,
         int selectedIndex,
-        float itemHeight = 40f,
+        float itemHeight = -1f,
         float fontSize = -1f,
         int maxVisibleItems = 8)
     {
         if (fontSize < 0f) fontSize = FontSizes.Body;
+        if (itemHeight < 0f) itemHeight = UiScale.Scaled(40f);
         var mousePos = ImGui.GetMousePos();
-        var menuTop = y + height + 2f;
+        var menuTop = y + height + UiScale.Scaled(2f);
         var menuStart = new Vector2(x, menuTop);
         var contentHeight = items.Length * itemHeight;
         var visibleHeight = MathF.Min(items.Length, MathF.Max(1, maxVisibleItems)) * itemHeight;
@@ -231,9 +234,9 @@ internal static class Dropdown
         // Menu background + border (sized to the visible window, not the full
         // content height — the rest scrolls inside).
         var menuBgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Background);
-        drawList.AddRectFilled(menuStart, menuEnd, menuBgColor, 4f);
+        drawList.AddRectFilled(menuStart, menuEnd, menuBgColor, UiScale.Scaled(4f));
         var menuBorderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.7f);
-        drawList.AddRect(menuStart, menuEnd, menuBorderColor, 4f, ImDrawFlags.None, 2f);
+        drawList.AddRect(menuStart, menuEnd, menuBorderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
         // Clip rendering to the visible menu rect so off-screen items don't
         // bleed outside the border when scrolled.
@@ -264,7 +267,7 @@ internal static class Dropdown
             var itemTextSize = ImGui.CalcTextSize(items[i]);
             ImGui.SetWindowFontScale(1f);
 
-            var itemTextPos = new Vector2(x + 12f, itemY + (itemHeight - itemTextSize.Y) / 2);
+            var itemTextPos = new Vector2(x + UiScale.Scaled(12f), itemY + (itemHeight - itemTextSize.Y) / 2);
             var itemOnDark = isItemHovering || i == selectedIndex;
             var itemTextColor = ImGui.ColorConvertFloat4ToU32(
                 itemOnDark ? ColorPalette.LightText : ColorPalette.White);
@@ -285,14 +288,14 @@ internal static class Dropdown
             var trackTop = menuTop + ScrollbarTrackPadding;
             var trackBottom = menuEnd.Y - ScrollbarTrackPadding;
             var trackHeight = trackBottom - trackTop;
-            var thumbHeight = MathF.Max(16f, trackHeight * (visibleHeight / contentHeight));
+            var thumbHeight = MathF.Max(UiScale.Scaled(16f), trackHeight * (visibleHeight / contentHeight));
             var thumbTop = trackTop + (trackHeight - thumbHeight) * (scrollY / maxScroll);
 
             drawList.AddRectFilled(new Vector2(trackLeft, trackTop), new Vector2(trackRight, trackBottom),
-                ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.4f), 2f);
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.4f), UiScale.Scaled(2f));
             drawList.AddRectFilled(new Vector2(trackLeft, thumbTop),
                 new Vector2(trackRight, thumbTop + thumbHeight),
-                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.7f), 2f);
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.7f), UiScale.Scaled(2f));
         }
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationBrowseRenderer.cs
@@ -26,30 +26,30 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationBrowseRenderer
 {
-    private const float ProseLineHeight = 18f;
-    private const float ProseBottomSpacing = 12f;
-    private const float SearchRowHeight = 26f;
-    private const float SearchRowBottomSpacing = 6f;
-    private const float FilterRowHeight = 26f;
-    private const float FilterRowBottomSpacing = 8f;
-    private const float FilterChipGap = 10f;
-    private const float FilterChipPaddingX = 8f;
-    private const float ActiveMarkerSize = 4f;
-    private const float ActiveMarkerGap = 6f;
-    private const float RefreshGlyphSize = 24f;
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float RowLine1Height = 26f;
-    private const float RowLine2Spacing = 2f;
-    private const float RowGap = 10f;
-    private const float DescriptionIndent = 24f;
-    private const float RowOrnamentSize = 5f;
-    private const float RowOrnamentGap = 10f;
-    private const float ChevronSize = 10f;
-    private const float ChevronGap = 8f;
-    private const float CounterTopSpacing = 8f;
-    private const float CounterHeight = 22f;
-    private const float ScrollbarWidth = 16f;
+    private static float ProseLineHeight => UiScale.Scaled(18f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float SearchRowHeight => UiScale.Scaled(26f);
+    private static float SearchRowBottomSpacing => UiScale.Scaled(6f);
+    private static float FilterRowHeight => UiScale.Scaled(26f);
+    private static float FilterRowBottomSpacing => UiScale.Scaled(8f);
+    private static float FilterChipGap => UiScale.Scaled(10f);
+    private static float FilterChipPaddingX => UiScale.Scaled(8f);
+    private static float ActiveMarkerSize => UiScale.Scaled(4f);
+    private static float ActiveMarkerGap => UiScale.Scaled(6f);
+    private static float RefreshGlyphSize => UiScale.Scaled(24f);
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float RowLine1Height => UiScale.Scaled(26f);
+    private static float RowLine2Spacing => UiScale.Scaled(2f);
+    private static float RowGap => UiScale.Scaled(10f);
+    private static float DescriptionIndent => UiScale.Scaled(24f);
+    private static float RowOrnamentSize => UiScale.Scaled(5f);
+    private static float RowOrnamentGap => UiScale.Scaled(10f);
+    private static float ChevronSize => UiScale.Scaled(10f);
+    private static float ChevronGap => UiScale.Scaled(8f);
+    private static float CounterTopSpacing => UiScale.Scaled(8f);
+    private static float CounterHeight => UiScale.Scaled(22f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
 
     public static CivilizationBrowseRenderResult Draw(
         CivilizationBrowseViewModel viewModel,
@@ -164,7 +164,7 @@ internal static class CivilizationBrowseRenderer
         var rowCenterY = y + FilterRowHeight / 2f;
         drawList.AddText(new Vector2(x, rowCenterY - labelSize.Y / 2f), labelColor, label);
 
-        var cursor = x + labelSize.X + 16f;
+        var cursor = x + labelSize.X + UiScale.Scaled(16f);
 
         var refreshX = x + width - RefreshGlyphSize;
         var refreshY = y + (FilterRowHeight - RefreshGlyphSize) / 2f;
@@ -184,8 +184,8 @@ internal static class CivilizationBrowseRenderer
             var chipWidth = FilterChipPaddingX + markerWidth + chipSize.X + FilterChipPaddingX;
             if (cursor + chipWidth > chipLimitX) break;
 
-            var chipMinY = y + (FilterRowHeight - chipSize.Y) / 2f - 2f;
-            var chipMaxY = chipMinY + chipSize.Y + 4f;
+            var chipMinY = y + (FilterRowHeight - chipSize.Y) / 2f - UiScale.Scaled(2f);
+            var chipMaxY = chipMinY + chipSize.Y + UiScale.Scaled(4f);
             var chipMin = new Vector2(cursor, chipMinY);
             var chipMax = new Vector2(cursor + chipWidth, chipMaxY);
 
@@ -196,9 +196,9 @@ internal static class CivilizationBrowseRenderer
             {
                 var underlineColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.55f);
                 drawList.AddLine(
-                    new Vector2(chipMin.X + 2f, chipMaxY + 1f),
-                    new Vector2(chipMax.X - 2f, chipMaxY + 1f),
-                    underlineColor, 1f);
+                    new Vector2(chipMin.X + UiScale.Scaled(2f), chipMaxY + UiScale.Scaled(1f)),
+                    new Vector2(chipMax.X - UiScale.Scaled(2f), chipMaxY + UiScale.Scaled(1f)),
+                    underlineColor, UiScale.Scaled(1f));
             }
 
             if (isHover) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -271,7 +271,7 @@ internal static class CivilizationBrowseRenderer
             var t = i / (float)segments;
             var a = arcStart + arcSweep * t;
             var p = new Vector2(cx + MathF.Cos(a) * r, cy + MathF.Sin(a) * r);
-            if (i > 0) drawList.AddLine(prev, p, ink, 1.5f);
+            if (i > 0) drawList.AddLine(prev, p, ink, UiScale.Scaled(1.5f));
             prev = p;
         }
         var endA = arcStart + arcSweep;
@@ -304,7 +304,7 @@ internal static class CivilizationBrowseRenderer
             var emptyText = LocalizationService.Instance.Get(emptyKey);
             TextRenderer.DrawInfoText(drawList, emptyText, x, y, width, Body, ColorPalette.Grey);
             var measured = TextRenderer.MeasureWrappedHeight(emptyText, width, Body);
-            return y + (measured > 0 ? measured : ProseLineHeight) + 8f;
+            return y + (measured > 0 ? measured : ProseLineHeight) + UiScale.Scaled(8f);
         }
 
         var rowY = y;
@@ -331,7 +331,7 @@ internal static class CivilizationBrowseRenderer
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 var hoverBg = ImGui.ColorConvertFloat4ToU32(ColorPalette.LightBrown * 0.25f);
-                drawList.AddRectFilled(rowMin, rowMax, hoverBg, 2f);
+                drawList.AddRectFilled(rowMin, rowMax, hoverBg, UiScale.Scaled(2f));
             }
 
             DrawRowLine1(drawList, civ, x, rowY, width);
@@ -386,7 +386,7 @@ internal static class CivilizationBrowseRenderer
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(ordersX, textY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White), ordersText);
 
-        const float padding = 6f;
+        var padding = UiScale.Scaled(6f);
         var leaderStart = nameX + nameSize.X + padding;
         var leaderEnd = ordersX - padding;
         DrawLeaderDots(drawList, leaderStart, leaderEnd, textY);
@@ -424,13 +424,13 @@ internal static class CivilizationBrowseRenderer
 
         var lineColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.45f);
         var lineY = y + textSize.Y / 2f;
-        const float sideGap = 12f;
+        var sideGap = UiScale.Scaled(12f);
         if (textX - sideGap > x)
             drawList.AddLine(new Vector2(x + sideGap, lineY),
-                new Vector2(textX - sideGap, lineY), lineColor, 1f);
+                new Vector2(textX - sideGap, lineY), lineColor, UiScale.Scaled(1f));
         if (textX + textSize.X + sideGap < x + width)
             drawList.AddLine(new Vector2(textX + textSize.X + sideGap, lineY),
-                new Vector2(x + width - sideGap, lineY), lineColor, 1f);
+                new Vector2(x + width - sideGap, lineY), lineColor, UiScale.Scaled(1f));
 
         drawList.AddText(new Vector2(textX, y), color, text);
     }
@@ -445,7 +445,7 @@ internal static class CivilizationBrowseRenderer
         h += DividerHeight;
         if (vm.Civilizations.Count == 0)
         {
-            h += ProseLineHeight + 8f;
+            h += ProseLineHeight + UiScale.Scaled(8f);
         }
         else
         {

--- a/DivineAscension/GUI/UI/Renderers/Civilization/DiplomacyTabRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/DiplomacyTabRenderer.cs
@@ -31,35 +31,35 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class DiplomacyTabRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float OrnateDividerHeight = 22f;
-    private const float SectionHeadingHeight = 26f;
-    private const float ProseLineHeight = 18f;
-    private const float ProseBottomSpacing = 10f;
-    private const float ScrollbarWidth = 16f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float OrnateDividerHeight => UiScale.Scaled(22f);
+    private static float SectionHeadingHeight => UiScale.Scaled(26f);
+    private static float ProseLineHeight => UiScale.Scaled(18f);
+    private static float ProseBottomSpacing => UiScale.Scaled(10f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
 
     // Standing-accord entry geometry.
-    private const float EntryGlyphSize = 18f;
-    private const float EntryGlyphGap = 12f;
-    private const float EntryLeftPadding = 6f;
-    private const float EntryLineHeight = 20f;
-    private const float EntryActionHeight = 24f;
-    private const float EntryActionWidth = 150f;
-    private const float EntryBottomSpacing = 10f;
-    private const float SlimDividerHeight = 18f;
-    private const float SlimDividerYPadding = 4f;
+    private static float EntryGlyphSize => UiScale.Scaled(18f);
+    private static float EntryGlyphGap => UiScale.Scaled(12f);
+    private static float EntryLeftPadding => UiScale.Scaled(6f);
+    private static float EntryLineHeight => UiScale.Scaled(20f);
+    private static float EntryActionHeight => UiScale.Scaled(24f);
+    private static float EntryActionWidth => UiScale.Scaled(150f);
+    private static float EntryBottomSpacing => UiScale.Scaled(10f);
+    private static float SlimDividerHeight => UiScale.Scaled(18f);
+    private static float SlimDividerYPadding => UiScale.Scaled(4f);
 
     // Pending proposal row geometry.
-    private const float ProposalEnvelopeSize = 18f;
-    private const float ProposalGlyphGap = 10f;
-    private const float ProposalTextLeading = 4f;
-    private const float ProposalActionHeight = 22f;
-    private const float ProposalAcceptWidth = 78f;
-    private const float ProposalRefuseWidth = 78f;
-    private const float ProposalActionGap = 8f;
-    private const float ProposalRowHeight = 28f;
-    private const float ProposalRowSpacing = 4f;
+    private static float ProposalEnvelopeSize => UiScale.Scaled(18f);
+    private static float ProposalGlyphGap => UiScale.Scaled(10f);
+    private static float ProposalTextLeading => UiScale.Scaled(4f);
+    private static float ProposalActionHeight => UiScale.Scaled(22f);
+    private static float ProposalAcceptWidth => UiScale.Scaled(78f);
+    private static float ProposalRefuseWidth => UiScale.Scaled(78f);
+    private static float ProposalActionGap => UiScale.Scaled(8f);
+    private static float ProposalRowHeight => UiScale.Scaled(28f);
+    private static float ProposalRowSpacing => UiScale.Scaled(4f);
 
     public static DiplomacyTabRendererResult Draw(
         DiplomacyTabViewModel vm,
@@ -257,7 +257,7 @@ internal static class DiplomacyTabRenderer
         // Right-aligned action button per status.
         var actionY = lineY;
         DrawEntryAction(drawList, rel, hasScheduledBreak, textRight, actionY, events);
-        var bottomY = actionY + EntryActionHeight + 4f;
+        var bottomY = actionY + EntryActionHeight + UiScale.Scaled(4f);
         return bottomY;
     }
 
@@ -414,9 +414,9 @@ internal static class DiplomacyTabRenderer
                 // Crossed blades — two diagonals through the centre.
                 var color = ImGui.ColorConvertFloat4ToU32(ColorPalette.Vermilion);
                 drawList.AddLine(new Vector2(cx - half, cy - half),
-                    new Vector2(cx + half, cy + half), color, 2f);
+                    new Vector2(cx + half, cy + half), color, UiScale.Scaled(2f));
                 drawList.AddLine(new Vector2(cx + half, cy - half),
-                    new Vector2(cx - half, cy + half), color, 2f);
+                    new Vector2(cx - half, cy + half), color, UiScale.Scaled(2f));
                 break;
         }
     }
@@ -429,10 +429,10 @@ internal static class DiplomacyTabRenderer
         var right = new Vector2(cx + halfSize, cy);
         var bottom = new Vector2(cx, cy + halfSize);
         var left = new Vector2(cx - halfSize, cy);
-        drawList.AddLine(top, right, col, 1.5f);
-        drawList.AddLine(right, bottom, col, 1.5f);
-        drawList.AddLine(bottom, left, col, 1.5f);
-        drawList.AddLine(left, top, col, 1.5f);
+        drawList.AddLine(top, right, col, UiScale.Scaled(1.5f));
+        drawList.AddLine(right, bottom, col, UiScale.Scaled(1.5f));
+        drawList.AddLine(bottom, left, col, UiScale.Scaled(1.5f));
+        drawList.AddLine(left, top, col, UiScale.Scaled(1.5f));
     }
 
     private static int StatusGroupOrder(DiplomaticStatus status) => status switch
@@ -494,7 +494,7 @@ internal static class DiplomacyTabRenderer
         var contentWidth = vm.Width - ChapterStripRenderer.ScrollbarGutter;
 
         // Error banner reserves a rough line + padding when present.
-        if (!string.IsNullOrEmpty(vm.ErrorMessage)) h += 48f;
+        if (!string.IsNullOrEmpty(vm.ErrorMessage)) h += UiScale.Scaled(48f);
 
         // Intro prose.
         var intro = string.IsNullOrWhiteSpace(vm.CurrentCivilizationName)
@@ -544,7 +544,7 @@ internal static class DiplomacyTabRenderer
                 && (rel.BreakScheduledDate.Value - DateTime.UtcNow).TotalSeconds > 0)
                 lines += 1;                                        // countdown line
         }
-        var h = lines * EntryLineHeight + EntryActionHeight + 4f;
+        var h = lines * EntryLineHeight + EntryActionHeight + UiScale.Scaled(4f);
         return h;
     }
 

--- a/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoActionsRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoActionsRenderer.cs
@@ -18,12 +18,12 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization.Info;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationInfoActionsRenderer
 {
-    private const float ButtonHeight = 34f;
-    private const float LeaveWidth = 140f;
-    private const float DisbandWidth = 170f;
-    private const float ButtonGap = 10f;
-    private const float DaggerSize = 14f;
-    private const float DaggerLabelPadding = 8f;
+    private static float ButtonHeight => UiScale.Scaled(34f);
+    private static float LeaveWidth => UiScale.Scaled(140f);
+    private static float DisbandWidth => UiScale.Scaled(170f);
+    private static float ButtonGap => UiScale.Scaled(10f);
+    private static float DaggerSize => UiScale.Scaled(14f);
+    private static float DaggerLabelPadding => UiScale.Scaled(8f);
 
     public static float Draw(
         CivilizationInfoViewModel vm,
@@ -52,7 +52,7 @@ internal static class CivilizationInfoActionsRenderer
             var labelSize = ImGui.CalcTextSize(disbandLabel);
             var labelRightX = cursor + (DisbandWidth + labelSize.X) / 2f;
             var daggerCx = labelRightX + DaggerLabelPadding;
-            var maxDaggerCx = cursor + DisbandWidth - DaggerSize / 2f - 4f;
+            var maxDaggerCx = cursor + DisbandWidth - DaggerSize / 2f - UiScale.Scaled(4f);
             if (daggerCx > maxDaggerCx) daggerCx = maxDaggerCx;
             ChromeRenderer.DrawDagger(drawList,
                 daggerCx,
@@ -71,6 +71,6 @@ internal static class CivilizationInfoActionsRenderer
             events.Add(new InfoEvent.LeaveClicked());
         }
 
-        return y + ButtonHeight + 6f;
+        return y + ButtonHeight + UiScale.Scaled(6f);
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoCapitalRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoCapitalRenderer.cs
@@ -23,14 +23,14 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization.Info;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationInfoCapitalRenderer
 {
-    private const float EditGlyphSize = 20f;
-    private const float InputHeight = 26f;
-    private const float ButtonHeight = 26f;
-    private const float ButtonWidth = 80f;
-    private const float ButtonGap = 8f;
-    private const float SectionBottomSpacing = 8f;
-    private const float DropdownHeight = 32f;
-    private const float DropdownMenuItemHeight = 28f;
+    private static float EditGlyphSize => UiScale.Scaled(20f);
+    private static float InputHeight => UiScale.Scaled(26f);
+    private static float ButtonHeight => UiScale.Scaled(26f);
+    private static float ButtonWidth => UiScale.Scaled(80f);
+    private static float ButtonGap => UiScale.Scaled(8f);
+    private static float SectionBottomSpacing => UiScale.Scaled(8f);
+    private static float DropdownHeight => UiScale.Scaled(32f);
+    private static float DropdownMenuItemHeight => UiScale.Scaled(28f);
 
     public readonly record struct CapitalEditLayout(bool HasDropdown, float DropdownX, float DropdownY, float DropdownWidth);
 
@@ -60,7 +60,7 @@ internal static class CivilizationInfoCapitalRenderer
             ChromeRenderer.DrawPencil(drawList,
                 glyphX + EditGlyphSize / 2f,
                 currentY + EditGlyphSize / 2f,
-                EditGlyphSize - 8f,
+                EditGlyphSize - UiScale.Scaled(8f),
                 ColorPalette.LightText);
 
             return (currentY + EditGlyphSize + SectionBottomSpacing, default);
@@ -69,7 +69,7 @@ internal static class CivilizationInfoCapitalRenderer
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_SEAT),
             x, currentY, SubsectionLabel, ColorPalette.Gold);
-        currentY += SubsectionLabel + 6f;
+        currentY += SubsectionLabel + UiScale.Scaled(6f);
 
         var newName = TextInput.Draw(drawList, "##civCapitalName",
             vm.CapitalNameText, x, currentY, width, InputHeight,
@@ -77,7 +77,7 @@ internal static class CivilizationInfoCapitalRenderer
         if (newName != vm.CapitalNameText)
             events.Add(new InfoEvent.CapitalNameChanged(newName));
 
-        currentY += InputHeight + 8f;
+        currentY += InputHeight + UiScale.Scaled(8f);
 
         var dropdownX = x;
         var dropdownY = currentY;
@@ -90,7 +90,7 @@ internal static class CivilizationInfoCapitalRenderer
             events.Add(new InfoEvent.ToggleCapitalSiteDropdown(!vm.IsCapitalSiteDropdownOpen));
         }
 
-        currentY += DropdownHeight + 8f;
+        currentY += DropdownHeight + UiScale.Scaled(8f);
 
         var rightX = x + width;
         var cancelX = rightX - ButtonWidth;

--- a/DivineAscension/GUI/UI/Renderers/Civilization/ProposeAccordRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/ProposeAccordRenderer.cs
@@ -28,19 +28,19 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class ProposeAccordRenderer
 {
-    private const float DividerHeight = 22f;
-    private const float DividerYPadding = 6f;
-    private const float SectionHeadingHeight = 24f;
-    private const float ProseLineHeight = 18f;
-    private const float ProseBottomSpacing = 12f;
-    private const float LabelToInputGap = 6f;
-    private const float DropdownWidth = 360f;
-    private const float DropdownHeight = 30f;
-    private const float DropdownBottomSpacing = 18f;
-    private const float SendButtonWidth = 180f;
-    private const float SendButtonHeight = 32f;
-    private const float SendButtonTopSpacing = 12f;
-    private const float SendButtonBottomSpacing = 6f;
+    private static float DividerHeight => UiScale.Scaled(22f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float SectionHeadingHeight => UiScale.Scaled(24f);
+    private static float ProseLineHeight => UiScale.Scaled(18f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float LabelToInputGap => UiScale.Scaled(6f);
+    private static float DropdownWidth => UiScale.Scaled(360f);
+    private static float DropdownHeight => UiScale.Scaled(30f);
+    private static float DropdownBottomSpacing => UiScale.Scaled(18f);
+    private static float SendButtonWidth => UiScale.Scaled(180f);
+    private static float SendButtonHeight => UiScale.Scaled(32f);
+    private static float SendButtonTopSpacing => UiScale.Scaled(12f);
+    private static float SendButtonBottomSpacing => UiScale.Scaled(6f);
 
     public static ProposeAccordRenderResult Draw(
         ProposeAccordViewModel vm,

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoActionsRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoActionsRenderer.cs
@@ -18,12 +18,12 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Info;
 /// </summary>
 internal static class ReligionInfoActionsRenderer
 {
-    private const float ButtonHeight = 34f;
-    private const float LeaveWidth = 140f;
-    private const float DisbandWidth = 170f;
-    private const float ButtonGap = 10f;
-    private const float DaggerSize = 14f;
-    private const float DaggerLabelPadding = 8f;
+    private static float ButtonHeight => UiScale.Scaled(34f);
+    private static float LeaveWidth => UiScale.Scaled(140f);
+    private static float DisbandWidth => UiScale.Scaled(170f);
+    private static float ButtonGap => UiScale.Scaled(10f);
+    private static float DaggerSize => UiScale.Scaled(14f);
+    private static float DaggerLabelPadding => UiScale.Scaled(8f);
 
     public static float Draw(
         ReligionInfoViewModel viewModel,
@@ -55,7 +55,7 @@ internal static class ReligionInfoActionsRenderer
             var labelRightX = cursor + (DisbandWidth + labelSize.X) / 2f;
             var daggerCx = labelRightX + DaggerLabelPadding;
             // Keep the dagger inside the button bounds even if the label is wide.
-            var maxDaggerCx = cursor + DisbandWidth - DaggerSize / 2f - 4f;
+            var maxDaggerCx = cursor + DisbandWidth - DaggerSize / 2f - UiScale.Scaled(4f);
             if (daggerCx > maxDaggerCx) daggerCx = maxDaggerCx;
             ChromeRenderer.DrawDagger(drawList,
                 daggerCx,
@@ -74,6 +74,6 @@ internal static class ReligionInfoActionsRenderer
             events.Add(new InfoEvent.LeaveClicked());
         }
 
-        return y + ButtonHeight + 6f;
+        return y + ButtonHeight + UiScale.Scaled(6f);
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionBrowseRenderer.cs
@@ -29,28 +29,28 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionBrowseRenderer
 {
-    private const float ProseLineHeight = 18f;
-    private const float ProseBottomSpacing = 12f;
-    private const float SearchRowHeight = 26f;
-    private const float SearchRowBottomSpacing = 6f;
-    private const float FilterRowHeight = 26f;
-    private const float FilterRowBottomSpacing = 8f;
-    private const float FilterChipGap = 10f;
-    private const float FilterChipPaddingX = 8f;
-    private const float ActiveMarkerSize = 4f;
-    private const float ActiveMarkerGap = 6f;
-    private const float RefreshGlyphSize = 24f;
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float RowHeight = 28f;
-    private const float RowSpacing = 4f;
-    private const float RowOrnamentSize = 5f;
-    private const float RowOrnamentGap = 10f;
-    private const float ChevronSize = 10f;
-    private const float ChevronGap = 8f;
-    private const float CounterTopSpacing = 8f;
-    private const float CounterHeight = 22f;
-    private const float ScrollbarWidth = 16f;
+    private static float ProseLineHeight => UiScale.Scaled(18f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float SearchRowHeight => UiScale.Scaled(26f);
+    private static float SearchRowBottomSpacing => UiScale.Scaled(6f);
+    private static float FilterRowHeight => UiScale.Scaled(26f);
+    private static float FilterRowBottomSpacing => UiScale.Scaled(8f);
+    private static float FilterChipGap => UiScale.Scaled(10f);
+    private static float FilterChipPaddingX => UiScale.Scaled(8f);
+    private static float ActiveMarkerSize => UiScale.Scaled(4f);
+    private static float ActiveMarkerGap => UiScale.Scaled(6f);
+    private static float RefreshGlyphSize => UiScale.Scaled(24f);
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float RowHeight => UiScale.Scaled(28f);
+    private static float RowSpacing => UiScale.Scaled(4f);
+    private static float RowOrnamentSize => UiScale.Scaled(5f);
+    private static float RowOrnamentGap => UiScale.Scaled(10f);
+    private static float ChevronSize => UiScale.Scaled(10f);
+    private static float ChevronGap => UiScale.Scaled(8f);
+    private static float CounterTopSpacing => UiScale.Scaled(8f);
+    private static float CounterHeight => UiScale.Scaled(22f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
 
     public static ReligionBrowseRenderResult Draw(
         ReligionBrowseViewModel viewModel,
@@ -182,7 +182,7 @@ internal static class ReligionBrowseRenderer
         var rowCenterY = y + FilterRowHeight / 2f;
         drawList.AddText(new Vector2(x, rowCenterY - labelSize.Y / 2f), labelColor, label);
 
-        var cursor = x + labelSize.X + 16f;
+        var cursor = x + labelSize.X + UiScale.Scaled(16f);
 
         // Refresh glyph anchored at right edge of contentWidth (scrollbar gutter
         // already reserved by the caller).
@@ -204,8 +204,8 @@ internal static class ReligionBrowseRenderer
             var chipWidth = FilterChipPaddingX + markerWidth + chipSize.X + FilterChipPaddingX;
             if (cursor + chipWidth > chipLimitX) break;
 
-            var chipMinY = y + (FilterRowHeight - chipSize.Y) / 2f - 2f;
-            var chipMaxY = chipMinY + chipSize.Y + 4f;
+            var chipMinY = y + (FilterRowHeight - chipSize.Y) / 2f - UiScale.Scaled(2f);
+            var chipMaxY = chipMinY + chipSize.Y + UiScale.Scaled(4f);
             var chipMin = new Vector2(cursor, chipMinY);
             var chipMax = new Vector2(cursor + chipWidth, chipMaxY);
 
@@ -216,9 +216,9 @@ internal static class ReligionBrowseRenderer
             {
                 var underlineColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.55f);
                 drawList.AddLine(
-                    new Vector2(chipMin.X + 2f, chipMaxY + 1f),
-                    new Vector2(chipMax.X - 2f, chipMaxY + 1f),
-                    underlineColor, 1f);
+                    new Vector2(chipMin.X + UiScale.Scaled(2f), chipMaxY + UiScale.Scaled(1f)),
+                    new Vector2(chipMax.X - UiScale.Scaled(2f), chipMaxY + UiScale.Scaled(1f)),
+                    underlineColor, UiScale.Scaled(1f));
             }
 
             if (isHover)
@@ -291,7 +291,7 @@ internal static class ReligionBrowseRenderer
             var t = i / (float)segments;
             var a = arcStart + arcSweep * t;
             var p = new Vector2(cx + MathF.Cos(a) * r, cy + MathF.Sin(a) * r);
-            if (i > 0) drawList.AddLine(prev, p, ink, 1.5f);
+            if (i > 0) drawList.AddLine(prev, p, ink, UiScale.Scaled(1.5f));
             prev = p;
         }
         var endA = arcStart + arcSweep;
@@ -324,7 +324,7 @@ internal static class ReligionBrowseRenderer
             var emptyText = LocalizationService.Instance.Get(emptyKey);
             TextRenderer.DrawInfoText(drawList, emptyText, x, y, width, Body, ColorPalette.Grey);
             var measured = TextRenderer.MeasureWrappedHeight(emptyText, width, Body);
-            return y + (measured > 0 ? measured : ProseLineHeight) + 8f;
+            return y + (measured > 0 ? measured : ProseLineHeight) + UiScale.Scaled(8f);
         }
 
         var rowY = y;
@@ -343,7 +343,7 @@ internal static class ReligionBrowseRenderer
                 hovered = religion;
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 var hoverBg = ImGui.ColorConvertFloat4ToU32(ColorPalette.LightBrown * 0.25f);
-                drawList.AddRectFilled(rowMin, rowMax, hoverBg, 2f);
+                drawList.AddRectFilled(rowMin, rowMax, hoverBg, UiScale.Scaled(2f));
             }
 
             DrawRow(drawList, religion, x, rowY, width);
@@ -408,7 +408,7 @@ internal static class ReligionBrowseRenderer
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White), domainText);
 
         // Dotted leaders between name end and domain start.
-        const float padding = 6f;
+        var padding = UiScale.Scaled(6f);
         var leaderStart = nameX + nameSize.X + padding;
         var leaderEnd = domainX - padding;
         DrawLeaderDots(drawList, leaderStart, leaderEnd, textY);
@@ -446,13 +446,13 @@ internal static class ReligionBrowseRenderer
 
         var lineColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.45f);
         var lineY = y + textSize.Y / 2f;
-        const float sideGap = 12f;
+        var sideGap = UiScale.Scaled(12f);
         if (textX - sideGap > x)
             drawList.AddLine(new Vector2(x + sideGap, lineY),
-                new Vector2(textX - sideGap, lineY), lineColor, 1f);
+                new Vector2(textX - sideGap, lineY), lineColor, UiScale.Scaled(1f));
         if (textX + textSize.X + sideGap < x + width)
             drawList.AddLine(new Vector2(textX + textSize.X + sideGap, lineY),
-                new Vector2(x + width - sideGap, lineY), lineColor, 1f);
+                new Vector2(x + width - sideGap, lineY), lineColor, UiScale.Scaled(1f));
 
         drawList.AddText(new Vector2(textX, y), color, text);
     }
@@ -466,7 +466,7 @@ internal static class ReligionBrowseRenderer
         h += FilterRowHeight + FilterRowBottomSpacing;
         h += DividerHeight;
         if (vm.Religions.Count == 0)
-            h += ProseLineHeight + 8f;
+            h += ProseLineHeight + UiScale.Scaled(8f);
         else
             h += vm.Religions.Count * (RowHeight + RowSpacing);
         h += CounterTopSpacing + CounterHeight;

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionRoleDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionRoleDetailRenderer.cs
@@ -41,9 +41,9 @@ internal static class ReligionRoleDetailRenderer
         // Back button (like civilization detail view)
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLE_DETAIL_BACK),
-                x, currentY, 160f, 32f))
+                x, currentY, UiScale.Scaled(160f), UiScale.Scaled(32f)))
             events.Add(new RoleDetailEvent.BackToRolesClicked());
-        currentY += 42f;
+        currentY += UiScale.Scaled(42f);
 
         // Title — shared chapter strip, positioned below the Back button.
         var strip = ChapterStripRenderer.Draw(drawList, x, currentY, width, 0f,
@@ -62,8 +62,8 @@ internal static class ReligionRoleDetailRenderer
         }
 
         // Draw members list with dropdowns
-        var dropdownWidth = 180f;
-        var dropdownHeight = 28f;
+        var dropdownWidth = UiScale.Scaled(180f);
+        var dropdownHeight = UiScale.Scaled(28f);
         var assignableRoles = viewModel.GetAssignableRoles();
         string? openDropdownMemberUID = null;
 
@@ -78,8 +78,8 @@ internal static class ReligionRoleDetailRenderer
                 : LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLE_DETAIL_NO_ROLE);
 
             // Member name on left
-            TextRenderer.DrawInfoText(drawList, $"- {memberName}", x, currentY + 4f,
-                width - dropdownWidth - 10f, TableHeader);
+            TextRenderer.DrawInfoText(drawList, $"- {memberName}", x, currentY + UiScale.Scaled(4f),
+                width - dropdownWidth - UiScale.Scaled(10f), TableHeader);
 
             // Role dropdown or static text on right
             if (viewModel.CanAssignRoleToMember(memberUID))
@@ -105,10 +105,11 @@ internal static class ReligionRoleDetailRenderer
                         ? LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLE_DETAIL_FOUNDER_ROLE)
                         : "";
                 TextRenderer.DrawInfoText(drawList, memberRoleName + reason,
-                    x + width - dropdownWidth - 10f, currentY + 4f, dropdownWidth + 10f);
+                    x + width - dropdownWidth - UiScale.Scaled(10f), currentY + UiScale.Scaled(4f),
+                    dropdownWidth + UiScale.Scaled(10f));
             }
 
-            currentY += 32f;
+            currentY += UiScale.Scaled(32f);
         }
 
         // Draw open dropdown menu (after all buttons for proper z-ordering)
@@ -117,7 +118,7 @@ internal static class ReligionRoleDetailRenderer
             var memberUID = openDropdownMemberUID;
             var dropdownX = x + width - dropdownWidth;
             var memberIndex = membersWithRole.IndexOf(memberUID);
-            var dropdownY = y + 42f + PaneHeaderRenderer.TotalHeight + memberIndex * 32f;
+            var dropdownY = y + UiScale.Scaled(42f) + PaneHeaderRenderer.TotalHeight + memberIndex * UiScale.Scaled(32f);
             var memberRoleUID = viewModel.MemberRoles.GetValueOrDefault(memberUID);
             var currentRoleIndex = memberRoleUID != null
                 ? assignableRoles.ToList().FindIndex(r => r.RoleUID == memberRoleUID)
@@ -127,12 +128,12 @@ internal static class ReligionRoleDetailRenderer
 
             // Draw menu visual with larger font (pass button position, not menu position - component handles offset)
             Dropdown.DrawMenuVisual(drawList, dropdownX, dropdownY, dropdownWidth,
-                dropdownHeight, roleNames, currentRoleIndex, 32f, SubsectionLabel);
+                dropdownHeight, roleNames, currentRoleIndex, UiScale.Scaled(32f), SubsectionLabel);
 
             // Handle menu interaction
             var (selectedIndex, shouldClose, clickConsumed) = Dropdown.DrawMenuAndHandleInteraction(
                 dropdownX, dropdownY, dropdownWidth, dropdownHeight,
-                roleNames, currentRoleIndex, 32f);
+                roleNames, currentRoleIndex, UiScale.Scaled(32f));
 
             if (selectedIndex != currentRoleIndex && selectedIndex >= 0)
             {

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionRolesBrowseRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionRolesBrowseRenderer.cs
@@ -31,22 +31,22 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionRolesBrowseRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float RowLine1Height = 24f;
-    private const float RowLine2Height = 22f;
-    private const float RowBottomSpacing = 10f;
-    private const float RowHeight = RowLine1Height + RowLine2Height + RowBottomSpacing;
-    private const float PencilSize = 22f;
-    private const float BadgeGap = 10f;
-    private const float DiamondInset = 6f;
-    private const float NameInset = 16f;
-    private const float ScrollbarWidth = 16f;
-    private const float InscribeLabelHeight = 22f;
-    private const float InscribeInputHeight = 30f;
-    private const float InscribeButtonHeight = 30f;
-    private const float InscribeButtonWidth = 140f;
-    private const float InscribeGap = 8f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float RowLine1Height => UiScale.Scaled(24f);
+    private static float RowLine2Height => UiScale.Scaled(22f);
+    private static float RowBottomSpacing => UiScale.Scaled(10f);
+    private static float RowHeight => RowLine1Height + RowLine2Height + RowBottomSpacing;
+    private static float PencilSize => UiScale.Scaled(22f);
+    private static float BadgeGap => UiScale.Scaled(10f);
+    private static float DiamondInset => UiScale.Scaled(6f);
+    private static float NameInset => UiScale.Scaled(16f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float InscribeLabelHeight => UiScale.Scaled(22f);
+    private static float InscribeInputHeight => UiScale.Scaled(30f);
+    private static float InscribeButtonHeight => UiScale.Scaled(30f);
+    private static float InscribeButtonWidth => UiScale.Scaled(140f);
+    private static float InscribeGap => UiScale.Scaled(8f);
     private const string LeaderDot = "·";
 
     public static ReligionRolesBrowseRenderResult Draw(
@@ -64,7 +64,7 @@ internal static class ReligionRolesBrowseRenderer
         {
             TextRenderer.DrawInfoText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_LOADING),
-                x, currentY + 8f, width, Secondary, ColorPalette.Grey);
+                x, currentY + UiScale.Scaled(8f), width, Secondary, ColorPalette.Grey);
             return new ReligionRolesBrowseRenderResult(events, height);
         }
 
@@ -72,7 +72,7 @@ internal static class ReligionRolesBrowseRenderer
         {
             TextRenderer.DrawInfoText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_NOT_IN_RELIGION),
-                x, currentY + 8f, width, Secondary, ColorPalette.Grey);
+                x, currentY + UiScale.Scaled(8f), width, Secondary, ColorPalette.Grey);
             return new ReligionRolesBrowseRenderResult(events, height);
         }
 
@@ -80,7 +80,7 @@ internal static class ReligionRolesBrowseRenderer
         {
             var errorMsg = viewModel.RolesData?.ErrorMessage ??
                            LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_FAILED);
-            TextRenderer.DrawInfoText(drawList, errorMsg, x, currentY + 8f, width, Secondary, ColorPalette.Grey);
+            TextRenderer.DrawInfoText(drawList, errorMsg, x, currentY + UiScale.Scaled(8f), width, Secondary, ColorPalette.Grey);
             return new ReligionRolesBrowseRenderResult(events, height);
         }
 
@@ -114,7 +114,7 @@ internal static class ReligionRolesBrowseRenderer
         // Prose intro on parchment → iron-gall ink.
         var intro = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_CHAPTER_INTRO);
         TextRenderer.DrawInfoText(drawList, intro, x, currentY, contentWidth, Body, ColorPalette.White);
-        currentY += MathF.Max(TextRenderer.MeasureWrappedHeight(intro, contentWidth, Body), 20f) + 8f;
+        currentY += MathF.Max(TextRenderer.MeasureWrappedHeight(intro, contentWidth, Body), UiScale.Scaled(20f)) + UiScale.Scaled(8f);
 
         currentY = DrawDivider(drawList, x, currentY, contentWidth);
 
@@ -162,8 +162,8 @@ internal static class ReligionRolesBrowseRenderer
         var nameColor = role.RoleUID == RoleDefaults.FOUNDER_ROLE_ID
             ? ColorPalette.Vermilion
             : ColorPalette.White;
-        ChromeRenderer.DrawDiamond(drawList, x + DiamondInset, midY, 4f, ColorPalette.Gold);
-        TextRenderer.DrawLabel(drawList, role.RoleName, x + NameInset, line1Y + 2f, Body, nameColor);
+        ChromeRenderer.DrawDiamond(drawList, x + DiamondInset, midY, UiScale.Scaled(4f), ColorPalette.Gold);
+        TextRenderer.DrawLabel(drawList, role.RoleName, x + NameInset, line1Y + UiScale.Scaled(2f), Body, nameColor);
         var nameWidth = ImGui.CalcTextSize(role.RoleName).X;
 
         // Optional badge after the name — protected (rubric), default (gold leaf).
@@ -172,18 +172,18 @@ internal static class ReligionRolesBrowseRenderer
         if (role.IsProtected)
         {
             var badge = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_BADGE_PROTECTED);
-            ChromeRenderer.DrawDiamond(drawList, badgeStart + 4f, midY, 3f, ColorPalette.Vermilion);
-            drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(badgeStart + 12f, line1Y + 4f),
+            ChromeRenderer.DrawDiamond(drawList, badgeStart + UiScale.Scaled(4f), midY, UiScale.Scaled(3f), ColorPalette.Vermilion);
+            drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(badgeStart + UiScale.Scaled(12f), line1Y + UiScale.Scaled(4f)),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Vermilion), badge);
-            badgeEnd = badgeStart + 12f + ImGui.CalcTextSize(badge).X * (Secondary / SubsectionLabel);
+            badgeEnd = badgeStart + UiScale.Scaled(12f) + ImGui.CalcTextSize(badge).X * (Secondary / SubsectionLabel);
         }
         else if (role.IsDefault)
         {
             var badge = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_BADGE_DEFAULT);
-            ChromeRenderer.DrawDiamond(drawList, badgeStart + 4f, midY, 3f, ColorPalette.Gold);
-            drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(badgeStart + 12f, line1Y + 4f),
+            ChromeRenderer.DrawDiamond(drawList, badgeStart + UiScale.Scaled(4f), midY, UiScale.Scaled(3f), ColorPalette.Gold);
+            drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(badgeStart + UiScale.Scaled(12f), line1Y + UiScale.Scaled(4f)),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), badge);
-            badgeEnd = badgeStart + 12f + ImGui.CalcTextSize(badge).X * (Secondary / SubsectionLabel);
+            badgeEnd = badgeStart + UiScale.Scaled(12f) + ImGui.CalcTextSize(badge).X * (Secondary / SubsectionLabel);
         }
 
         // Right side: pencil (if editable) then wear count, dotted leader fills the gap.
@@ -199,19 +199,19 @@ internal static class ReligionRolesBrowseRenderer
                 events.Add(new RolesBrowseEvent.EditRoleOpen(role.RoleUID));
             }
             ChromeRenderer.DrawPencil(drawList,
-                px + PencilSize / 2f, py + PencilSize / 2f, PencilSize - 8f,
+                px + PencilSize / 2f, py + PencilSize / 2f, PencilSize - UiScale.Scaled(8f),
                 ColorPalette.LightText);
-            rightCursor = px - 8f;
+            rightCursor = px - UiScale.Scaled(8f);
         }
 
         var memberCount = viewModel.GetMemberCount(role.RoleUID);
         var wearText = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_WEAR_COUNT, memberCount);
         var wearSize = ImGui.CalcTextSize(wearText);
         var wearX = rightCursor - wearSize.X;
-        drawList.AddText(new Vector2(wearX, line1Y + 4f),
+        drawList.AddText(new Vector2(wearX, line1Y + UiScale.Scaled(4f)),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), wearText);
 
-        DrawDots(drawList, badgeEnd + 6f, wearX - 6f, line1Y + 4f);
+        DrawDots(drawList, badgeEnd + UiScale.Scaled(6f), wearX - UiScale.Scaled(6f), line1Y + UiScale.Scaled(4f));
 
         // Line 2 — auto-phrased permission summary, indented under the name.
         var summary = RolePermissionPhrases.BuildSummary(role.RoleUID, role.Permissions);
@@ -272,7 +272,7 @@ internal static class ReligionRolesBrowseRenderer
             events.Add(new RolesBrowseEvent.CreateRoleConfirm(viewModel.NewRoleName));
         }
 
-        currentY += InscribeInputHeight + 8f;
+        currentY += InscribeInputHeight + UiScale.Scaled(8f);
         return currentY;
     }
 
@@ -292,18 +292,18 @@ internal static class ReligionRolesBrowseRenderer
         drawList.AddRectFilled(winPos, new Vector2(winPos.X + winSize.X, winPos.Y + winSize.Y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.BlackOverlay));
 
-        const float dialogWidth = 500f;
-        const float dialogHeight = 600f;
+        var dialogWidth = UiScale.Scaled(500f);
+        var dialogHeight = UiScale.Scaled(600f);
         var dlgX = winPos.X + (winSize.X - dialogWidth) / 2f;
         var dlgY = winPos.Y + (winSize.Y - dialogHeight) / 2f;
 
         // Parchment mini-page surface with a faded-ink border.
         drawList.AddRectFilled(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), 6f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), UiScale.Scaled(6f));
         drawList.AddRect(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 6f, ImDrawFlags.None, 1.5f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), UiScale.Scaled(6f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
-        const float padding = 18f;
+        var padding = UiScale.Scaled(18f);
         var bodyWidth = dialogWidth - padding * 2;
         var currentY = dlgY + padding;
 
@@ -312,9 +312,9 @@ internal static class ReligionRolesBrowseRenderer
         drawList.AddText(ImGui.GetFont(), PageTitle,
             new Vector2(dlgX + padding, currentY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), title);
-        currentY += PageTitle + 6f;
+        currentY += PageTitle + UiScale.Scaled(6f);
         ChromeRenderer.DrawDivider(drawList, dlgX + padding, currentY, bodyWidth);
-        currentY += 16f;
+        currentY += UiScale.Scaled(16f);
 
         // Name field — ink labels on parchment.
         if (role.RoleUID == RoleDefaults.FOUNDER_ROLE_ID)
@@ -323,36 +323,36 @@ internal static class ReligionRolesBrowseRenderer
                 LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_FOUNDER_NO_EDIT),
                 dlgX + padding, currentY, bodyWidth,
                 Secondary, ColorPalette.Grey);
-            currentY += 24f;
+            currentY += UiScale.Scaled(24f);
         }
         else
         {
             TextRenderer.DrawLabel(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_NAME_LABEL),
                 dlgX + padding, currentY, Body, ColorPalette.Grey);
-            currentY += 22f;
+            currentY += UiScale.Scaled(22f);
 
             var newName = TextInput.Draw(drawList, "##editRoleName",
                 viewModel.EditingRoleName ?? string.Empty,
-                dlgX + padding, currentY, bodyWidth, 28f, string.Empty, 100);
+                dlgX + padding, currentY, bodyWidth, UiScale.Scaled(28f), string.Empty, 100);
             if (newName != (viewModel.EditingRoleName ?? string.Empty))
                 events.Add(new RolesBrowseEvent.EditRoleNameChanged(newName));
-            currentY += 28f + 14f;
+            currentY += UiScale.Scaled(28f) + UiScale.Scaled(14f);
         }
 
         ChromeRenderer.DrawDivider(drawList, dlgX + padding, currentY, bodyWidth);
-        currentY += 16f;
+        currentY += UiScale.Scaled(16f);
 
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_PERMISSIONS_LABEL),
             dlgX + padding, currentY, SubsectionLabel, ColorPalette.Gold);
-        currentY += 24f;
+        currentY += UiScale.Scaled(24f);
 
         // Permission rows: diamond bullet (filled gold when granted, faded
         // outline when withheld) + display name in ink. Whole row is the
         // hit target so the click area matches the visual row.
-        const float rowHeight = 22f;
-        const float bulletRadius = 5f;
+        var rowHeight = UiScale.Scaled(22f);
+        var bulletRadius = UiScale.Scaled(5f);
         var mousePos = ImGui.GetMousePos();
         foreach (var perm in RolePermissions.AllPermissions)
         {
@@ -370,7 +370,7 @@ internal static class ReligionRolesBrowseRenderer
                 drawList.AddRectFilled(new Vector2(rowMinX, currentY),
                     new Vector2(rowMaxX, currentY + rowHeight),
                     ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Gold, 0.12f)),
-                    3f);
+                    UiScale.Scaled(3f));
                 if (ImGui.IsMouseReleased(ImGuiMouseButton.Left))
                     events.Add(new RolesBrowseEvent.EditRolePermissionToggled(perm, !isEnabled));
             }
@@ -389,15 +389,15 @@ internal static class ReligionRolesBrowseRenderer
                 var right = new Vector2(cx + bulletRadius, rowMidY);
                 var bottom = new Vector2(cx, rowMidY + bulletRadius);
                 var left = new Vector2(cx - bulletRadius, rowMidY);
-                drawList.AddLine(top, right, col, 1f);
-                drawList.AddLine(right, bottom, col, 1f);
-                drawList.AddLine(bottom, left, col, 1f);
-                drawList.AddLine(left, top, col, 1f);
+                drawList.AddLine(top, right, col, UiScale.Scaled(1f));
+                drawList.AddLine(right, bottom, col, UiScale.Scaled(1f));
+                drawList.AddLine(bottom, left, col, UiScale.Scaled(1f));
+                drawList.AddLine(left, top, col, UiScale.Scaled(1f));
             }
 
             var labelColor = isEnabled ? ColorPalette.White : ColorPalette.Grey;
             drawList.AddText(ImGui.GetFont(), Body,
-                new Vector2(rowMinX + bulletRadius * 2f + 10f, currentY + 2f),
+                new Vector2(rowMinX + bulletRadius * 2f + UiScale.Scaled(10f), currentY + UiScale.Scaled(2f)),
                 ImGui.ColorConvertFloat4ToU32(labelColor), displayName);
 
             currentY += rowHeight;
@@ -405,13 +405,13 @@ internal static class ReligionRolesBrowseRenderer
 
         // Footer: Strike † (left, destructive) + Cancel / Save (right). Strike
         // is dagger-marked, no red tint — moved into the overlay per #318.
-        const float btnWidth = 120f;
-        const float btnHeight = 32f;
+        var btnWidth = UiScale.Scaled(120f);
+        var btnHeight = UiScale.Scaled(32f);
         var btnY = dlgY + dialogHeight - padding - btnHeight;
 
         if (viewModel.CanDeleteRole(role))
         {
-            const float strikeWidth = 170f;
+            var strikeWidth = UiScale.Scaled(170f);
             var strikeLabel = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_STRIKE_BUTTON);
             if (ButtonRenderer.DrawButton(drawList, strikeLabel,
                     dlgX + padding, btnY, strikeWidth, btnHeight,
@@ -422,14 +422,14 @@ internal static class ReligionRolesBrowseRenderer
 
             var labelSize = ImGui.CalcTextSize(strikeLabel);
             var labelRightX = dlgX + padding + (strikeWidth + labelSize.X) / 2f;
-            var daggerCx = labelRightX + 8f;
-            var maxDaggerCx = dlgX + padding + strikeWidth - 14f / 2f - 4f;
+            var daggerCx = labelRightX + UiScale.Scaled(8f);
+            var maxDaggerCx = dlgX + padding + strikeWidth - UiScale.Scaled(14f) / 2f - UiScale.Scaled(4f);
             if (daggerCx > maxDaggerCx) daggerCx = maxDaggerCx;
-            ChromeRenderer.DrawDagger(drawList, daggerCx, btnY + btnHeight / 2f, 14f, ColorPalette.LightText);
+            ChromeRenderer.DrawDagger(drawList, daggerCx, btnY + btnHeight / 2f, UiScale.Scaled(14f), ColorPalette.LightText);
         }
 
         var btn2X = dlgX + dialogWidth - padding - btnWidth;
-        var btn1X = btn2X - btnWidth - 10f;
+        var btn1X = btn2X - btnWidth - UiScale.Scaled(10f);
 
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_CANCEL),
@@ -466,13 +466,13 @@ internal static class ReligionRolesBrowseRenderer
         var h = ChapterStripRenderer.TopPadding + PaneHeaderRenderer.TotalHeight;
         var intro = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ROLES_CHAPTER_INTRO);
         var contentWidth = viewModel.Width - ChapterStripRenderer.ScrollbarGutter;
-        h += MathF.Max(TextRenderer.MeasureWrappedHeight(intro, contentWidth, Body), 20f) + 8f;
+        h += MathF.Max(TextRenderer.MeasureWrappedHeight(intro, contentWidth, Body), UiScale.Scaled(20f)) + UiScale.Scaled(8f);
         h += DividerHeight;
         h += viewModel.Roles.Count * RowHeight;
         if (viewModel.CanManageRoles())
         {
             h += DividerHeight;
-            h += InscribeLabelHeight + InscribeInputHeight + 8f;
+            h += InscribeLabelHeight + InscribeInputHeight + UiScale.Scaled(8f);
         }
         return h;
     }

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionRosterRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionRosterRenderer.cs
@@ -28,11 +28,11 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionRosterRenderer
 {
-    private const float TopPadding = 8f;
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float ScrollbarWidth = 16f;
-    private const float SectionLabelHeight = 22f;
+    private static float TopPadding => UiScale.Scaled(8f);
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float SectionLabelHeight => UiScale.Scaled(22f);
 
     public static ReligionRosterRenderResult Draw(ReligionRosterViewModel vm, ImDrawListPtr drawList)
     {
@@ -118,13 +118,13 @@ internal static class ReligionRosterRenderer
         return new ReligionRosterRenderResult(events, height);
     }
 
-    private const float AddButtonSize = 26f;
+    private static float AddButtonSize => UiScale.Scaled(26f);
 
     private static void DrawAddButton(
         ImDrawListPtr drawList, float x, float y, float contentWidth, List<RosterEvent> events)
     {
         var bx = x + contentWidth - AddButtonSize;
-        var by = y + TopPadding + 2f;
+        var by = y + TopPadding + UiScale.Scaled(2f);
         if (ButtonRenderer.DrawButton(drawList, string.Empty, bx, by, AddButtonSize, AddButtonSize,
                 isPrimary: false, enabled: true))
         {
@@ -133,7 +133,7 @@ internal static class ReligionRosterRenderer
 
         ChromeRenderer.DrawPlus(drawList,
             bx + AddButtonSize / 2f, by + AddButtonSize / 2f,
-            AddButtonSize - 12f, ColorPalette.LightText);
+            AddButtonSize - UiScale.Scaled(12f), ColorPalette.LightText);
     }
 
     private static void DrawInviteDialog(
@@ -150,18 +150,18 @@ internal static class ReligionRosterRenderer
         drawList.AddRectFilled(winPos, new Vector2(winPos.X + winSize.X, winPos.Y + winSize.Y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.BlackOverlay));
 
-        const float dialogWidth = 460f;
-        const float dialogHeight = 220f;
+        var dialogWidth = UiScale.Scaled(460f);
+        var dialogHeight = UiScale.Scaled(220f);
         var dlgX = winPos.X + (winSize.X - dialogWidth) / 2f;
         var dlgY = winPos.Y + (winSize.Y - dialogHeight) / 2f;
 
         // Parchment mini-page with a faded-ink border, matching the role-edit dialog.
         drawList.AddRectFilled(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), 6f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), UiScale.Scaled(6f));
         drawList.AddRect(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 6f, ImDrawFlags.None, 1.5f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), UiScale.Scaled(6f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
-        const float padding = 18f;
+        var padding = UiScale.Scaled(18f);
         var bodyWidth = dialogWidth - padding * 2f;
         var curX = dlgX + padding;
         var curY = dlgY + padding;
@@ -170,26 +170,26 @@ internal static class ReligionRosterRenderer
         TextRenderer.DrawLabel(drawList,
             loc.Get(LocalizationKeys.UI_RELIGION_ROSTER_INVITE_TITLE),
             curX, curY, PageTitle, ColorPalette.Gold);
-        curY += PageTitle + 6f;
+        curY += PageTitle + UiScale.Scaled(6f);
         ChromeRenderer.DrawDivider(drawList, curX, curY, bodyWidth);
-        curY += 16f;
+        curY += UiScale.Scaled(16f);
 
         // Prompt + name field.
         TextRenderer.DrawInfoText(drawList,
             loc.Get(LocalizationKeys.UI_RELIGION_ROSTER_INVITE_LABEL),
             curX, curY, bodyWidth, Body, ColorPalette.White);
-        curY += 24f;
+        curY += UiScale.Scaled(24f);
 
         var newName = TextInput.Draw(drawList, "##rosterInvite", vm.InvitePlayerName,
-            curX, curY, bodyWidth, 32f,
+            curX, curY, bodyWidth, UiScale.Scaled(32f),
             loc.Get(LocalizationKeys.UI_RELIGION_ROSTER_INVITE_PLACEHOLDER));
         if (newName != vm.InvitePlayerName)
             events.Add(new RosterEvent.InviteNameChanged(newName));
 
         // Footer: Cancel + Invite (right-aligned).
-        const float btnWidth = 120f;
-        const float btnHeight = 32f;
-        const float btnGap = 10f;
+        var btnWidth = UiScale.Scaled(120f);
+        var btnHeight = UiScale.Scaled(32f);
+        var btnGap = UiScale.Scaled(10f);
         var btnY = dlgY + dialogHeight - padding - btnHeight;
         var inviteX = dlgX + dialogWidth - padding - btnWidth;
         var cancelX = inviteX - btnWidth - btnGap;
@@ -236,7 +236,7 @@ internal static class ReligionRosterRenderer
     {
         var h = TopPadding;
         h += PaneHeaderRenderer.TotalHeight;
-        h += 22f; // intro line
+        h += UiScale.Scaled(22f); // intro line
         h += DividerHeight;
         if (vm.HasMembers)
         {


### PR DESCRIPTION
Part of epic #584. Focused pass on the input controls that still looked wrong at GUIScale > 1 (reported with screenshots): search fields overlapping their filter rows, text inputs overflowing reserved slots, and action buttons clipping their scaled labels.

## Cause

These leaf renderers laid out controls with **raw pixel literals** while the text scaled (via FontGlobalScale #601 + FontSizes #587). So:
- native `InputText` frames grew with the font but callers reserved a **raw** slot height → the next row overlapped the input;
- buttons centred **scaled** `CalcTextSize` text in a **raw** fixed width → labels clipped ("Schedule break" → "hedule bre").

## Fix

Scale the control geometry on the affected screens, per the established `Scaled()` convention (layout consts → scaled `static` properties; inline offsets/sizes/paddings/radii/thicknesses → `UiScale.Scaled(...)`):

- **ButtonRenderer** (shared): icon size, paddings, corner radius, border.
- **ReligionBrowseRenderer** / **CivilizationBrowseRenderer**: search-row reserved height + filter-row + list metrics → filter row no longer overlaps the taller input.
- **ReligionRolesBrowseRenderer**: vestment name input height + "Inscribe" button width/height.
- **DiplomacyTabRenderer**: `EntryActionWidth` + proposal Accept/Refuse widths → "Schedule break"/"Recall" stop clipping.
- **ReligionRosterRenderer**: invite input + button.

Centring divisors (`/2f`), multipliers over already-scaled bases, colour alphas, loop/segment counts and angles left unscaled; font sizes already scaled. Diff is balanced (mostly const→property + literal wrapping). **No behavioural change at Factor 1.0.**

## Relationship to other PRs

Orthogonal to #606 (#605, ImGui style-padding) — that scales native-widget *frame padding*, this scales the *layout geometry around* the controls; they compose. This covers the specific screens shown; the remaining renderers in #595/#596 are still the broader grind.

## Tests

Full suite: **2515 passed**. Build clean. Diff sanity-checked (no divisor/alpha mis-scaling).

## Manual test

GUIScale 1 vs 2 (Settings → Graphics → GUI Scale): Religion/Civ browse search boxes no longer overlap the "By deity/accord" row; "Inscribe" and diplomacy "Schedule break"/"Recall" buttons fit their labels.

Refs #599 #595 #596