### PR TITLE
feat(ui): scale Religion content renderers (#595)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Religion/Activity/ReligionActivityFeedRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Activity/ReligionActivityFeedRenderer.cs
@@ -22,13 +22,13 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Activity;
 /// </summary>
 internal static class ReligionActivityFeedRenderer
 {
-    public const float DayHeadingHeight = 24f;
-    public const float DayHeadingTopSpacing = 4f;
-    public const float EntryRowHeight = 22f;
-    public const float EntryLeftPadding = 16f;
-    public const float GlyphSize = 14f;
-    public const float GlyphToTextGap = 8f;
-    public const float DayBottomSpacing = 8f;
+    public static float DayHeadingHeight => UiScale.Scaled(24f);
+    public static float DayHeadingTopSpacing => UiScale.Scaled(4f);
+    public static float EntryRowHeight => UiScale.Scaled(22f);
+    public static float EntryLeftPadding => UiScale.Scaled(16f);
+    public static float GlyphSize => UiScale.Scaled(14f);
+    public static float GlyphToTextGap => UiScale.Scaled(8f);
+    public static float DayBottomSpacing => UiScale.Scaled(8f);
 
     public static float Draw(
         ReligionActivityViewModel viewModel,
@@ -105,7 +105,7 @@ internal static class ReligionActivityFeedRenderer
         DomainGlyphRenderer.Draw(drawList, domain, glyphMin, glyphMax, ColorPalette.White);
 
         var textX = x + GlyphSize + GlyphToTextGap;
-        var textY = y + 2f;
+        var textY = y + UiScale.Scaled(2f);
 
         var actionPhrase = FormatActionPhrase(entry.ActionType);
         var line = LocalizationService.Instance.Get(
@@ -120,8 +120,8 @@ internal static class ReligionActivityFeedRenderer
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Vermilion), favorText);
 
         // Body line — clip to the gap before the favor column.
-        drawList.PushClipRect(new Vector2(textX, textY - 2f),
-            new Vector2(favorX - 8f, textY + EntryRowHeight), true);
+        drawList.PushClipRect(new Vector2(textX, textY - UiScale.Scaled(2f)),
+            new Vector2(favorX - UiScale.Scaled(8f), textY + EntryRowHeight), true);
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(textX, textY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White), line);
         drawList.PopClipRect();

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoDescriptionRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoDescriptionRenderer.cs
@@ -21,16 +21,16 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Info;
 /// </summary>
 internal static class ReligionInfoDescriptionRenderer
 {
-    private const float HeadingHeight = 22f;
-    private const float EditGlyphSize = 20f;
-    private const float ButtonHeight = 26f;
-    private const float ButtonWidth = 80f;
-    private const float ButtonGap = 8f;
-    private const float EditBoxHeight = 80f;
-    private const float SectionBottomSpacing = 8f;
+    private static float HeadingHeight => UiScale.Scaled(22f);
+    private static float EditGlyphSize => UiScale.Scaled(20f);
+    private static float ButtonHeight => UiScale.Scaled(26f);
+    private static float ButtonWidth => UiScale.Scaled(80f);
+    private static float ButtonGap => UiScale.Scaled(8f);
+    private static float EditBoxHeight => UiScale.Scaled(80f);
+    private static float SectionBottomSpacing => UiScale.Scaled(8f);
     // Fixed reservation sized for the 200-char description cap so the
     // section's vertical footprint doesn't shift with text length.
-    private const float ProseBodyHeight = 80f;
+    private static float ProseBodyHeight => UiScale.Scaled(80f);
 
     public static float Draw(
         ReligionInfoViewModel viewModel,
@@ -61,7 +61,7 @@ internal static class ReligionInfoDescriptionRenderer
             ChromeRenderer.DrawPencil(drawList,
                 glyphX + EditGlyphSize / 2f,
                 currentY + EditGlyphSize / 2f,
-                EditGlyphSize - 8f,
+                EditGlyphSize - UiScale.Scaled(8f),
                 ColorPalette.LightText);
         }
 
@@ -74,7 +74,7 @@ internal static class ReligionInfoDescriptionRenderer
             if (newDescription != viewModel.DescriptionText)
                 events.Add(new InfoEvent.DescriptionChanged(newDescription));
 
-            currentY += EditBoxHeight + 6f;
+            currentY += EditBoxHeight + UiScale.Scaled(6f);
 
             // Save (only when dirty) + Cancel, right-aligned.
             var hasChanges = viewModel.HasDescriptionChanges();

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoFoundingMythRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoFoundingMythRenderer.cs
@@ -19,17 +19,17 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Info;
 /// </summary>
 internal static class ReligionInfoFoundingMythRenderer
 {
-    private const float HeadingHeight = 22f;
-    private const float EditGlyphSize = 20f;
-    private const float ButtonHeight = 26f;
-    private const float ButtonWidth = 80f;
-    private const float ButtonGap = 8f;
-    private const float EditBoxHeight = 200f;
-    private const float SectionBottomSpacing = 8f;
+    private static float HeadingHeight => UiScale.Scaled(22f);
+    private static float EditGlyphSize => UiScale.Scaled(20f);
+    private static float ButtonHeight => UiScale.Scaled(26f);
+    private static float ButtonWidth => UiScale.Scaled(80f);
+    private static float ButtonGap => UiScale.Scaled(8f);
+    private static float EditBoxHeight => UiScale.Scaled(200f);
+    private static float SectionBottomSpacing => UiScale.Scaled(8f);
     // Fixed reservation sized for the 2000-char myth cap (~34 wrapped
     // lines × ~16px line height) so long stories don't shove the
     // sections below up or down on each render.
-    private const float ProseBodyHeight = 540f;
+    private static float ProseBodyHeight => UiScale.Scaled(540f);
 
     public static float Draw(
         ReligionInfoViewModel viewModel,
@@ -59,7 +59,7 @@ internal static class ReligionInfoFoundingMythRenderer
             ChromeRenderer.DrawPencil(drawList,
                 glyphX + EditGlyphSize / 2f,
                 currentY + EditGlyphSize / 2f,
-                EditGlyphSize - 8f,
+                EditGlyphSize - UiScale.Scaled(8f),
                 ColorPalette.LightText);
         }
 
@@ -72,7 +72,7 @@ internal static class ReligionInfoFoundingMythRenderer
             if (newMyth != viewModel.FoundingMythText)
                 events.Add(new InfoEvent.FoundingMythChanged(newMyth));
 
-            currentY += EditBoxHeight + 6f;
+            currentY += EditBoxHeight + UiScale.Scaled(6f);
 
             var hasChanges = viewModel.HasFoundingMythChanges();
             var rightX = x + width;

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoHeaderRenderer.cs
@@ -22,12 +22,12 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Info;
 /// </summary>
 internal static class ReligionInfoHeaderRenderer
 {
-    private const float StatRowHeight = 22f;
-    private const float StatBlockBottomSpacing = 6f;
-    private const float ProseLineHeight = 18f;
-    private const float ProseBottomSpacing = 12f;
-    private const float PrestigeBarHeight = 12f;
-    private const float PrestigeBarMaxWidth = 180f;
+    private static float StatRowHeight => UiScale.Scaled(22f);
+    private static float StatBlockBottomSpacing => UiScale.Scaled(6f);
+    private static float ProseLineHeight => UiScale.Scaled(18f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float PrestigeBarHeight => UiScale.Scaled(12f);
+    private static float PrestigeBarMaxWidth => UiScale.Scaled(180f);
 
     public static float Draw(
         ReligionInfoViewModel viewModel,
@@ -134,16 +134,16 @@ internal static class ReligionInfoHeaderRenderer
         drawList.AddText(new Vector2(x, y), labelColor, label);
 
         var rankSize = ImGui.CalcTextSize(rankName);
-        var rankX = x + labelSize.X + 6f;
+        var rankX = x + labelSize.X + UiScale.Scaled(6f);
         var rankColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
         drawList.AddText(new Vector2(rankX, y), rankColor, rankName);
 
         // Progress bar fills the dot-leader gap between rank-name and numeral.
-        const float padding = 6f;
+        var padding = UiScale.Scaled(6f);
         var barLeft = rankX + rankSize.X + padding;
         var barRight = numeralX - padding;
         var availableBarWidth = barRight - barLeft;
-        if (availableBarWidth > 24f)
+        if (availableBarWidth > UiScale.Scaled(24f))
         {
             var barWidth = System.MathF.Min(availableBarWidth, PrestigeBarMaxWidth);
             var barX = barRight - barWidth;
@@ -158,7 +158,7 @@ internal static class ReligionInfoHeaderRenderer
                     : $"{viewModel.Prestige}/{viewModel.PrestigeRequired}");
         }
 
-        return y + StatRowHeight + 6f;
+        return y + StatRowHeight + UiScale.Scaled(6f);
     }
 
     private static string ToRoman(int n)
@@ -183,11 +183,11 @@ internal static class ReligionInfoHeaderRenderer
         List<InfoEvent> events)
     {
         var currentY = y;
-        const float inputHeight = 28f;
-        const float inputWidth = 300f;
-        const float buttonWidth = 60f;
-        const float buttonHeight = 24f;
-        const float buttonGap = 8f;
+        var inputHeight = UiScale.Scaled(28f);
+        var inputWidth = UiScale.Scaled(300f);
+        var buttonWidth = UiScale.Scaled(60f);
+        var buttonHeight = UiScale.Scaled(24f);
+        var buttonGap = UiScale.Scaled(8f);
 
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INFO_DEITY_LABEL),
@@ -197,7 +197,7 @@ internal static class ReligionInfoHeaderRenderer
             drawList,
             "##editDeityName",
             viewModel.EditDeityNameValue,
-            x + 80f,
+            x + UiScale.Scaled(80f),
             currentY,
             inputWidth,
             inputHeight,
@@ -207,15 +207,15 @@ internal static class ReligionInfoHeaderRenderer
         if (newValue != viewModel.EditDeityNameValue)
             events.Add(new InfoEvent.EditDeityNameChanged(newValue));
 
-        currentY += inputHeight + 4f;
+        currentY += inputHeight + UiScale.Scaled(4f);
 
         if (!string.IsNullOrEmpty(viewModel.DeityNameError))
         {
-            TextRenderer.DrawErrorText(drawList, viewModel.DeityNameError, x + 80f, currentY);
-            currentY += 20f;
+            TextRenderer.DrawErrorText(drawList, viewModel.DeityNameError, x + UiScale.Scaled(80f), currentY);
+            currentY += UiScale.Scaled(20f);
         }
 
-        var buttonX = x + 80f;
+        var buttonX = x + UiScale.Scaled(80f);
         var canSave = !viewModel.IsSavingDeityName &&
                       !string.IsNullOrWhiteSpace(viewModel.EditDeityNameValue) &&
                       viewModel.EditDeityNameValue.Length >= 2 &&
@@ -243,7 +243,7 @@ internal static class ReligionInfoHeaderRenderer
             events.Add(new InfoEvent.EditDeityNameCancel());
         }
 
-        currentY += buttonHeight + 8f;
+        currentY += buttonHeight + UiScale.Scaled(8f);
         return currentY;
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoMottoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Info/ReligionInfoMottoRenderer.cs
@@ -19,13 +19,13 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Info;
 /// </summary>
 internal static class ReligionInfoMottoRenderer
 {
-    private const float HeadingHeight = 22f;
-    private const float EditGlyphSize = 20f;
-    private const float ButtonHeight = 26f;
-    private const float ButtonWidth = 80f;
-    private const float ButtonGap = 8f;
-    private const float InputHeight = 28f;
-    private const float SectionBottomSpacing = 8f;
+    private static float HeadingHeight => UiScale.Scaled(22f);
+    private static float EditGlyphSize => UiScale.Scaled(20f);
+    private static float ButtonHeight => UiScale.Scaled(26f);
+    private static float ButtonWidth => UiScale.Scaled(80f);
+    private static float ButtonGap => UiScale.Scaled(8f);
+    private static float InputHeight => UiScale.Scaled(28f);
+    private static float SectionBottomSpacing => UiScale.Scaled(8f);
     private const int MaxLen = 80;
 
     public static float Draw(
@@ -54,7 +54,7 @@ internal static class ReligionInfoMottoRenderer
             ChromeRenderer.DrawPencil(drawList,
                 glyphX + EditGlyphSize / 2f,
                 currentY + EditGlyphSize / 2f,
-                EditGlyphSize - 8f,
+                EditGlyphSize - UiScale.Scaled(8f),
                 ColorPalette.LightText);
         }
 
@@ -69,7 +69,7 @@ internal static class ReligionInfoMottoRenderer
             if (newMotto != viewModel.MottoText)
                 events.Add(new InfoEvent.MottoChanged(newMotto));
 
-            currentY += InputHeight + 6f;
+            currentY += InputHeight + UiScale.Scaled(6f);
 
             var hasChanges = viewModel.HasMottoChanges();
             var rightX = x + width;
@@ -110,8 +110,8 @@ internal static class ReligionInfoMottoRenderer
                 // Paint primitive curly-quote glyphs flanking the motto since
                 // the font lacks U+201C/U+201D coverage. Motto is single-line
                 // (80-char cap), so the close quote hugs the text end.
-                const float glyphSize = 14f;
-                const float glyphGap = 6f;
+                var glyphSize = UiScale.Scaled(14f);
+                var glyphGap = UiScale.Scaled(6f);
                 var textIndent = glyphSize + glyphGap;
                 var openCx = x + glyphSize / 2f;
                 var glyphCy = currentY + glyphSize / 2f;
@@ -130,13 +130,13 @@ internal static class ReligionInfoMottoRenderer
                     colorOverride: ColorPalette.Grey);
 
                 var textHeight = TextRenderer.MeasureWrappedHeight(prose, width - textIndent * 2f);
-                currentY += (textHeight > 0 ? textHeight : 20f) + SectionBottomSpacing;
+                currentY += (textHeight > 0 ? textHeight : UiScale.Scaled(20f)) + SectionBottomSpacing;
             }
             else
             {
                 TextRenderer.DrawInfoText(drawList, prose, x, currentY, width, Secondary, proseColor);
                 var textHeight = TextRenderer.MeasureWrappedHeight(prose, width);
-                currentY += (textHeight > 0 ? textHeight : 20f) + SectionBottomSpacing;
+                currentY += (textHeight > 0 ? textHeight : UiScale.Scaled(20f)) + SectionBottomSpacing;
             }
         }
 

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionActivityRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionActivityRenderer.cs
@@ -26,13 +26,13 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionActivityRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float ScrollbarWidth = 16f;
-    private const float ClosingLineHeight = 24f;
-    private const float ClosingLineTopSpacing = 6f;
-    private const float RefreshGlyphSize = 22f;
-    private const float RefreshGlyphGap = 6f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float ClosingLineHeight => UiScale.Scaled(24f);
+    private static float ClosingLineTopSpacing => UiScale.Scaled(6f);
+    private static float RefreshGlyphSize => UiScale.Scaled(22f);
+    private static float RefreshGlyphGap => UiScale.Scaled(6f);
 
     public static ReligionActivityRenderResult Draw(ReligionActivityViewModel viewModel)
     {
@@ -70,7 +70,7 @@ internal static class ReligionActivityRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -124,7 +124,7 @@ internal static class ReligionActivityRenderer
     {
         var stripY = paneY + ChapterStripRenderer.TopPadding - scrollY;
         var glyphX = x + contentWidth - RefreshGlyphSize - RefreshGlyphGap;
-        var glyphY = stripY + 6f;
+        var glyphY = stripY + UiScale.Scaled(6f);
 
         var clicked = ButtonRenderer.DrawButton(drawList, string.Empty,
             glyphX, glyphY, RefreshGlyphSize, RefreshGlyphSize,
@@ -133,7 +133,7 @@ internal static class ReligionActivityRenderer
         ChromeRenderer.DrawRefreshArrow(drawList,
             glyphX + RefreshGlyphSize / 2f,
             glyphY + RefreshGlyphSize / 2f,
-            RefreshGlyphSize - 6f,
+            RefreshGlyphSize - UiScale.Scaled(6f),
             ColorPalette.LightText);
 
         return clicked;

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionChronicleRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionChronicleRenderer.cs
@@ -25,17 +25,17 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionChronicleRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float IntroBottomSpacing = 10f;
-    private const float IntroLineHeight = 18f;
-    private const float DiamondHalfSize = 3.5f;
-    private const float DiamondLeftPadding = 4f;
-    private const float ProseIndent = 18f;
-    private const float EntryGap = 8f;
-    private const float ScrollbarWidth = 16f;
-    private const float ClosingLineHeight = 24f;
-    private const float ClosingLineTopSpacing = 6f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float IntroBottomSpacing => UiScale.Scaled(10f);
+    private static float IntroLineHeight => UiScale.Scaled(18f);
+    private static float DiamondHalfSize => UiScale.Scaled(3.5f);
+    private static float DiamondLeftPadding => UiScale.Scaled(4f);
+    private static float ProseIndent => UiScale.Scaled(18f);
+    private static float EntryGap => UiScale.Scaled(8f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float ClosingLineHeight => UiScale.Scaled(24f);
+    private static float ClosingLineTopSpacing => UiScale.Scaled(6f);
 
     public static ReligionChronicleRenderResult Draw(ReligionChronicleViewModel vm, ImDrawListPtr drawList)
     {
@@ -72,7 +72,7 @@ internal static class ReligionChronicleRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -111,7 +111,7 @@ internal static class ReligionChronicleRenderer
         var proseWidth = contentWidth - ProseIndent;
         foreach (var entry in vm.Chronicle)
         {
-            var centerY = currentY + (Secondary + 6f) / 2f;
+            var centerY = currentY + (Secondary + UiScale.Scaled(6f)) / 2f;
             ChromeRenderer.DrawDiamond(drawList,
                 x + DiamondLeftPadding + DiamondHalfSize, centerY,
                 DiamondHalfSize,

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionCreateRenderer.cs
@@ -25,13 +25,13 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionCreateRenderer
 {
-    private const float FormWidth = 500f;
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float SectionLabelHeight = 22f;
-    private const float FieldRowHeight = 40f;
-    private const float InputHeight = 32f;
-    private const float FooterTopPadding = 12f;
+    private static float FormWidth => UiScale.Scaled(500f);
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float SectionLabelHeight => UiScale.Scaled(22f);
+    private static float FieldRowHeight => UiScale.Scaled(40f);
+    private static float InputHeight => UiScale.Scaled(32f);
+    private static float FooterTopPadding => UiScale.Scaled(12f);
 
     public static ReligionCreateRenderResult Draw(
         ReligionCreateViewModel viewModel,
@@ -54,7 +54,7 @@ internal static class ReligionCreateRenderer
         // === PROSE INTRO ===
         var intro = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_CREATE_INTRO);
         TextRenderer.DrawInfoText(drawList, intro, formX, currentY, FormWidth, Body, ColorPalette.White);
-        currentY += TextRenderer.MeasureWrappedHeight(intro, FormWidth, Body) + 8f;
+        currentY += TextRenderer.MeasureWrappedHeight(intro, FormWidth, Body) + UiScale.Scaled(8f);
 
         currentY = DrawDivider(drawList, formX, currentY, FormWidth);
 
@@ -77,21 +77,21 @@ internal static class ReligionCreateRenderer
         var newIsPublic = CheckboxRenderer.DrawCheckbox(drawList, vowLabel, formX, currentY, viewModel.IsPublic);
         if (newIsPublic != viewModel.IsPublic)
             events.Add(new CreateEvent.IsPublicChanged(newIsPublic));
-        currentY += 32f;
+        currentY += UiScale.Scaled(32f);
 
         // Error message (if any) before the vow button.
         if (!string.IsNullOrEmpty(viewModel.ErrorMessage))
         {
             TextRenderer.DrawErrorText(drawList, viewModel.ErrorMessage, formX, currentY);
-            currentY += 26f;
+            currentY += UiScale.Scaled(26f);
         }
 
         currentY = DrawDivider(drawList, formX, currentY, FormWidth);
 
         // === VOW BUTTON (right-aligned) ===
         currentY += FooterTopPadding;
-        const float buttonWidth = 220f;
-        const float buttonHeight = 36f;
+        var buttonWidth = UiScale.Scaled(220f);
+        var buttonHeight = UiScale.Scaled(36f);
         var buttonX = formX + FormWidth - buttonWidth;
 
         if (ButtonRenderer.DrawButton(
@@ -107,7 +107,7 @@ internal static class ReligionCreateRenderer
             events.Add(new CreateEvent.SubmitClicked());
         }
 
-        currentY += buttonHeight + 6f;
+        currentY += buttonHeight + UiScale.Scaled(6f);
 
         if (!string.IsNullOrEmpty(hoveredDomainName))
         {
@@ -159,21 +159,21 @@ internal static class ReligionCreateRenderer
                 TextRenderer.DrawErrorText(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_NAME_ERROR_TOO_SHORT),
                     formX, currentY);
-                currentY += 25f;
+                currentY += UiScale.Scaled(25f);
             }
             else if (viewModel.ReligionName.Length > 32)
             {
                 TextRenderer.DrawErrorText(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_NAME_ERROR_TOO_LONG),
                     formX, currentY);
-                currentY += 25f;
+                currentY += UiScale.Scaled(25f);
             }
             else if (viewModel.ReligionNameHasProfanity)
             {
                 TextRenderer.DrawErrorText(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_NAME_ERROR_PROFANITY,
                         viewModel.ReligionNameProfanityWord ?? ""), formX, currentY);
-                currentY += 25f;
+                currentY += UiScale.Scaled(25f);
             }
         }
 
@@ -209,21 +209,21 @@ internal static class ReligionCreateRenderer
                 TextRenderer.DrawErrorText(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_DEITY_NAME_ERROR_TOO_SHORT),
                     formX, currentY);
-                currentY += 25f;
+                currentY += UiScale.Scaled(25f);
             }
             else if (viewModel.DeityName.Length > 48)
             {
                 TextRenderer.DrawErrorText(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_DEITY_NAME_ERROR_TOO_LONG),
                     formX, currentY);
-                currentY += 25f;
+                currentY += UiScale.Scaled(25f);
             }
             else if (viewModel.DeityNameHasProfanity)
             {
                 TextRenderer.DrawErrorText(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_NAME_ERROR_PROFANITY,
                         viewModel.DeityNameProfanityWord ?? ""), formX, currentY);
-                currentY += 25f;
+                currentY += UiScale.Scaled(25f);
             }
         }
 
