### PR TITLE
feat(ui): scale Civilization content renderers (#596)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationChronicleRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationChronicleRenderer.cs
@@ -25,17 +25,17 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationChronicleRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float IntroBottomSpacing = 10f;
-    private const float IntroLineHeight = 18f;
-    private const float DiamondHalfSize = 3.5f;
-    private const float DiamondLeftPadding = 4f;
-    private const float ProseIndent = 18f;
-    private const float EntryGap = 8f;
-    private const float ScrollbarWidth = 16f;
-    private const float ClosingLineHeight = 24f;
-    private const float ClosingLineTopSpacing = 6f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float IntroBottomSpacing => UiScale.Scaled(10f);
+    private static float IntroLineHeight => UiScale.Scaled(18f);
+    private static float DiamondHalfSize => UiScale.Scaled(3.5f);
+    private static float DiamondLeftPadding => UiScale.Scaled(4f);
+    private static float ProseIndent => UiScale.Scaled(18f);
+    private static float EntryGap => UiScale.Scaled(8f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float ClosingLineHeight => UiScale.Scaled(24f);
+    private static float ClosingLineTopSpacing => UiScale.Scaled(6f);
 
     public static CivilizationChronicleRenderResult Draw(CivilizationChronicleViewModel vm, ImDrawListPtr drawList)
     {
@@ -72,7 +72,7 @@ internal static class CivilizationChronicleRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -109,7 +109,7 @@ internal static class CivilizationChronicleRenderer
         var proseWidth = contentWidth - ProseIndent;
         foreach (var entry in vm.Chronicle)
         {
-            var centerY = currentY + (Secondary + 6f) / 2f;
+            var centerY = currentY + (Secondary + UiScale.Scaled(6f)) / 2f;
             ChromeRenderer.DrawDiamond(drawList,
                 x + DiamondLeftPadding + DiamondHalfSize, centerY,
                 DiamondHalfSize,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationCreateRenderer.cs
@@ -25,15 +25,15 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationCreateRenderer
 {
-    private const float DividerSpacingTop = 8f;
-    private const float DividerSpacingBottom = 14f;
-    private const float SectionGap = 8f;
-    private const float LabelHeight = 22f;
-    private const float NameInputHeight = 30f;
-    private const float DescriptionInputHeight = 80f;
-    private const float ErrorRowHeight = 22f;
-    private const float ButtonWidth = 200f;
-    private const float ButtonHeight = 36f;
+    private static float DividerSpacingTop => UiScale.Scaled(8f);
+    private static float DividerSpacingBottom => UiScale.Scaled(14f);
+    private static float SectionGap => UiScale.Scaled(8f);
+    private static float LabelHeight => UiScale.Scaled(22f);
+    private static float NameInputHeight => UiScale.Scaled(30f);
+    private static float DescriptionInputHeight => UiScale.Scaled(80f);
+    private static float ErrorRowHeight => UiScale.Scaled(22f);
+    private static float ButtonWidth => UiScale.Scaled(200f);
+    private static float ButtonHeight => UiScale.Scaled(36f);
 
     public static CivilizationCreateRenderResult Draw(
         CivilizationCreateViewModel vm,
@@ -49,7 +49,7 @@ internal static class CivilizationCreateRenderer
         // Prose intro on parchment → iron-gall ink.
         var intro = LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_CREATE_CHAPTER_INTRO);
         TextRenderer.DrawInfoText(drawList, intro, vm.X, currentY, contentWidth, Body, ColorPalette.White);
-        currentY += MathF.Max(TextRenderer.MeasureWrappedHeight(intro, contentWidth, Body), 20f) + 8f;
+        currentY += MathF.Max(TextRenderer.MeasureWrappedHeight(intro, contentWidth, Body), UiScale.Scaled(20f)) + UiScale.Scaled(8f);
 
         currentY = DrawDivider(drawList, vm.X, currentY, contentWidth);
         currentY = DrawNameSection(drawList, vm, currentY, contentWidth, events);
@@ -90,7 +90,7 @@ internal static class CivilizationCreateRenderer
         if (newName != vm.CivilizationName)
             events.Add(new CreateEvent.NameChanged(newName));
 
-        currentY += NameInputHeight + 4f;
+        currentY += NameInputHeight + UiScale.Scaled(4f);
         currentY = DrawNameValidation(drawList, vm, currentY);
 
         return currentY + SectionGap;
@@ -141,7 +141,7 @@ internal static class CivilizationCreateRenderer
         if (newDescription != vm.Description)
             events.Add(new CreateEvent.DescriptionChanged(newDescription));
 
-        currentY += DescriptionInputHeight + 4f;
+        currentY += DescriptionInputHeight + UiScale.Scaled(4f);
         currentY = DrawDescriptionValidation(drawList, vm, currentY);
 
         return currentY + SectionGap;
@@ -179,9 +179,9 @@ internal static class CivilizationCreateRenderer
         CivilizationEthos.Ascetic
     };
 
-    private const float EthosButtonHeight = 30f;
-    private const float EthosButtonGap = 6f;
-    private const float EthosHintTopPadding = 4f;
+    private static float EthosButtonHeight => UiScale.Scaled(30f);
+    private static float EthosButtonGap => UiScale.Scaled(6f);
+    private static float EthosHintTopPadding => UiScale.Scaled(4f);
 
     private static float DrawEthosSection(
         ImDrawListPtr drawList,
@@ -249,7 +249,7 @@ internal static class CivilizationCreateRenderer
             events.Add(new CreateEvent.SubmitClicked());
         }
 
-        return y + ButtonHeight + 12f;
+        return y + ButtonHeight + UiScale.Scaled(12f);
     }
 
     private static float DrawDivider(ImDrawListPtr drawList, float x, float y, float width)

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationDetailRenderer.cs
@@ -29,20 +29,20 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationDetailRenderer
 {
-    private const float TopPadding = 8f;
-    private const float NavRowHeight = 32f;
-    private const float NavRowBottomPadding = 12f;
-    private const float NavBackWidth = 36f;
-    private const float NavJoinWidth = 130f;
-    private const float BackGlyphSize = 14f;
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float StatRowHeight = 22f;
-    private const float StatBlockBottomSpacing = 8f;
-    private const float ProseBottomSpacing = 12f;
-    private const float MemberRowHeight = 26f;
-    private const float MemberRowGap = 2f;
-    private const float SectionBottomSpacing = 8f;
+    private static float TopPadding => UiScale.Scaled(8f);
+    private static float NavRowHeight => UiScale.Scaled(32f);
+    private static float NavRowBottomPadding => UiScale.Scaled(12f);
+    private static float NavBackWidth => UiScale.Scaled(36f);
+    private static float NavJoinWidth => UiScale.Scaled(130f);
+    private static float BackGlyphSize => UiScale.Scaled(14f);
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float StatRowHeight => UiScale.Scaled(22f);
+    private static float StatBlockBottomSpacing => UiScale.Scaled(8f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float MemberRowHeight => UiScale.Scaled(26f);
+    private static float MemberRowGap => UiScale.Scaled(2f);
+    private static float SectionBottomSpacing => UiScale.Scaled(8f);
 
     public static CivilizationDetailRendererResult Draw(
         CivilizationDetailViewModel vm,
@@ -58,7 +58,7 @@ internal static class CivilizationDetailRenderer
         {
             TextRenderer.DrawInfoText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_DETAIL_LOADING),
-                vm.X, currentY + 8f, contentWidth, Body, ColorPalette.Grey);
+                vm.X, currentY + UiScale.Scaled(8f), contentWidth, Body, ColorPalette.Grey);
             return new CivilizationDetailRendererResult(events, vm.Height);
         }
 
@@ -103,7 +103,7 @@ internal static class CivilizationDetailRenderer
             var joinX = vm.X + contentWidth - NavJoinWidth;
             if (ButtonRenderer.DrawButton(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_ACTION_JOIN),
-                    joinX, y, NavJoinWidth, NavRowHeight + 4f,
+                    joinX, y, NavJoinWidth, NavRowHeight + UiScale.Scaled(4f),
                     isPrimary: true))
             {
                 events.Add(new DetailEvent.RequestToJoinClicked(vm.CivId));
@@ -247,11 +247,11 @@ internal static class CivilizationDetailRenderer
             return currentY + StatRowHeight + SectionBottomSpacing;
         }
 
-        const float glyphLeftPadding = 4f;
-        const float glyphBox = 14f;
-        const float glyphToLabelGap = 8f;
+        var glyphLeftPadding = UiScale.Scaled(4f);
+        var glyphBox = UiScale.Scaled(14f);
+        var glyphToLabelGap = UiScale.Scaled(8f);
         var leaderX = vm.X + glyphLeftPadding + glyphBox + glyphToLabelGap;
-        var leaderWidth = MathF.Max(width - (leaderX - vm.X) - 8f, 40f);
+        var leaderWidth = MathF.Max(width - (leaderX - vm.X) - UiScale.Scaled(8f), UiScale.Scaled(40f));
         var glyphCx = vm.X + glyphLeftPadding + glyphBox / 2f;
 
         foreach (var boon in leaders)
@@ -287,7 +287,7 @@ internal static class CivilizationDetailRenderer
                 // Fleuron — a gold diamond with a small centre spark, matching
                 // the Boons of Standing bullet on the Chronicles chapter.
                 ChromeRenderer.DrawDiamond(drawList, cx, cy, box * 0.32f, ColorPalette.Gold);
-                drawList.AddCircleFilled(new Vector2(cx, cy), 1.2f,
+                drawList.AddCircleFilled(new Vector2(cx, cy), UiScale.Scaled(1.2f),
                     ImGui.ColorConvertFloat4ToU32(ColorPalette.LightText));
                 break;
         }
@@ -378,9 +378,9 @@ internal static class CivilizationDetailRenderer
         ImDrawListPtr drawList)
     {
         // ✦ <OrderName> · · · · · <Deity>
-        const float diamondLeftPadding = 4f;
-        const float diamondHalfSize = 3.5f;
-        const float diamondToLabelGap = 10f;
+        var diamondLeftPadding = UiScale.Scaled(4f);
+        var diamondHalfSize = UiScale.Scaled(3.5f);
+        var diamondToLabelGap = UiScale.Scaled(10f);
 
         var centerY = y + height / 2f;
         ChromeRenderer.DrawDiamond(drawList,
@@ -389,7 +389,7 @@ internal static class CivilizationDetailRenderer
             ColorPalette.Gold * 0.6f);
 
         var leaderX = x + diamondLeftPadding + diamondHalfSize * 2f + diamondToLabelGap;
-        var leaderWidth = MathF.Max(width - (leaderX - x) - 8f, 40f);
+        var leaderWidth = MathF.Max(width - (leaderX - x) - UiScale.Scaled(8f), UiScale.Scaled(40f));
         var rowY = centerY - Body * 0.5f;
         ChromeRenderer.DrawLeader(drawList,
             member.ReligionName,

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationEditRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationEditRenderer.cs
@@ -34,11 +34,11 @@ internal static class CivilizationEditRenderer
         // plus the surrounding labels + preview + buttons. The previous fixed
         // 450f wasn't tall enough for the current icon count, so the button
         // row drew on top of the bottom grid rows.
-        const float dialogWidth = 500f;
+        var dialogWidth = UiScale.Scaled(500f);
         const int pickerColumns = 4;
-        const float pickerIconSize = 40f;
-        const float pickerSpacing = 8f;
-        const float previewHeightEstimate = 14f + 8f + 48f + 8f + 14f; // label+gap+icon+gap+name
+        var pickerIconSize = UiScale.Scaled(40f);
+        var pickerSpacing = UiScale.Scaled(8f);
+        var previewHeightEstimate = UiScale.Scaled(14f + 8f + 48f + 8f + 14f); // label+gap+icon+gap+name
         var availableIconsForMeasure = CivilizationIconLoader.GetAvailableIcons();
         var pickerRows = (int)System.Math.Ceiling(availableIconsForMeasure.Count / (double)pickerColumns);
         var pickerHeightEstimate = pickerRows * pickerIconSize + System.Math.Max(0, pickerRows - 1) * pickerSpacing;
@@ -53,10 +53,10 @@ internal static class CivilizationEditRenderer
         // + pickerHeight + 20 gap
         // + 60 button strip
         // + 20 bottom pad
-        var dialogHeight = 20f + PaneHeaderRenderer.TotalHeight + 30f + 25f + previewHeightEstimate + 20f
-                           + 25f + pickerHeightEstimate + 20f + 60f + 20f;
+        var dialogHeight = UiScale.Scaled(20f) + PaneHeaderRenderer.TotalHeight + UiScale.Scaled(30f) + UiScale.Scaled(25f) + previewHeightEstimate + UiScale.Scaled(20f)
+                           + UiScale.Scaled(25f) + pickerHeightEstimate + UiScale.Scaled(20f) + UiScale.Scaled(60f) + UiScale.Scaled(20f);
         // Clamp to the available overlay so dialogs never escape the dialog.
-        dialogHeight = System.MathF.Min(dialogHeight, System.MathF.Max(300f, vm.Height - 40f));
+        dialogHeight = System.MathF.Min(dialogHeight, System.MathF.Max(UiScale.Scaled(300f), vm.Height - UiScale.Scaled(40f)));
 
         var dialogX = vm.X + (vm.Width - dialogWidth) / 2;
         var dialogY = vm.Y + (vm.Height - dialogHeight) / 2;
@@ -65,15 +65,15 @@ internal static class CivilizationEditRenderer
         var dialogStart = new Vector2(dialogX, dialogY);
         var dialogEnd = new Vector2(dialogX + dialogWidth, dialogY + dialogHeight);
         var dialogBgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
-        drawList.AddRectFilled(dialogStart, dialogEnd, dialogBgColor, 8f);
+        drawList.AddRectFilled(dialogStart, dialogEnd, dialogBgColor, UiScale.Scaled(8f));
 
         // Dialog border
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        drawList.AddRect(dialogStart, dialogEnd, borderColor, 8f, ImDrawFlags.None, 2f);
+        drawList.AddRect(dialogStart, dialogEnd, borderColor, UiScale.Scaled(8f), ImDrawFlags.None, UiScale.Scaled(2f));
 
-        var currentY = dialogY + 20f;
-        var contentX = dialogX + 20f;
-        var contentWidth = dialogWidth - 40f;
+        var currentY = dialogY + UiScale.Scaled(20f);
+        var contentX = dialogX + UiScale.Scaled(20f);
+        var contentWidth = dialogWidth - UiScale.Scaled(40f);
 
         // Title
         currentY = PaneHeaderRenderer.Draw(drawList,
@@ -85,13 +85,13 @@ internal static class CivilizationEditRenderer
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_EDIT_CIV_LABEL, vm.CivilizationName),
             contentX, currentY, 14f,
             ColorPalette.Grey);
-        currentY += 30f;
+        currentY += UiScale.Scaled(30f);
 
         // Current icon preview
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_EDIT_CURRENT_ICON), contentX, currentY,
             14f, ColorPalette.Grey);
-        currentY += 25f;
+        currentY += UiScale.Scaled(25f);
 
         var previewHeight = IconPicker.DrawPreview(
             drawList,
@@ -100,13 +100,13 @@ internal static class CivilizationEditRenderer
             contentX,
             currentY
         );
-        currentY += previewHeight + 20f;
+        currentY += previewHeight + UiScale.Scaled(20f);
 
         // Icon selection
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_EDIT_SELECT_ICON), contentX, currentY,
             14f, ColorPalette.White);