@@ -257,14 +257,14 @@ internal static class ReligionCreateRenderer
             TextRenderer.DrawErrorText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.NET_RELIGION_MOTTO_TOO_LONG),
                 formX, currentY);
-            currentY += 25f;
+            currentY += UiScale.Scaled(25f);
         }
         else if (viewModel.MottoHasProfanity)
         {
             TextRenderer.DrawErrorText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_NAME_ERROR_PROFANITY,
                     viewModel.MottoProfanityWord ?? ""), formX, currentY);
-            currentY += 25f;
+            currentY += UiScale.Scaled(25f);
         }
 
         return currentY;
@@ -277,15 +277,15 @@ internal static class ReligionCreateRenderer
         TextRenderer.DrawLabel(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_PATRON_HEADING),
             formX, currentY, SubsectionLabel, ColorPalette.Gold);
-        currentY += SectionLabelHeight + 4f;
+        currentY += SectionLabelHeight + UiScale.Scaled(4f);
 
         var currentDomainIndex = viewModel.GetCurrentDomainIndex();
         var domains = viewModel.AvailableDomains;
         var count = domains.Length;
         if (count == 0) return null;
 
-        const float buttonHeight = 36f;
-        const float spacing = 6f;
+        var buttonHeight = UiScale.Scaled(36f);
+        var spacing = UiScale.Scaled(6f);
         var buttonWidth = (fieldWidth - spacing * (count - 1)) / count;
 
         string? hoveredDomainName = null;