-        currentY += 25f;
+        currentY += UiScale.Scaled(25f);
 
         var availableIcons = CivilizationIconLoader.GetAvailableIcons();
         var (clickedIcon, pickerHeight) = IconPicker.Draw(
@@ -121,17 +121,17 @@ internal static class CivilizationEditRenderer
         if (clickedIcon != null)
             events.Add(new EditEvent.IconSelected(clickedIcon));
 
-        currentY += pickerHeight + 20f;
+        currentY += pickerHeight + UiScale.Scaled(20f);
 
         // Buttons
-        var buttonY = dialogY + dialogHeight - 60f;
+        var buttonY = dialogY + dialogHeight - UiScale.Scaled(60f);
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_EDIT_UPDATE_BUTTON), contentX,
-                buttonY, 150f, 36f, true))
+                buttonY, UiScale.Scaled(150f), UiScale.Scaled(36f), true))
             events.Add(new EditEvent.SubmitClicked());
 
         if (ButtonRenderer.DrawButton(drawList, LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_CANCEL),
-                contentX + 160f, buttonY, 100f, 36f))
+                contentX + UiScale.Scaled(160f), buttonY, UiScale.Scaled(100f), UiScale.Scaled(36f)))
             events.Add(new EditEvent.CancelClicked());
 
         return new CivilizationEditRenderResult(events);

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationHolySitesRenderer.cs
@@ -29,33 +29,33 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationHolySitesRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float ScrollbarWidth = 16f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
 
-    private const float IntroLineHeight = 18f;
-    private const float IntroBottomSpacing = 10f;
+    private static float IntroLineHeight => UiScale.Scaled(18f);
+    private static float IntroBottomSpacing => UiScale.Scaled(10f);
 
-    private const float OrderHeaderHeight = 26f;
-    private const float OrderHeaderTopSpacing = 4f;
-    private const float OrderHeaderBottomSpacing = 6f;
-    private const float CaretSize = 12f;
-    private const float CaretToTextGap = 6f;
-    private const float OrderLeftPadding = 8f;
+    private static float OrderHeaderHeight => UiScale.Scaled(26f);
+    private static float OrderHeaderTopSpacing => UiScale.Scaled(4f);
+    private static float OrderHeaderBottomSpacing => UiScale.Scaled(6f);
+    private static float CaretSize => UiScale.Scaled(12f);
+    private static float CaretToTextGap => UiScale.Scaled(6f);
+    private static float OrderLeftPadding => UiScale.Scaled(8f);
 
-    private const float SiteRowLeftPadding = 32f;
-    private const float SiteNameLineHeight = 20f;
-    private const float SiteClaimLineHeight = 18f;
-    private const float SiteRowBottomSpacing = 6f;
-    private const float SiteGlyphSize = 16f;
-    private const float SiteGlyphToTextGap = 8f;
-    private const float SiteClaimIndent = SiteGlyphSize + SiteGlyphToTextGap;
+    private static float SiteRowLeftPadding => UiScale.Scaled(32f);
+    private static float SiteNameLineHeight => UiScale.Scaled(20f);
+    private static float SiteClaimLineHeight => UiScale.Scaled(18f);
+    private static float SiteRowBottomSpacing => UiScale.Scaled(6f);
+    private static float SiteGlyphSize => UiScale.Scaled(16f);
+    private static float SiteGlyphToTextGap => UiScale.Scaled(8f);
+    private static float SiteClaimIndent => SiteGlyphSize + SiteGlyphToTextGap;
 
-    private const float PerOrderDividerHeight = 16f;
-    private const float ClosingLineHeight = 24f;
-    private const float ClosingLineTopSpacing = 6f;
+    private static float PerOrderDividerHeight => UiScale.Scaled(16f);
+    private static float ClosingLineHeight => UiScale.Scaled(24f);
+    private static float ClosingLineTopSpacing => UiScale.Scaled(6f);
 