@@ -301,7 +301,7 @@ internal static class ReligionCreateRenderer
                 hoveredDomainName = domainName;
         }
 
-        currentY += buttonHeight + 4f;
+        currentY += buttonHeight + UiScale.Scaled(4f);
         return hoveredDomainName;
     }
 
@@ -323,10 +323,10 @@ internal static class ReligionCreateRenderer
                 : ColorPalette.DarkBrown;
         if (hovering && !isSelected) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
 
-        drawList.AddRectFilled(topLeft, bottomRight, ImGui.ColorConvertFloat4ToU32(bgColor), 4f);
+        drawList.AddRectFilled(topLeft, bottomRight, ImGui.ColorConvertFloat4ToU32(bgColor), UiScale.Scaled(4f));
         drawList.AddRect(topLeft, bottomRight,
             ImGui.ColorConvertFloat4ToU32(isSelected ? ColorPalette.Gold : ColorPalette.BorderColor),
-            4f, ImDrawFlags.None, 2f);
+            UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
         // Glyph centered in the button — tooltip provides the domain name on hover.
         var glyphSize = height * 0.7f;

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionDetailRenderer.cs
@@ -30,22 +30,22 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionDetailRenderer
 {
-    private const float TopPadding = 8f;
-    private const float NavRowHeight = 32f;
-    private const float NavRowBottomPadding = 12f;
-    private const float NavBackWidth = 36f;
-    private const float NavJoinWidth = 130f;
-    private const float BackGlyphSize = 14f;
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float StatRowHeight = 22f;
-    private const float StatBlockBottomSpacing = 8f;
-    private const float ProseBottomSpacing = 12f;
-    private const float PrestigeBarHeight = 12f;
-    private const float PrestigeBarMaxWidth = 180f;
-    private const float MemberRowHeight = 26f;
-    private const float MemberRowGap = 2f;
-    private const float SectionBottomSpacing = 8f;
+    private static float TopPadding => UiScale.Scaled(8f);
+    private static float NavRowHeight => UiScale.Scaled(32f);
+    private static float NavRowBottomPadding => UiScale.Scaled(12f);
+    private static float NavBackWidth => UiScale.Scaled(36f);
+    private static float NavJoinWidth => UiScale.Scaled(130f);
+    private static float BackGlyphSize => UiScale.Scaled(14f);
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float StatRowHeight => UiScale.Scaled(22f);
+    private static float StatBlockBottomSpacing => UiScale.Scaled(8f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float PrestigeBarHeight => UiScale.Scaled(12f);
+    private static float PrestigeBarMaxWidth => UiScale.Scaled(180f);
+    private static float MemberRowHeight => UiScale.Scaled(26f);
+    private static float MemberRowGap => UiScale.Scaled(2f);
+    private static float SectionBottomSpacing => UiScale.Scaled(8f);
 
     public static ReligionDetailRendererResult Draw(
         ReligionDetailViewModel vm,
@@ -65,7 +65,7 @@ internal static class ReligionDetailRenderer
             TextRenderer.DrawInfoText(
                 drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_DETAIL_LOADING),
-                vm.X, currentY + 8f, contentWidth);
+                vm.X, currentY + UiScale.Scaled(8f), contentWidth);
             return new ReligionDetailRendererResult(events, vm.Height);
         }
 