-    private const float RefreshButtonSize = 22f;
+    private static float RefreshButtonSize => UiScale.Scaled(22f);
 
     public static CivilizationHolySitesRenderResult Draw(
         CivilizationHolySitesViewModel viewModel,
@@ -95,7 +95,7 @@ internal static class CivilizationHolySitesRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -152,7 +152,7 @@ internal static class CivilizationHolySitesRenderer
     {
         var stripY = paneY + ChapterStripRenderer.TopPadding - scrollY;
         var px = x + width - ChapterStripRenderer.ScrollbarGutter - RefreshButtonSize;
-        var py = stripY + 6f;
+        var py = stripY + UiScale.Scaled(6f);
 
         if (ButtonRenderer.DrawButton(drawList, string.Empty,
                 px, py, RefreshButtonSize, RefreshButtonSize,
@@ -164,7 +164,7 @@ internal static class CivilizationHolySitesRenderer
         ChromeRenderer.DrawRefreshArrow(drawList,
             px + RefreshButtonSize / 2f,
             py + RefreshButtonSize / 2f,
-            RefreshButtonSize - 6f,
+            RefreshButtonSize - UiScale.Scaled(6f),
             ColorPalette.LightText);
     }
 
@@ -241,7 +241,7 @@ internal static class CivilizationHolySitesRenderer
         if (isHovered)
         {
             var hoverColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.10f);
-            drawList.AddRectFilled(rowMin, rowMax, hoverColor, 2f);
+            drawList.AddRectFilled(rowMin, rowMax, hoverColor, UiScale.Scaled(2f));
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
             if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
                 events.Add(new HolySitesEvent.ReligionToggled(religionUID));
@@ -288,7 +288,7 @@ internal static class CivilizationHolySitesRenderer
         if (isHovered)
         {
             var hoverColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.08f);
-            drawList.AddRectFilled(rowMin, rowMax, hoverColor, 2f);
+            drawList.AddRectFilled(rowMin, rowMax, hoverColor, UiScale.Scaled(2f));
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
             if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
                 events.Add(new HolySitesEvent.SiteSelected(site.SiteUID));
@@ -327,7 +327,7 @@ internal static class CivilizationHolySitesRenderer
     private static float DrawPerOrderDivider(ImDrawListPtr drawList, float x, float y, float width)
     {
         var inset = width * 0.30f;
-        var dividerY = y + 4f;
+        var dividerY = y + UiScale.Scaled(4f);
         ChromeRenderer.DrawDivider(drawList,
             x + inset, dividerY, width - inset * 2f,
             ColorPalette.Gold * 0.40f);

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationInfoRenderer.cs
@@ -28,21 +28,21 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationInfoRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float SectionLabelHeight = 22f;
-    private const float OrderRowHeight = 22f;
-    private const float BoonRowHeight = 22f;
-    private const float BoonProseHeight = 20f;
-    private const float InviteInputHeight = 30f;
-    private const float InviteButtonWidth = 130f;
-    private const float InviteButtonHeight = 32f;
-    private const float LetterRowHeight = 22f;
-    private const float FooterTopPadding = 12f;
-    private const float ScrollbarWidth = 16f;
-    private const float DiamondHalfSize = 3.5f;
-    private const float DiamondLeftPadding = 4f;
-    private const float DiamondLabelGap = 10f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float SectionLabelHeight => UiScale.Scaled(22f);
+    private static float OrderRowHeight => UiScale.Scaled(22f);
+    private static float BoonRowHeight => UiScale.Scaled(22f);
+    private static float BoonProseHeight => UiScale.Scaled(20f);
+    private static float InviteInputHeight => UiScale.Scaled(30f);
+    private static float InviteButtonWidth => UiScale.Scaled(130f);
+    private static float InviteButtonHeight => UiScale.Scaled(32f);
+    private static float LetterRowHeight => UiScale.Scaled(22f);
+    private static float FooterTopPadding => UiScale.Scaled(12f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float DiamondHalfSize => UiScale.Scaled(3.5f);
+    private static float DiamondLeftPadding => UiScale.Scaled(4f);
+    private static float DiamondLabelGap => UiScale.Scaled(10f);
 
     public static CivilizationInfoRendererResult Draw(
         CivilizationInfoViewModel vm,
@@ -83,7 +83,7 @@ internal static class CivilizationInfoRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -162,7 +162,7 @@ internal static class CivilizationInfoRenderer
             TextRenderer.DrawInfoText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_BOONS_EMPTY),
                 x, currentY, width, Secondary, ColorPalette.Grey);
-            return currentY + BoonRowHeight + 4f;
+            return currentY + BoonRowHeight + UiScale.Scaled(4f);
         }
 
         foreach (var boon in phrases)
@@ -179,7 +179,7 @@ internal static class CivilizationInfoRenderer
             currentY += BoonRowHeight;
         }
 
-        return currentY + 4f;
+        return currentY + UiScale.Scaled(4f);
     }
 
     private static float DrawBannerOrders(
@@ -208,7 +208,7 @@ internal static class CivilizationInfoRenderer
             currentY += OrderRowHeight;
         }
 
-        return currentY + 4f;
+        return currentY + UiScale.Scaled(4f);
     }
 
     private static void DrawOrderRow(
@@ -224,7 +224,7 @@ internal static class CivilizationInfoRenderer
 
         var labelX = x + DiamondLeftPadding + DiamondHalfSize * 2f + DiamondLabelGap;
         var rowY = centerY - Body * 0.5f;
-        var leaderWidth = MathF.Max(width - (labelX - x), 40f);
+        var leaderWidth = MathF.Max(width - (labelX - x), UiScale.Scaled(40f));
 
         var deity = !string.IsNullOrWhiteSpace(member.DeityName)
             ? member.DeityName
@@ -256,8 +256,8 @@ internal static class CivilizationInfoRenderer
             x, currentY, SubsectionLabel, ColorPalette.Grey);
         currentY += SectionLabelHeight;
 
-        var inputWidth = width - InviteButtonWidth - 10f;
-        if (inputWidth < 120f) inputWidth = MathF.Max(120f, width - 10f);
+        var inputWidth = width - InviteButtonWidth - UiScale.Scaled(10f);
+        if (inputWidth < UiScale.Scaled(120f)) inputWidth = MathF.Max(UiScale.Scaled(120f), width - UiScale.Scaled(10f));
 
         var newInvite = TextInput.Draw(
             drawList,
@@ -273,7 +273,7 @@ internal static class CivilizationInfoRenderer
             events.Add(new InfoEvent.InviteReligionNameChanged(newInvite));
 
         var canInvite = !overlayOpen && vm.CanInvite && !vm.IsLoading;
-        var inviteButtonX = x + inputWidth + 10f;
+        var inviteButtonX = x + inputWidth + UiScale.Scaled(10f);
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_INVITE_BUTTON),
                 inviteButtonX, currentY, InviteButtonWidth, InviteButtonHeight,
@@ -282,7 +282,7 @@ internal static class CivilizationInfoRenderer
             events.Add(new InfoEvent.InviteReligionClicked(vm.InviteReligionName));
         }
 
-        currentY += InviteInputHeight + 10f;
+        currentY += InviteInputHeight + UiScale.Scaled(10f);
 
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_INFO_LETTERS_HEADING),
@@ -305,7 +305,7 @@ internal static class CivilizationInfoRenderer
             currentY += LetterRowHeight;
         }
 
-        return currentY + 4f;
+        return currentY + UiScale.Scaled(4f);
     }
 
     private static void DrawLetterRow(
@@ -321,7 +321,7 @@ internal static class CivilizationInfoRenderer
             ColorPalette.Gold * 0.4f);
 
         var leaderX = x + DiamondLeftPadding + DiamondHalfSize * 2f + DiamondLabelGap;
-        var leaderWidth = MathF.Max(width - (leaderX - x) - 8f, 40f);
+        var leaderWidth = MathF.Max(width - (leaderX - x) - UiScale.Scaled(8f), UiScale.Scaled(40f));
         var rowY = centerY - Body * 0.5f;
         ChromeRenderer.DrawLeader(drawList,
             invite.ReligionName,
@@ -341,17 +341,17 @@ internal static class CivilizationInfoRenderer
         var h = 0f;
         h += PaneHeaderRenderer.TotalHeight;
         // Prose intro
-        h += Body + LinePadding + 12f;
+        h += Body + LinePadding + UiScale.Scaled(12f);
         // Stat block (5 rows: founded, founder+epithet, founding order, ethos, seat)
-        h += OrderRowHeight * 5 + 8f;
+        h += OrderRowHeight * 5 + UiScale.Scaled(8f);
 
         h += DividerHeight;
 
         // Description
         if (vm.IsFounder && vm.IsEditingDescription)
-            h += SectionLabelHeight + 80f + 6f + 26f + 8f;
+            h += SectionLabelHeight + UiScale.Scaled(80f) + UiScale.Scaled(6f) + UiScale.Scaled(26f) + UiScale.Scaled(8f);
         else
-            h += SectionLabelHeight + Secondary + LinePadding + 8f;
+            h += SectionLabelHeight + Secondary + LinePadding + UiScale.Scaled(8f);
 
         h += DividerHeight;
 
@@ -359,27 +359,27 @@ internal static class CivilizationInfoRenderer
         h += SectionLabelHeight + BoonProseHeight;
         var boonCount = 0;
         foreach (var _ in MilestonePhrases.ActiveBonusPhrases(vm.Bonuses)) boonCount++;
-        h += boonCount == 0 ? BoonRowHeight + 4f : BoonRowHeight * boonCount + 4f;
+        h += boonCount == 0 ? BoonRowHeight + UiScale.Scaled(4f) : BoonRowHeight * boonCount + UiScale.Scaled(4f);
 
         h += DividerHeight;
 
         // Banner orders
         h += SectionLabelHeight;
-        h += vm.MemberCount == 0 ? OrderRowHeight : OrderRowHeight * vm.MemberCount + 4f;
+        h += vm.MemberCount == 0 ? OrderRowHeight : OrderRowHeight * vm.MemberCount + UiScale.Scaled(4f);
 
         // Invite block (founder only)
         if (vm.IsFounder)
         {
             h += DividerHeight;
-            h += SectionLabelHeight + InviteInputHeight + 10f;
+            h += SectionLabelHeight + InviteInputHeight + UiScale.Scaled(10f);
             h += SectionLabelHeight;
             h += vm.HasPendingInvites
-                ? LetterRowHeight * vm.PendingInvites.Count + 4f
+                ? LetterRowHeight * vm.PendingInvites.Count + UiScale.Scaled(4f)
                 : LetterRowHeight;
         }
 
         // Footer
-        h += FooterTopPadding + 34f + 6f;
+        h += FooterTopPadding + UiScale.Scaled(34f) + UiScale.Scaled(6f);
         return h;
     }
 

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationLeaderboardRenderer.cs
@@ -28,24 +28,24 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationLeaderboardRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float ProseBottomSpacing = 12f;
-    private const float RowHeight = 24f;
-    private const float RefreshGlyphSize = 22f;
-    private const float ScrollbarWidth = 16f;
-    private const float SummaryTopSpacing = 6f;
-    private const float SelectorRowHeight = 28f;
-    private const float SelectorRowBottomSpacing = 6f;
-    private const float SelectorChipGap = 18f;
-    private const float SelectorChipPaddingX = 8f;
-    private const float RowMarkerWidth = 16f; // ▸/◂ pin gutter on the viewer row
-    private const float RowRankWidth = 46f;    // "VIII." rank column
-    private const float RowGlyphSize = 16f;    // heraldic ethos mark
-    private const float RowGlyphGap = 8f;
-    private const float RowBarWidth = 72f;
-    private const float RowBarHeight = 8f;
-    private const float RowColumnGap = 12f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float RowHeight => UiScale.Scaled(24f);
+    private static float RefreshGlyphSize => UiScale.Scaled(22f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float SummaryTopSpacing => UiScale.Scaled(6f);
+    private static float SelectorRowHeight => UiScale.Scaled(28f);
+    private static float SelectorRowBottomSpacing => UiScale.Scaled(6f);
+    private static float SelectorChipGap => UiScale.Scaled(18f);
+    private static float SelectorChipPaddingX => UiScale.Scaled(8f);
+    private static float RowMarkerWidth => UiScale.Scaled(16f); // ▸/◂ pin gutter on the viewer row
+    private static float RowRankWidth => UiScale.Scaled(46f);    // "VIII." rank column
+    private static float RowGlyphSize => UiScale.Scaled(16f);    // heraldic ethos mark
+    private static float RowGlyphGap => UiScale.Scaled(8f);
+    private static float RowBarWidth => UiScale.Scaled(72f);
+    private static float RowBarHeight => UiScale.Scaled(8f);
+    private static float RowColumnGap => UiScale.Scaled(12f);
 
     public static CivilizationLeaderboardRenderResult Draw(
         CivilizationLeaderboardViewModel viewModel,
@@ -85,7 +85,7 @@ internal static class CivilizationLeaderboardRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -150,7 +150,7 @@ internal static class CivilizationLeaderboardRenderer
         List<LeaderboardEvent> events)
     {
         var bx = paneX + contentWidth - RefreshGlyphSize;
-        var by = stripTopY + ChapterStripRenderer.TopPadding + 6f;
+        var by = stripTopY + ChapterStripRenderer.TopPadding + UiScale.Scaled(6f);
         if (ButtonRenderer.DrawButton(drawList, string.Empty,
                 bx, by, RefreshGlyphSize, RefreshGlyphSize,
                 isPrimary: false, enabled: !viewModel.IsLoading))
@@ -160,7 +160,7 @@ internal static class CivilizationLeaderboardRenderer
         ChromeRenderer.DrawRefreshArrow(drawList,
             bx + RefreshGlyphSize / 2f,
             by + RefreshGlyphSize / 2f,
-            RefreshGlyphSize - 6f,
+            RefreshGlyphSize - UiScale.Scaled(6f),
             ColorPalette.LightText);
     }
 
@@ -186,7 +186,7 @@ internal static class CivilizationLeaderboardRenderer
         // Drawn as chevrons rather than glyphs: ▸/◂ aren't in the ImGui font.
         if (isViewer)
         {
-            const float pinSize = 9f;
+            var pinSize = UiScale.Scaled(9f);
             ChromeRenderer.DrawChevron(drawList, x + pinSize * 0.6f, rowMidY, pinSize,
                 ChromeRenderer.ChevronDirection.Right, ColorPalette.Gold);
             ChromeRenderer.DrawChevron(drawList, x + width - pinSize * 0.6f, rowMidY, pinSize,
@@ -243,10 +243,10 @@ internal static class CivilizationLeaderboardRenderer
         var fillCol = ImGui.ColorConvertFloat4ToU32(isViewer ? ColorPalette.Gold : ColorPalette.Grey);
 
         drawList.AddRectFilled(new Vector2(x, y), new Vector2(x + width, y + height),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor * 0.4f), 2f);
-        drawList.AddRect(new Vector2(x, y), new Vector2(x + width, y + height), trackCol, 2f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor * 0.4f), UiScale.Scaled(2f));
+        drawList.AddRect(new Vector2(x, y), new Vector2(x + width, y + height), trackCol, UiScale.Scaled(2f));
         if (fraction > 0f)
-            drawList.AddRectFilled(new Vector2(x, y), new Vector2(x + width * fraction, y + height), fillCol, 2f);
+            drawList.AddRectFilled(new Vector2(x, y), new Vector2(x + width * fraction, y + height), fillCol, UiScale.Scaled(2f));
     }
 
     private static float DrawProseIntro(
@@ -256,7 +256,7 @@ internal static class CivilizationLeaderboardRenderer
         var prose = LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_LEADERBOARD_INTRO);
         TextRenderer.DrawInfoText(drawList, prose, x, y, width, Body, ColorPalette.White);
         var lines = TextRenderer.MeasureWrappedHeight(prose, width, Body);