@@ -124,7 +124,7 @@ internal static class ReligionDetailRenderer
             if (ButtonRenderer.DrawButton(
                     drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_ACTION_JOIN),
-                    joinX, y, NavJoinWidth, NavRowHeight + 4f,
+                    joinX, y, NavJoinWidth, NavRowHeight + UiScale.Scaled(4f),
                     isPrimary: true))
             {
                 events.Add(new DetailEvent.JoinClicked(vm.ReligionUID));
@@ -225,18 +225,18 @@ internal static class ReligionDetailRenderer
         drawList.AddText(new Vector2(x, y), labelCol, label);
 
         var rankSize = ImGui.CalcTextSize(rankName);
-        var rankX = x + labelSize.X + 6f;
+        var rankX = x + labelSize.X + UiScale.Scaled(6f);
         drawList.AddText(new Vector2(rankX, y), rankCol, rankName);
 
         var numeralSize = ImGui.CalcTextSize(numeral);
         var numeralX = x + width - numeralSize.X;
         drawList.AddText(new Vector2(numeralX, y), numeralCol, numeral);
 
-        const float padding = 6f;
+        var padding = UiScale.Scaled(6f);
         var barLeft = rankX + rankSize.X + padding;
         var barRight = numeralX - padding;
         var availableBarWidth = barRight - barLeft;
-        if (availableBarWidth > 24f)
+        if (availableBarWidth > UiScale.Scaled(24f))
         {
             var barWidth = MathF.Min(availableBarWidth, PrestigeBarMaxWidth);
             var barX = barRight - barWidth;
@@ -328,9 +328,9 @@ internal static class ReligionDetailRenderer
         // Diamond marker is painted as a primitive (Dingbats glyphs don't
         // render in the loaded font). DrawLeader then paints the row with a
         // dot-leader run filling the gap between name and favor rank.
-        const float diamondLeftPadding = 4f;
-        const float diamondHalfSize = 3.5f;
-        const float diamondToLabelGap = 10f;
+        var diamondLeftPadding = UiScale.Scaled(4f);
+        var diamondHalfSize = UiScale.Scaled(3.5f);
+        var diamondToLabelGap = UiScale.Scaled(10f);
 
         var centerY = y + height / 2f;
         ChromeRenderer.DrawDiamond(drawList,
@@ -339,7 +339,7 @@ internal static class ReligionDetailRenderer
             ColorPalette.Gold * 0.6f);
 
         var leaderX = x + diamondLeftPadding + diamondHalfSize * 2f + diamondToLabelGap;
-        var leaderWidth = MathF.Max(width - (leaderX - x) - 8f, 40f);
+        var leaderWidth = MathF.Max(width - (leaderX - x) - UiScale.Scaled(8f), UiScale.Scaled(40f));
         var rowY = centerY - Body * 0.5f;
         ChromeRenderer.DrawLeader(drawList,
             member.PlayerName,

--- a/DivineAscension/GUI/UI/Renderers/Religion/ReligionInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/ReligionInfoRenderer.cs
@@ -25,10 +25,10 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class ReligionInfoRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float FooterTopPadding = 12f;
-    private const float ScrollbarWidth = 16f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float FooterTopPadding => UiScale.Scaled(12f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
 
     public static ReligionInfoRenderResult Draw(
         ReligionInfoViewModel viewModel,
@@ -67,7 +67,7 @@ internal static class ReligionInfoRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -104,11 +104,11 @@ internal static class ReligionInfoRenderer
         // prose past the footer. Myth absorbs the squeeze first since it
         // owns the bulk of the vertical budget.
         var paneBottomY = y + height;
-        var actionsFooterReserve = FooterTopPadding + 34f + 6f;
+        var actionsFooterReserve = FooterTopPadding + UiScale.Scaled(34f) + UiScale.Scaled(6f);
         var dividerBetween = DividerHeight;
-        const float headingAndSpacing = 22f + 8f;
-        const float purposeMax = 80f;
-        const float mythMax = 540f;
+        var headingAndSpacing = UiScale.Scaled(22f) + UiScale.Scaled(8f);
+        var purposeMax = UiScale.Scaled(80f);
+        var mythMax = UiScale.Scaled(540f);
         // Remaining height for both prose bodies after fixed reservations.
         var remainingForProse = paneBottomY - currentY
             - headingAndSpacing       // purpose heading + spacing
@@ -117,9 +117,9 @@ internal static class ReligionInfoRenderer
             - actionsFooterReserve;
         // Purpose keeps its small max unless the pane is so small it forces
         // a share; floor at a readable 40px.
-        var purposeBody = MathF.Max(40f, MathF.Min(purposeMax, remainingForProse * 0.15f));
-        if (remainingForProse < purposeMax + 80f) purposeBody = MathF.Max(40f, remainingForProse * 0.25f);
-        var mythBody = MathF.Max(60f, MathF.Min(mythMax, remainingForProse - purposeBody));
+        var purposeBody = MathF.Max(UiScale.Scaled(40f), MathF.Min(purposeMax, remainingForProse * 0.15f));
+        if (remainingForProse < purposeMax + UiScale.Scaled(80f)) purposeBody = MathF.Max(UiScale.Scaled(40f), remainingForProse * 0.25f);
+        var mythBody = MathF.Max(UiScale.Scaled(60f), MathF.Min(mythMax, remainingForProse - purposeBody));
 
         // === OF THE ORDER'S PURPOSE ===
         currentY = ReligionInfoDescriptionRenderer.Draw(viewModel, drawList, x, currentY, contentWidth, events, purposeBody);
@@ -161,16 +161,16 @@ internal static class ReligionInfoRenderer
         // Pane header (icon row + divider below)
         h += PaneHeaderRenderer.TotalHeight;
         // Prose intro (~2 lines)
-        h += 36f;
+        h += UiScale.Scaled(36f);
         // Stat block: deity / founder / members / prestige
-        h += 22f * 4 + 8f;
-        if (viewModel.IsEditingDeityName) h += 80f;
+        h += UiScale.Scaled(22f) * 4 + UiScale.Scaled(8f);
+        if (viewModel.IsEditingDeityName) h += UiScale.Scaled(80f);
 
         // Motto block
         if (viewModel.IsFounder && viewModel.IsEditingMotto)
-            h += 22f + 28f + 6f + 26f + 8f;
+            h += UiScale.Scaled(22f) + UiScale.Scaled(28f) + UiScale.Scaled(6f) + UiScale.Scaled(26f) + UiScale.Scaled(8f);
         else
-            h += 22f + 28f;
+            h += UiScale.Scaled(22f) + UiScale.Scaled(28f);
 
         // Divider
         h += DividerHeight;
@@ -178,9 +178,9 @@ internal static class ReligionInfoRenderer
         // Description block — prose path reserves a fixed 80f frame
         // (matches ReligionInfoDescriptionRenderer.ProseBodyHeight).
         if (viewModel.IsFounder && viewModel.IsEditingDescription)
-            h += 22f + 80f + 6f + 26f + 8f;
+            h += UiScale.Scaled(22f) + UiScale.Scaled(80f) + UiScale.Scaled(6f) + UiScale.Scaled(26f) + UiScale.Scaled(8f);
         else
-            h += 22f + 80f + 8f;
+            h += UiScale.Scaled(22f) + UiScale.Scaled(80f) + UiScale.Scaled(8f);
 
         // Divider
         h += DividerHeight;
@@ -188,12 +188,12 @@ internal static class ReligionInfoRenderer
         // Founding myth block — prose path reserves a fixed 540f frame
         // (matches ReligionInfoFoundingMythRenderer.ProseBodyHeight).
         if (viewModel.IsFounder && viewModel.IsEditingFoundingMyth)
-            h += 22f + 200f + 6f + 26f + 8f;
+            h += UiScale.Scaled(22f) + UiScale.Scaled(200f) + UiScale.Scaled(6f) + UiScale.Scaled(26f) + UiScale.Scaled(8f);
         else
-            h += 22f + 540f + 8f;
+            h += UiScale.Scaled(22f) + UiScale.Scaled(540f) + UiScale.Scaled(8f);
 
         // Footer
-        h += FooterTopPadding + 34f + 6f;
+        h += FooterTopPadding + UiScale.Scaled(34f) + UiScale.Scaled(6f);
         return h;
     }
 

--- a/DivineAscension/GUI/UI/Renderers/Religion/Roster/ReligionRosterRowsRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Roster/ReligionRosterRowsRenderer.cs
@@ -16,12 +16,12 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Roster;
 [ExcludeFromCodeCoverage]
 internal static class ReligionRosterRowsRenderer
 {
-    public const float RowHeight = 22f;
-    public const float ActionStripHeight = 30f;
-    public const float CounterHeight = 22f;
-    private const float MarkerInset = 4f;
-    private const float MarkerSize = 4f;
-    private const float NameOffset = 18f;
+    public static float RowHeight => UiScale.Scaled(22f);
+    public static float ActionStripHeight => UiScale.Scaled(30f);
+    public static float CounterHeight => UiScale.Scaled(22f);
+    private static float MarkerInset => UiScale.Scaled(4f);
+    private static float MarkerSize => UiScale.Scaled(4f);
+    private static float NameOffset => UiScale.Scaled(18f);
 
     public static float Draw(
         ReligionRosterViewModel vm,
@@ -52,7 +52,7 @@ internal static class ReligionRosterRowsRenderer
 
             ChromeRenderer.DrawLeader(drawList,
                 member.PlayerName, roleLabel,
-                x + NameOffset, currentY + 3f, width - NameOffset,
+                x + NameOffset, currentY + UiScale.Scaled(3f), width - NameOffset,
                 labelColor: nameColor,
                 valueColor: ColorPalette.White);
 
@@ -78,7 +78,7 @@ internal static class ReligionRosterRowsRenderer
         var counterSize = ImGui.CalcTextSize(counter);
         var counterX = x + (width - counterSize.X) / 2f;
         var counterColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
-        drawList.AddText(new Vector2(counterX, currentY + 4f), counterColor, counter);
+        drawList.AddText(new Vector2(counterX, currentY + UiScale.Scaled(4f)), counterColor, counter);
         currentY += CounterHeight;
 
         return currentY;
@@ -92,12 +92,12 @@ internal static class ReligionRosterRowsRenderer
         List<RosterEvent> events)
     {
         var loc = LocalizationService.Instance;
-        const float buttonW = 80f;
-        const float buttonH = 24f;
-        const float gap = 8f;
-        const float rightPad = 8f;
+        var buttonW = UiScale.Scaled(80f);
+        var buttonH = UiScale.Scaled(24f);
+        var gap = UiScale.Scaled(8f);
+        var rightPad = UiScale.Scaled(8f);
 
-        var btnY = y + 3f;
+        var btnY = y + UiScale.Scaled(3f);
         var strikeX = x + width - buttonW - rightPad;
         var kickX = strikeX - buttonW - gap;
 
@@ -116,9 +116,9 @@ internal static class ReligionRosterRowsRenderer
             events.Add(new RosterEvent.StrikeClicked(member.PlayerUID, member.PlayerName));
         }
         var labelWidth = ImGui.CalcTextSize(loc.Get(LocalizationKeys.UI_RELIGION_ROSTER_STRIKE_BUTTON)).X;
-        var daggerCx = strikeX + buttonW / 2f + labelWidth / 2f + 8f;
+        var daggerCx = strikeX + buttonW / 2f + labelWidth / 2f + UiScale.Scaled(8f);
         var daggerCy = btnY + buttonH / 2f;
-        ChromeRenderer.DrawDagger(drawList, daggerCx, daggerCy, 10f, ColorPalette.LightText);
+        ChromeRenderer.DrawDagger(drawList, daggerCx, daggerCy, UiScale.Scaled(10f), ColorPalette.LightText);
 
         return y + ActionStripHeight;
     }

--- a/DivineAscension/GUI/UI/Renderers/Religion/Roster/ReligionRosterStrickenRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/Roster/ReligionRosterStrickenRenderer.cs
@@ -22,11 +22,11 @@ namespace DivineAscension.GUI.UI.Renderers.Religion.Roster;
 [ExcludeFromCodeCoverage]
 internal static class ReligionRosterStrickenRenderer
 {
-    public const float RowHeight = 22f;
-    public const float ActionStripHeight = 30f;
-    private const float MarkerInset = 4f;
-    private const float MarkerSize = 9f;
-    private const float NameOffset = 18f;
+    public static float RowHeight => UiScale.Scaled(22f);
+    public static float ActionStripHeight => UiScale.Scaled(30f);
+    private static float MarkerInset => UiScale.Scaled(4f);
+    private static float MarkerSize => UiScale.Scaled(9f);
+    private static float NameOffset => UiScale.Scaled(18f);
 
     public static float Draw(
         ReligionRosterViewModel vm,
@@ -54,7 +54,7 @@ internal static class ReligionRosterStrickenRenderer
 
             ChromeRenderer.DrawLeader(drawList,
                 ban.PlayerName, ban.Reason,
-                x + NameOffset, currentY + 3f, width - NameOffset,
+                x + NameOffset, currentY + UiScale.Scaled(3f), width - NameOffset,
                 labelColor: ColorPalette.White,
                 valueColor: ColorPalette.Grey);
 
@@ -80,9 +80,9 @@ internal static class ReligionRosterStrickenRenderer
         List<RosterEvent> events)
     {
         var loc = LocalizationService.Instance;
-        const float buttonW = 80f;
-        const float buttonH = 24f;
-        const float rightPad = 8f;
+        var buttonW = UiScale.Scaled(80f);
+        var buttonH = UiScale.Scaled(24f);
+        var rightPad = UiScale.Scaled(8f);
 
         // Ban dates as a leader line, indented under the name.
         var expiry = ban.IsPermanent
@@ -90,10 +90,10 @@ internal static class ReligionRosterStrickenRenderer
             : ban.ExpiresAt;
         var dates = $"{loc.Get(LocalizationKeys.UI_RELIGION_INFO_BANNED_AT_LABEL)} {ban.BannedAt}   " +
                     $"{loc.Get(LocalizationKeys.UI_RELIGION_INFO_BANNED_EXPIRES_LABEL)} {expiry}";
-        TextRenderer.DrawInfoText(drawList, dates, x + NameOffset, y + 5f, width - NameOffset - buttonW - rightPad,
+        TextRenderer.DrawInfoText(drawList, dates, x + NameOffset, y + UiScale.Scaled(5f), width - NameOffset - buttonW - rightPad,
             Secondary, ColorPalette.Grey);
 
-        var btnY = y + 3f;
+        var btnY = y + UiScale.Scaled(3f);
         var unbanX = x + width - buttonW - rightPad;
         if (ButtonRenderer.DrawButton(drawList,
                 loc.Get(LocalizationKeys.UI_RELIGION_INFO_UNBAN_BUTTON),

--- a/DivineAscension/GUI/UI/Renderers/Religion/SacredCalendarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Religion/SacredCalendarRenderer.cs
@@ -26,14 +26,14 @@ namespace DivineAscension.GUI.UI.Renderers.Religion;
 [ExcludeFromCodeCoverage]
 internal static class SacredCalendarRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float IntroBottomSpacing = 10f;
-    private const float IntroLineHeight = 18f;
-    private const float RowHeight = 22f;
-    private const float ScrollbarWidth = 16f;
-    private const float ClosingLineHeight = 24f;
-    private const float ClosingLineTopSpacing = 6f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float IntroBottomSpacing => UiScale.Scaled(10f);
+    private static float IntroLineHeight => UiScale.Scaled(18f);
+    private static float RowHeight => UiScale.Scaled(22f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float ClosingLineHeight => UiScale.Scaled(24f);
+    private static float ClosingLineTopSpacing => UiScale.Scaled(6f);
 
     public static SacredCalendarRenderResult Draw(SacredCalendarViewModel vm, ImDrawListPtr drawList)
     {
@@ -70,7 +70,7 @@ internal static class SacredCalendarRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -101,8 +101,8 @@ internal static class SacredCalendarRenderer
         currentY = DrawIntro(drawList, x, currentY, contentWidth);
         currentY = DrawDivider(drawList, x, currentY, contentWidth);
 
-        const float removeBtnSize = 18f;
-        const float removeBtnGap = 8f;
+        var removeBtnSize = UiScale.Scaled(18f);
+        var removeBtnGap = UiScale.Scaled(8f);
         foreach (var feast in vm.Feasts)
         {
             var isRemovable = vm.IsFounder &&
@@ -119,7 +119,7 @@ internal static class SacredCalendarRenderer
             if (isRemovable)
             {
                 var btnX = x + contentWidth - removeBtnSize;
-                if (ButtonRenderer.DrawButton(drawList, "x", btnX, currentY - 2f,
+                if (ButtonRenderer.DrawButton(drawList, "x", btnX, currentY - UiScale.Scaled(2f),
                         removeBtnSize, removeBtnSize, isPrimary: false, enabled: true))
                 {
                     events.Add(new SacredCalendarEvent.RemoveRequested(feast.FeastId, feast.Name));
@@ -132,7 +132,7 @@ internal static class SacredCalendarRenderer
         // Founder controls under the list: Add button / Add form / cap notice
         if (vm.IsFounder)
         {
-            currentY += 6f;
+            currentY += UiScale.Scaled(6f);
             currentY = DrawFounderControls(vm, drawList, events, x, currentY, contentWidth);
         }
 
@@ -187,12 +187,12 @@ internal static class SacredCalendarRenderer
         }
 
         var addLabel = loc.Get(LocalizationKeys.UI_FEASTDAY_ADD);
-        if (ButtonRenderer.DrawButton(drawList, addLabel, x, y, 160f, 22f,
+        if (ButtonRenderer.DrawButton(drawList, addLabel, x, y, UiScale.Scaled(160f), UiScale.Scaled(22f),
                 isPrimary: true, enabled: true))
         {
             events.Add(new SacredCalendarEvent.AddDialogOpened());
         }
-        return y + RowHeight + 4f;
+        return y + RowHeight + UiScale.Scaled(4f);
     }
 
     /// <summary>
@@ -213,17 +213,17 @@ internal static class SacredCalendarRenderer
         drawList.AddRectFilled(winPos, new Vector2(winPos.X + winSize.X, winPos.Y + winSize.Y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.BlackOverlay));
 
-        const float dialogWidth = 460f;
-        const float dialogHeight = 260f;
+        var dialogWidth = UiScale.Scaled(460f);
+        var dialogHeight = UiScale.Scaled(260f);
         var dlgX = winPos.X + (winSize.X - dialogWidth) / 2f;
         var dlgY = winPos.Y + (winSize.Y - dialogHeight) / 2f;
 
         drawList.AddRectFilled(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), 6f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), UiScale.Scaled(6f));
         drawList.AddRect(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 6f, ImDrawFlags.None, 1.5f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), UiScale.Scaled(6f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
-        const float padding = 18f;
+        var padding = UiScale.Scaled(18f);
         var bodyWidth = dialogWidth - padding * 2f;
         var curX = dlgX + padding;
         var curY = dlgY + padding;
@@ -231,21 +231,21 @@ internal static class SacredCalendarRenderer
         TextRenderer.DrawLabel(drawList,
             loc.Get(LocalizationKeys.UI_FEASTDAY_ADD_TITLE),
             curX, curY, PageTitle, ColorPalette.Gold);
-        curY += PageTitle + 6f;
+        curY += PageTitle + UiScale.Scaled(6f);
         ChromeRenderer.DrawDivider(drawList, curX, curY, bodyWidth);
-        curY += 16f;
+        curY += UiScale.Scaled(16f);
 
         // Name field
         TextRenderer.DrawInfoText(drawList,
             loc.Get(LocalizationKeys.UI_FEASTDAY_NAME_PLACEHOLDER),
             curX, curY, bodyWidth, Body, ColorPalette.White);
-        curY += 22f;
+        curY += UiScale.Scaled(22f);
         var newName = TextInput.Draw(drawList, "##feastname", vm.AddName ?? string.Empty,
-            curX, curY, bodyWidth, 32f,
+            curX, curY, bodyWidth, UiScale.Scaled(32f),
             loc.Get(LocalizationKeys.UI_FEASTDAY_NAME_PLACEHOLDER));
         if (newName != (vm.AddName ?? string.Empty))
             events.Add(new SacredCalendarEvent.AddNameChanged(newName));
-        curY += 40f;
+        curY += UiScale.Scaled(40f);
 
         // Month + Day steppers, side by side
         var monthMax = Math.Max(1, vm.MonthsPerYear);
@@ -253,7 +253,7 @@ internal static class SacredCalendarRenderer
         var month = Math.Clamp(vm.AddMonth, 1, monthMax);
         var day = Math.Clamp(vm.AddDay, 1, dayMax);
 
-        var halfWidth = (bodyWidth - 16f) / 2f;
+        var halfWidth = (bodyWidth - UiScale.Scaled(16f)) / 2f;
         var monthLabel = loc.Get(LocalizationKeys.UI_FEASTDAY_MONTH);
         var dayLabel = loc.Get(LocalizationKeys.UI_FEASTDAY_DAY);
         var monthDisplay = month is >= 1 and <= 12
@@ -263,14 +263,14 @@ internal static class SacredCalendarRenderer
             monthLabel, month, monthDisplay, 1, monthMax);
         if (nextMonth != month) events.Add(new SacredCalendarEvent.AddMonthChanged(nextMonth));
 
-        var nextDay = DrawStepper(drawList, events, curX + halfWidth + 16f, curY, halfWidth,
+        var nextDay = DrawStepper(drawList, events, curX + halfWidth + UiScale.Scaled(16f), curY, halfWidth,
             dayLabel, day, day.ToString(), 1, dayMax);
         if (nextDay != day) events.Add(new SacredCalendarEvent.AddDayChanged(nextDay));
 
         // Footer: Cancel + Add, right-aligned, same metrics as InviteDialog.
-        const float btnWidth = 120f;
-        const float btnHeight = 32f;
-        const float btnGap = 10f;
+        var btnWidth = UiScale.Scaled(120f);
+        var btnHeight = UiScale.Scaled(32f);
+        var btnGap = UiScale.Scaled(10f);
         var btnY = dlgY + dialogHeight - padding - btnHeight;
         var addX = dlgX + dialogWidth - padding - btnWidth;
         var cancelX = addX - btnWidth - btnGap;
@@ -299,28 +299,28 @@ internal static class SacredCalendarRenderer
     private static int DrawStepper(ImDrawListPtr drawList, List<SacredCalendarEvent> events,
         float x, float y, float width, string label, int value, string displayText, int min, int max)
     {
-        const float rowHeight = 30f;
-        const float btnW = 28f;
-        const float labelW = 60f;
+        var rowHeight = UiScale.Scaled(30f);
+        var btnW = UiScale.Scaled(28f);
+        var labelW = UiScale.Scaled(60f);
 
-        TextRenderer.DrawLabel(drawList, label, x, y + 6f, Body, ColorPalette.Grey);
+        TextRenderer.DrawLabel(drawList, label, x, y + UiScale.Scaled(6f), Body, ColorPalette.Grey);
 
         var fieldX = x + labelW;
-        var fieldW = width - labelW - btnW * 2f - 8f;
+        var fieldW = width - labelW - btnW * 2f - UiScale.Scaled(8f);
         drawList.AddRectFilled(new Vector2(fieldX, y),
             new Vector2(fieldX + fieldW, y + rowHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.7f), 4f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.7f), UiScale.Scaled(4f));
         drawList.AddRect(new Vector2(fieldX, y),
             new Vector2(fieldX + fieldW, y + rowHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 4f, ImDrawFlags.None, 1f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(1f));
         var textSize = ImGui.CalcTextSize(displayText);
         drawList.AddText(
             new Vector2(fieldX + (fieldW - textSize.X) / 2f, y + (rowHeight - textSize.Y) / 2f),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.LightText), displayText);
 
         var next = value;
-        var decX = fieldX + fieldW + 4f;
-        var incX = decX + btnW + 4f;
+        var decX = fieldX + fieldW + UiScale.Scaled(4f);
+        var incX = decX + btnW + UiScale.Scaled(4f);
         // ASCII hyphen — the bundled font lacks U+2212 (minus sign) and U+2013
         // (en-dash), which both rendered as a "?" tofu glyph. Plain '-' is in
         // every fallback so it draws correctly.
@@ -358,17 +358,17 @@ internal static class SacredCalendarRenderer
         drawList.AddRectFilled(winPos, new Vector2(winPos.X + winSize.X, winPos.Y + winSize.Y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.BlackOverlay));
 
-        const float dialogWidth = 420f;
-        const float dialogHeight = 170f;
+        var dialogWidth = UiScale.Scaled(420f);
+        var dialogHeight = UiScale.Scaled(170f);
         var dlgX = winPos.X + (winSize.X - dialogWidth) / 2f;
         var dlgY = winPos.Y + (winSize.Y - dialogHeight) / 2f;
 
         drawList.AddRectFilled(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), 6f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), UiScale.Scaled(6f));
         drawList.AddRect(new Vector2(dlgX, dlgY), new Vector2(dlgX + dialogWidth, dlgY + dialogHeight),
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 6f, ImDrawFlags.None, 1.5f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), UiScale.Scaled(6f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
-        const float padding = 18f;
+        var padding = UiScale.Scaled(18f);
         var bodyWidth = dialogWidth - padding * 2f;
         var curX = dlgX + padding;
         var curY = dlgY + padding;
@@ -376,17 +376,17 @@ internal static class SacredCalendarRenderer
         TextRenderer.DrawLabel(drawList,
             loc.Get(LocalizationKeys.UI_FEASTDAY_REMOVE_CONFIRM, vm.RemoveConfirmFeastName ?? string.Empty),
             curX, curY, PageTitle, ColorPalette.Gold);
-        curY += PageTitle + 6f;
+        curY += PageTitle + UiScale.Scaled(6f);
         ChromeRenderer.DrawDivider(drawList, curX, curY, bodyWidth);
-        curY += 16f;
+        curY += UiScale.Scaled(16f);
 
         TextRenderer.DrawInfoText(drawList,
             loc.Get(LocalizationKeys.UI_FEASTDAY_REMOVE_BODY),
             curX, curY, bodyWidth, Body, ColorPalette.White);
 
-        const float btnWidth = 120f;
-        const float btnHeight = 32f;
-        const float btnGap = 10f;
+        var btnWidth = UiScale.Scaled(120f);
+        var btnHeight = UiScale.Scaled(32f);
+        var btnGap = UiScale.Scaled(10f);
         var btnY = dlgY + dialogHeight - padding - btnHeight;
         var removeX = dlgX + dialogWidth - padding - btnWidth;
         var cancelX = removeX - btnWidth - btnGap;


### PR DESCRIPTION
Part of epic #584 — per-area layout grind. Scales the remaining Religion leaf renderers so their content panes lay out proportionally at GUIScale > 1.

## Scope (13 files, `Scaled()` convention)

Sacred calendar, ReligionInfo, ReligionDetail, ReligionCreate, ReligionChronicle, ReligionActivity (+ Activity feed), roster rows + stricken rows, and the Info sub-panes (header, motto, founding-myth, description). Layout consts → scaled `static` properties; inline offsets/sizes/paddings/gaps/radii/thicknesses → `UiScale.Scaled(...)`.

Already-scaled Religion files (chrome/controls: browse, roster container, roles-browse, role-detail, info-actions) were done in #589/#607 — not touched here.

**Hit-rects:** roster row click rects use the same scaled `RowHeight` as the drawn rows → clicks stay aligned.

Left unscaled (verified, empty diff-grep): `/2f` centring divisors, `*N` over already-scaled bases, colour alphas, loop counts, angles, epsilons, `CalcTextSize`/`MeasureWrappedHeight`, font sizes, region params. **No behavioural change at Factor 1.0.**

## Tests
13 files via parallel agents; built + diff-sanity-checked + full suite: **2515 passed**, build clean.

Closes #595