-        return y + (lines > 0 ? lines : Body + 6f) + ProseBottomSpacing;
+        return y + (lines > 0 ? lines : Body + UiScale.Scaled(6f)) + ProseBottomSpacing;
     }
 
     /// <summary>
@@ -284,8 +284,8 @@ internal static class CivilizationLeaderboardRenderer
             var chipWidth = SelectorChipPaddingX + labelSize.X + SelectorChipPaddingX;
             if (cursor + chipWidth > x + width) break;
 
-            var chipMinY = rowCenterY - labelSize.Y / 2f - 4f;
-            var chipMaxY = rowCenterY + labelSize.Y / 2f + 4f;
+            var chipMinY = rowCenterY - labelSize.Y / 2f - UiScale.Scaled(4f);
+            var chipMaxY = rowCenterY + labelSize.Y / 2f + UiScale.Scaled(4f);
             var chipMin = new Vector2(cursor, chipMinY);
             var chipMax = new Vector2(cursor + chipWidth, chipMaxY);
 
@@ -294,7 +294,7 @@ internal static class CivilizationLeaderboardRenderer
 
             if (isActive)
                 drawList.AddRect(chipMin, chipMax,
-                    ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), 3f, ImDrawFlags.None, 1.5f);
+                    ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), UiScale.Scaled(3f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
             if (isHover && !isActive) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
 
@@ -354,7 +354,7 @@ internal static class CivilizationLeaderboardRenderer
     private static float ComputeContentHeight(CivilizationLeaderboardViewModel viewModel)
     {
         var h = PaneHeaderRenderer.TotalHeight;
-        h += 36f + ProseBottomSpacing; // prose intro (~2 lines)
+        h += UiScale.Scaled(36f) + ProseBottomSpacing; // prose intro (~2 lines)
         h += SelectorRowHeight + SelectorRowBottomSpacing; // board selector
         h += DividerHeight;
         h += viewModel.Entries.Count * RowHeight;

--- a/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/CivilizationMilestoneRenderer.cs
@@ -27,21 +27,21 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationMilestoneRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float SectionLabelHeight = 22f;
-    private const float StatRowHeight = 22f;
-    private const float ProseBottomSpacing = 12f;
-    private const float BoonLineHeight = 22f;
-    private const float BoonProseHeight = 20f;
-    private const float DeedNameHeight = 22f;
-    private const float DeedProgressRowHeight = 22f;
-    private const float DeedItemSpacing = 10f;
-    private const float ProgressBarHeight = 12f;
-    private const float ProgressBarIndent = 22f;
-    private const float ProgressBarWidth = 160f;
-    private const float RefreshGlyphSize = 22f;
-    private const float ScrollbarWidth = 16f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float SectionLabelHeight => UiScale.Scaled(22f);
+    private static float StatRowHeight => UiScale.Scaled(22f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float BoonLineHeight => UiScale.Scaled(22f);
+    private static float BoonProseHeight => UiScale.Scaled(20f);
+    private static float DeedNameHeight => UiScale.Scaled(22f);
+    private static float DeedProgressRowHeight => UiScale.Scaled(22f);
+    private static float DeedItemSpacing => UiScale.Scaled(10f);
+    private static float ProgressBarHeight => UiScale.Scaled(12f);
+    private static float ProgressBarIndent => UiScale.Scaled(22f);
+    private static float ProgressBarWidth => UiScale.Scaled(160f);
+    private static float RefreshGlyphSize => UiScale.Scaled(22f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
 
     public static CivilizationMilestoneRenderResult Draw(
         CivilizationMilestoneViewModel viewModel,
@@ -137,7 +137,7 @@ internal static class CivilizationMilestoneRenderer
         List<MilestoneEvent> events)
     {
         var bx = paneX + contentWidth - RefreshGlyphSize;
-        var by = stripTopY + ChapterStripRenderer.TopPadding + 6f;
+        var by = stripTopY + ChapterStripRenderer.TopPadding + UiScale.Scaled(6f);
         if (ButtonRenderer.DrawButton(drawList, string.Empty,
                 bx, by, RefreshGlyphSize, RefreshGlyphSize,
                 isPrimary: false, enabled: !viewModel.IsLoading))
@@ -147,7 +147,7 @@ internal static class CivilizationMilestoneRenderer
         ChromeRenderer.DrawRefreshArrow(drawList,
             bx + RefreshGlyphSize / 2f,
             by + RefreshGlyphSize / 2f,
-            RefreshGlyphSize - 6f,
+            RefreshGlyphSize - UiScale.Scaled(6f),
             ColorPalette.LightText);
     }
 
@@ -164,7 +164,7 @@ internal static class CivilizationMilestoneRenderer
 
         TextRenderer.DrawInfoText(drawList, prose, x, y, width, Body, ColorPalette.White);
         var lines = TextRenderer.MeasureWrappedHeight(prose, width, Body);
-        return y + (lines > 0 ? lines : Body + 6f) + ProseBottomSpacing;
+        return y + (lines > 0 ? lines : Body + UiScale.Scaled(6f)) + ProseBottomSpacing;
     }
 
     private static float DrawStandingSection(
@@ -194,7 +194,7 @@ internal static class CivilizationMilestoneRenderer
             x, currentY, width);
         currentY += StatRowHeight;
 
-        return currentY + 6f;
+        return currentY + UiScale.Scaled(6f);
     }
 
     private static float DrawBoonsSection(
@@ -213,12 +213,12 @@ internal static class CivilizationMilestoneRenderer
             TextRenderer.DrawInfoText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_MILESTONES_BOONS_EMPTY),
                 x, currentY, width, Secondary, ColorPalette.Grey);
-            return currentY + BoonLineHeight + 6f;
+            return currentY + BoonLineHeight + UiScale.Scaled(6f);
         }
 
         foreach (var boon in phrases)
         {
-            DrawDiamondBullet(drawList, x + 4f, currentY + Body / 2f - 1f);
+            DrawDiamondBullet(drawList, x + UiScale.Scaled(4f), currentY + Body / 2f - UiScale.Scaled(1f));
             drawList.AddText(ImGui.GetFont(), Body,
                 new Vector2(x + ProgressBarIndent, currentY),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold),
@@ -232,14 +232,14 @@ internal static class CivilizationMilestoneRenderer
             currentY += BoonProseHeight;
         }
 
-        return currentY + 6f;
+        return currentY + UiScale.Scaled(6f);
     }
 
     private static void DrawDiamondBullet(ImDrawListPtr drawList, float cx, float cy)
     {
-        ChromeRenderer.DrawDiamond(drawList, cx + 4f, cy, 4f, ColorPalette.Gold);
+        ChromeRenderer.DrawDiamond(drawList, cx + UiScale.Scaled(4f), cy, UiScale.Scaled(4f), ColorPalette.Gold);
         // Inner spark for the fleuron — small centre highlight.
-        drawList.AddCircleFilled(new Vector2(cx + 4f, cy), 1.2f,
+        drawList.AddCircleFilled(new Vector2(cx + UiScale.Scaled(4f), cy), UiScale.Scaled(1.2f),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.LightText));
     }
 
@@ -269,7 +269,7 @@ internal static class CivilizationMilestoneRenderer
         MilestoneProgressDto deed,
         float x, float y, float width)
     {
-        var markCx = x + 8f;
+        var markCx = x + UiScale.Scaled(8f);
         var markCy = y + DeedNameHeight / 2f;
         if (deed.IsCompleted)
             DrawCheckmark(drawList, markCx, markCy);
@@ -280,7 +280,7 @@ internal static class CivilizationMilestoneRenderer
             ? ImGui.ColorConvertFloat4ToU32(ColorPalette.LightText)
             : ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
         drawList.AddText(ImGui.GetFont(), SubsectionLabel,
-            new Vector2(x + ProgressBarIndent, y + 2f),
+            new Vector2(x + ProgressBarIndent, y + UiScale.Scaled(2f)),
             nameColor, deed.MilestoneName);
 
         var currentY = y + DeedNameHeight;
@@ -298,7 +298,7 @@ internal static class CivilizationMilestoneRenderer
         else
         {
             var barX = x + ProgressBarIndent;
-            var barY = currentY + 4f;
+            var barY = currentY + UiScale.Scaled(4f);
             var pct = deed.TargetValue > 0
                 ? Math.Clamp((float)deed.CurrentValue / deed.TargetValue, 0f, 1f)
                 : 0f;
@@ -311,7 +311,7 @@ internal static class CivilizationMilestoneRenderer
                 LocalizationKeys.UI_CIVILIZATION_MILESTONES_DEEDS_COUNT,
                 deed.CurrentValue, deed.TargetValue, verb);
             drawList.AddText(ImGui.GetFont(), Secondary,
-                new Vector2(barX + ProgressBarWidth + 10f, currentY + 2f),
+                new Vector2(barX + ProgressBarWidth + UiScale.Scaled(10f), currentY + UiScale.Scaled(2f)),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.White),
                 countText);
             currentY += DeedProgressRowHeight;
@@ -323,18 +323,18 @@ internal static class CivilizationMilestoneRenderer
     private static void DrawCheckmark(ImDrawListPtr drawList, float cx, float cy)
     {
         var color = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        var s = 5f;
+        var s = UiScale.Scaled(5f);
         var a = new Vector2(cx - s, cy);
-        var b = new Vector2(cx - 1f, cy + s - 1f);
-        var c = new Vector2(cx + s, cy - s + 1f);
-        drawList.AddLine(a, b, color, 1.8f);
-        drawList.AddLine(b, c, color, 1.8f);
+        var b = new Vector2(cx - UiScale.Scaled(1f), cy + s - UiScale.Scaled(1f));
+        var c = new Vector2(cx + s, cy - s + UiScale.Scaled(1f));
+        drawList.AddLine(a, b, color, UiScale.Scaled(1.8f));
+        drawList.AddLine(b, c, color, UiScale.Scaled(1.8f));
     }
 
     private static void DrawOpenCircle(ImDrawListPtr drawList, float cx, float cy)
     {
         var color = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.7f);
-        drawList.AddCircle(new Vector2(cx, cy), 5f, color, 0, 1.4f);
+        drawList.AddCircle(new Vector2(cx, cy), UiScale.Scaled(5f), color, 0, UiScale.Scaled(1.4f));
     }
 
     private static float DrawDivider(ImDrawListPtr drawList, float x, float y, float width)
@@ -349,18 +349,18 @@ internal static class CivilizationMilestoneRenderer
         var h = PaneHeaderRenderer.TotalHeight;
 
         // Prose intro (~2 lines)
-        h += 36f + ProseBottomSpacing;
+        h += UiScale.Scaled(36f) + ProseBottomSpacing;
 
         // Standing: heading + 2 leader rows + bottom pad
         h += DividerHeight;
-        h += SectionLabelHeight + StatRowHeight * 2 + 6f;
+        h += SectionLabelHeight + StatRowHeight * 2 + UiScale.Scaled(6f);
 
         // Boons: heading + N lines (or empty single line)
         h += DividerHeight;
         var boonCount = MilestonePhrases.ActiveBonusPhrases(viewModel.Bonuses).Count();
         h += SectionLabelHeight + (boonCount > 0
             ? boonCount * (BoonLineHeight + BoonProseHeight)
-            : BoonLineHeight) + 6f;
+            : BoonLineHeight) + UiScale.Scaled(6f);
 
         // Deeds: heading + per-item (name + progress/set-down row + spacing)
         h += DividerHeight;

--- a/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoDescriptionRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Civilization/Info/CivilizationInfoDescriptionRenderer.cs
@@ -21,13 +21,13 @@ namespace DivineAscension.GUI.UI.Renderers.Civilization.Info;
 [ExcludeFromCodeCoverage]
 internal static class CivilizationInfoDescriptionRenderer
 {
-    private const float HeadingHeight = 22f;
-    private const float EditGlyphSize = 20f;
-    private const float ButtonHeight = 26f;
-    private const float ButtonWidth = 80f;
-    private const float ButtonGap = 8f;
-    private const float EditBoxHeight = 80f;
-    private const float SectionBottomSpacing = 8f;
+    private static float HeadingHeight => UiScale.Scaled(22f);
+    private static float EditGlyphSize => UiScale.Scaled(20f);
+    private static float ButtonHeight => UiScale.Scaled(26f);
+    private static float ButtonWidth => UiScale.Scaled(80f);
+    private static float ButtonGap => UiScale.Scaled(8f);
+    private static float EditBoxHeight => UiScale.Scaled(80f);
+    private static float SectionBottomSpacing => UiScale.Scaled(8f);
 
     public static float Draw(
         CivilizationInfoViewModel vm,
@@ -55,7 +55,7 @@ internal static class CivilizationInfoDescriptionRenderer
             ChromeRenderer.DrawPencil(drawList,
                 glyphX + EditGlyphSize / 2f,
                 currentY + EditGlyphSize / 2f,
-                EditGlyphSize - 8f,
+                EditGlyphSize - UiScale.Scaled(8f),
                 ColorPalette.LightText);
         }
 
@@ -68,7 +68,7 @@ internal static class CivilizationInfoDescriptionRenderer
             if (newDescription != vm.DescriptionText)
                 events.Add(new InfoEvent.DescriptionChanged(newDescription));
 
-            currentY += EditBoxHeight + 6f;
+            currentY += EditBoxHeight + UiScale.Scaled(6f);
 
             var rightX = x + width;
             var cancelX = rightX - ButtonWidth;

--- a/DivineAscension/GUI/UI/Utilities/Spacing.cs
+++ b/DivineAscension/GUI/UI/Utilities/Spacing.cs
@@ -7,22 +7,24 @@ namespace DivineAscension.GUI.UI.Utilities;
 /// </summary>
 internal static class Spacing
 {
+    // All values scale with UiScale.Factor so spacing tracks the UI scale (#600).
+
     // Horizontal padding inside a content panel (gap from the panel edge).
-    public const float ContentPadding = 16f;
+    public static float ContentPadding => UiScale.Scaled(16f);
 
     // Gap between the back-button row and the panel content below it.
-    public const float BackButtonRow = 44f;
+    public static float BackButtonRow => UiScale.Scaled(44f);
 
     // Vertical rhythm — pick one of these for "blank space between things".
-    public const float Tight = 8f;
-    public const float Compact = 12f;
-    public const float Comfortable = 16f;
-    public const float Section = 24f;
-    public const float Block = 32f;
+    public static float Tight => UiScale.Scaled(8f);
+    public static float Compact => UiScale.Scaled(12f);
+    public static float Comfortable => UiScale.Scaled(16f);
+    public static float Section => UiScale.Scaled(24f);
+    public static float Block => UiScale.Scaled(32f);
 
     // Spacing between a section header label and the first content row underneath it.
-    public const float HeaderToContent = 28f;
+    public static float HeaderToContent => UiScale.Scaled(28f);
 
     // Gap between repeated rows in a vertical list (members, milestones, etc.).
-    public const float ListItemGap = 8f;
+    public static float ListItemGap => UiScale.Scaled(8f);
 }


### PR DESCRIPTION
Part of epic #584 — the per-area layout grind. Scales the remaining Civilization leaf renderers so their content panes lay out proportionally at GUIScale > 1 (the #589 chrome + #607 controls already scale; this is the content inside).

## Scope

Per the established `Scaled()` convention (layout consts → scaled `static` properties, zero use-site churn; inline offsets/sizes/paddings/gaps/radii/thicknesses → `UiScale.Scaled(...)`):

- `CivilizationMilestoneRenderer`, `CivilizationLeaderboardRenderer`, `CivilizationInfoRenderer`, `CivilizationDetailRenderer`, `CivilizationHolySitesRenderer`, `CivilizationEditRenderer`, `CivilizationChronicleRenderer`, `CivilizationCreateRenderer`, `CivilizationInfoDescriptionRenderer`.
- Shared `Spacing.cs` constants → scaled properties.

Already-scaled Civ files (chrome/controls) were done in #589/#607 and aren't touched here.

Left unscaled (verified): `/2f` centring divisors, `*N` multipliers over already-scaled bases, colour alphas, loop/segment counts, angles, epsilons, `CalcTextSize`/`MeasureWrappedHeight` results, font sizes, region/width/height params. **No behavioural change at Factor 1.0.**

## How

10 files via parallel agents on the convention, then built + diff-sanity-checked (no divisor/alpha mis-scaling) + full suite.

## Tests

**2515 passed**, build clean.

Closes #596