### PR TITLE
feat(ui): scale Blessing content renderers (#597)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingNodeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingNodeRenderer.cs
@@ -19,10 +19,10 @@ namespace DivineAscension.GUI.UI.Renderers.Blessing;
 [ExcludeFromCodeCoverage]
 internal static class BlessingNodeRenderer
 {
-    private const float SealRadius = 22f;
-    private const float RimThickness = 2.0f;
-    private const float SelectedRimThickness = 3.0f;
-    private const float IconSize = 28f;
+    private static float SealRadius => UiScale.Scaled(22f);
+    private static float RimThickness => UiScale.Scaled(2.0f);
+    private static float SelectedRimThickness => UiScale.Scaled(3.0f);
+    private static float IconSize => UiScale.Scaled(28f);
 
     // Shared animation clock for the "available" gentle pulse.
     private static float _glowAnimationTime;
@@ -54,7 +54,7 @@ internal static class BlessingNodeRenderer
             var glowAlpha = 0.18f + 0.22f * pulse;
             var glowColor = ColorPalette.Gold;
             glowColor.W = glowAlpha;
-            drawList.AddCircleFilled(center, SealRadius + 5f,
+            drawList.AddCircleFilled(center, SealRadius + UiScale.Scaled(5f),
                 ImGui.ColorConvertFloat4ToU32(glowColor), 32);
         }
 
@@ -70,8 +70,8 @@ internal static class BlessingNodeRenderer
         // Hover halo — single thin gold ring, no blue tint.
         if (isHovering && !isSelected)
         {
-            drawList.AddCircle(center, SealRadius + 2f,
-                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.5f), 32, 1f);
+            drawList.AddCircle(center, SealRadius + UiScale.Scaled(2f),
+                ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.5f), 32, UiScale.Scaled(1f));
         }
 
         // Inner symbol — icon if registered, else initials in iron-gall ink.
@@ -108,7 +108,7 @@ internal static class BlessingNodeRenderer
             var captionSize = ImGui.CalcTextSize(caption);
             var captionPos = new Vector2(
                 center.X - captionSize.X / 2f,
-                center.Y + SealRadius + 6f);
+                center.Y + SealRadius + UiScale.Scaled(6f));
             var captionColor = state.VisualState switch
             {
                 BlessingNodeVisualState.Unlocked => ColorPalette.Gold,
@@ -151,15 +151,15 @@ internal static class BlessingNodeRenderer
         // sibling seals instead of slicing through them.
         if (Math.Abs(fromCenter.X - toCenter.X) < 0.5f)
         {
-            drawList.AddLine(fromCenter, toCenter, col32, 1.25f);
+            drawList.AddLine(fromCenter, toCenter, col32, UiScale.Scaled(1.25f));
             return;
         }
 
         var dy = toCenter.Y - fromCenter.Y;
-        var tangent = Math.Max(24f, Math.Abs(dy) * 0.55f);
+        var tangent = Math.Max(UiScale.Scaled(24f), Math.Abs(dy) * 0.55f);
         var cp1 = new Vector2(fromCenter.X, fromCenter.Y + tangent);
         var cp2 = new Vector2(toCenter.X, toCenter.Y - tangent);
-        drawList.AddBezierCubic(fromCenter, cp1, cp2, toCenter, col32, 1.25f, 24);
+        drawList.AddBezierCubic(fromCenter, cp1, cp2, toCenter, col32, UiScale.Scaled(1.25f), 24);
     }
 
     private static (Vector4 Fill, Vector4 Rim, Vector4 IconTint, Vector4 Text) StyleFor(

--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTabRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTabRenderer.cs
@@ -27,13 +27,13 @@ namespace DivineAscension.GUI.UI.Renderers.Blessing;
 [ExcludeFromCodeCoverage]
 internal static class BlessingTabRenderer
 {
-    private const float Padding = 16f;
-    private const float SectionLabelHeight = 22f;
-    private const float LeaderRowHeight = 22f;
-    private const float DividerSpacing = 18f;
-    private const float ScrollbarWidth = 16f;
-    private const float TreePaneHeight = 340f;
-    private const float BannerHeight = 26f;
+    private static float Padding => UiScale.Scaled(16f);
+    private static float SectionLabelHeight => UiScale.Scaled(22f);
+    private static float LeaderRowHeight => UiScale.Scaled(22f);
+    private static float DividerSpacing => UiScale.Scaled(18f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float TreePaneHeight => UiScale.Scaled(340f);
+    private static float BannerHeight => UiScale.Scaled(26f);
 
     internal static BlessingTabRenderResult DrawBlessingsTab(BlessingTabViewModel vm)
     {
@@ -62,10 +62,10 @@ internal static class BlessingTabRenderer
 
         // Approximate tree rect for wheel-exclusion. Mirrors the body layout below.
         var preTreeOffset = HeaderHeight() + (vm.FreeRespecActive ? BannerHeight : 0f)
-                            + IntroHeight(vm, contentWidth) + 8f + DividerSpacing
-                            + SectionLabelHeight + vm.DeitySummaries.Count * LeaderRowHeight + 4f
-                            + DividerSpacing + LeaderRowHeight + (showSlots ? LeaderRowHeight : 0f) + 4f
-                            + DeitySelectorRenderer.Height + 6f + DividerSpacing;
+                            + IntroHeight(vm, contentWidth) + UiScale.Scaled(8f) + DividerSpacing
+                            + SectionLabelHeight + vm.DeitySummaries.Count * LeaderRowHeight + UiScale.Scaled(4f)
+                            + DividerSpacing + LeaderRowHeight + (showSlots ? LeaderRowHeight : 0f) + UiScale.Scaled(4f)
+                            + DeitySelectorRenderer.Height + UiScale.Scaled(6f) + DividerSpacing;
         var treeScreenTop = vm.Y + preTreeOffset - scrollY;
         var overTree = mousePos.X >= vm.X && mousePos.X <= vm.X + contentWidth
                                           && mousePos.Y >= treeScreenTop
@@ -76,7 +76,7 @@ internal static class BlessingTabRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0f)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (MathF.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -116,7 +116,7 @@ internal static class BlessingTabRenderer
         var introHeight = TextRenderer.MeasureWrappedHeight(intro, introWidth, Secondary);
         TextRenderer.DrawInfoText(drawList, intro, vm.X + Padding, topY, introWidth, Secondary,
             ColorPalette.White);
-        topY += introHeight + 8f;
+        topY += introHeight + UiScale.Scaled(8f);
 
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
@@ -142,7 +142,7 @@ internal static class BlessingTabRenderer
             topY += LeaderRowHeight;
         }
 
-        topY += 4f;
+        topY += UiScale.Scaled(4f);
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
 
@@ -171,12 +171,12 @@ internal static class BlessingTabRenderer
             topY += LeaderRowHeight;
         }
 
-        topY += 4f;
+        topY += UiScale.Scaled(4f);
 
         // --- Deity sub-index (selector strip, glyph primitives) — horizontally centered.
         var stripX = vm.X + (contentWidth - DeitySelectorRenderer.StripWidth) * 0.5f;
         var requestedDeity = DeitySelectorRenderer.Draw(stripX, topY, vm.ActiveDeity, vm.PatronDomain);
-        topY += DeitySelectorRenderer.Height + 6f;
+        topY += DeitySelectorRenderer.Height + UiScale.Scaled(6f);
 
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
@@ -216,7 +216,7 @@ internal static class BlessingTabRenderer
             }
         }
 
-        topY += TreePaneHeight + 6f;
+        topY += TreePaneHeight + UiScale.Scaled(6f);
 
         drawList.PopClipRect();
 
@@ -297,15 +297,15 @@ internal static class BlessingTabRenderer
         var h = 0f;
         h += PaneHeaderRenderer.TotalHeight;
         h += freeRespec ? BannerHeight : 0f;
-        h += introH + 8f;
+        h += introH + UiScale.Scaled(8f);
         h += DividerSpacing;
         h += SectionLabelHeight;
         h += summaryRows * LeaderRowHeight;
-        h += 4f + DividerSpacing;
-        h += LeaderRowHeight + (showSlots ? LeaderRowHeight : 0f) + 4f;
-        h += DeitySelectorRenderer.Height + 6f;
+        h += UiScale.Scaled(4f) + DividerSpacing;
+        h += LeaderRowHeight + (showSlots ? LeaderRowHeight : 0f) + UiScale.Scaled(4f);
+        h += DeitySelectorRenderer.Height + UiScale.Scaled(6f);
         h += DividerSpacing;
-        h += TreePaneHeight + 6f;
+        h += TreePaneHeight + UiScale.Scaled(6f);
         return h;
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTreeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingTreeRenderer.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using DivineAscension.Constants;
 using DivineAscension.GUI.Events.Blessing;
 using DivineAscension.GUI.Models.Blessing.Tree;
+using DivineAscension.GUI.UI.Utilities;
 using DivineAscension.Models;
 using DivineAscension.Services;
 using ImGuiNET;
@@ -31,7 +32,7 @@ internal static class BlessingTreeRenderer
 
     public static BlessingTreeRendererResult Draw(BlessingTreeViewModel vm)
     {
-        const float labelHeight = 30f;
+        var labelHeight = UiScale.Scaled(30f);
         var treeAreaHeight = vm.ShowBalanceHeader ? vm.Height - labelHeight : vm.Height;
 
         var drawList = ImGui.GetWindowDrawList();
@@ -74,8 +75,8 @@ internal static class BlessingTreeRenderer
     private static void DrawPanelLabel(ImDrawListPtr drawList, string label, float x, float y, float width,
         string? currencyText = null)
     {
-        const float labelHeight = 30f;
-        const float padding = 8f;
+        var labelHeight = UiScale.Scaled(30f);
+        var padding = UiScale.Scaled(8f);
 
         var bgStart = new Vector2(x, y);
         var bgEnd = new Vector2(x + width, y + labelHeight);
@@ -121,7 +122,7 @@ internal static class BlessingTreeRenderer
         string? selectedBlessingId,
         string panelId)
     {
-        const float padding = 16f;
+        var padding = UiScale.Scaled(16f);
 
         if (blessingStates.Count == 0)
         {

--- a/DivineAscension/GUI/UI/Renderers/Blessing/BlessingVowsTabRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/BlessingVowsTabRenderer.cs
@@ -28,12 +28,12 @@ namespace DivineAscension.GUI.UI.Renderers.Blessing;
 [ExcludeFromCodeCoverage]
 internal static class BlessingVowsTabRenderer
 {
-    private const float Padding = 16f;
-    private const float SectionLabelHeight = 22f;
-    private const float LeaderRowHeight = 22f;
-    private const float DividerSpacing = 18f;
-    private const float ScrollbarWidth = 16f;
-    private const float TreePaneHeight = 360f;
+    private static float Padding => UiScale.Scaled(16f);
+    private static float SectionLabelHeight => UiScale.Scaled(22f);
+    private static float LeaderRowHeight => UiScale.Scaled(22f);
+    private static float DividerSpacing => UiScale.Scaled(18f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float TreePaneHeight => UiScale.Scaled(360f);
 
     internal static BlessingTabRenderResult Draw(BlessingTabViewModel vm)
     {
@@ -59,10 +59,10 @@ internal static class BlessingVowsTabRenderer
         // Approximate tree rect for wheel-exclusion. Real position depends on cumulative
         // section heights — pre-compute the same way the body does below.
         var slotsRowHeight = vm.ReligionBlessingSlotCap > 0 ? LeaderRowHeight : 0f;
-        var preTreeOffset = HeaderHeight() + IntroHeight(vm, contentWidth) + 8f + DividerSpacing
-                            + SectionLabelHeight + vm.DeitySummaries.Count * LeaderRowHeight + 4f
-                            + DividerSpacing + LeaderRowHeight + 4f + slotsRowHeight
-                            + DeitySelectorRenderer.Height + 6f + DividerSpacing;
+        var preTreeOffset = HeaderHeight() + IntroHeight(vm, contentWidth) + UiScale.Scaled(8f) + DividerSpacing
+                            + SectionLabelHeight + vm.DeitySummaries.Count * LeaderRowHeight + UiScale.Scaled(4f)
+                            + DividerSpacing + LeaderRowHeight + UiScale.Scaled(4f) + slotsRowHeight
+                            + DeitySelectorRenderer.Height + UiScale.Scaled(6f) + DividerSpacing;
         var treeScreenTop = vm.Y + preTreeOffset - scrollY;
         var overTree = mousePos.X >= vm.X && mousePos.X <= vm.X + contentWidth
                                           && mousePos.Y >= treeScreenTop
@@ -73,7 +73,7 @@ internal static class BlessingVowsTabRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0f)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (MathF.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -101,7 +101,7 @@ internal static class BlessingVowsTabRenderer
         var introHeight = TextRenderer.MeasureWrappedHeight(intro, introWidth, Secondary);
         TextRenderer.DrawInfoText(drawList, intro, vm.X + Padding, topY, introWidth, Secondary,
             ColorPalette.White);
-        topY += introHeight + 8f;
+        topY += introHeight + UiScale.Scaled(8f);
 
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
@@ -124,7 +124,7 @@ internal static class BlessingVowsTabRenderer
             topY += LeaderRowHeight;
         }
 
-        topY += 4f;
+        topY += UiScale.Scaled(4f);
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
 
@@ -138,7 +138,7 @@ internal static class BlessingVowsTabRenderer
         ChromeRenderer.DrawLeader(drawList, patronHeading, prestigeBalance,
             vm.X + Padding, topY, contentWidth - Padding * 2,
             labelColor: ColorPalette.Gold, valueColor: ColorPalette.White);
-        topY += LeaderRowHeight + 4f;
+        topY += LeaderRowHeight + UiScale.Scaled(4f);
 
         // --- "Inscribed: X/Y" religion slot counter (#479). Hidden until the cap is synced
         //     (cap 0 = unknown). Turns gold when the religion is at its inscribe cap.
@@ -156,7 +156,7 @@ internal static class BlessingVowsTabRenderer
         // --- Deity sub-index (selector strip, glyph primitives) — horizontally centered.
         var stripX = vm.X + (contentWidth - DeitySelectorRenderer.StripWidth) * 0.5f;
         var requestedDeity = DeitySelectorRenderer.Draw(stripX, topY, vm.ActiveDeity, vm.PatronDomain);
-        topY += DeitySelectorRenderer.Height + 6f;
+        topY += DeitySelectorRenderer.Height + UiScale.Scaled(6f);
 
         ChromeRenderer.DrawDivider(drawList, vm.X, topY, contentWidth);
         topY += DividerSpacing;
@@ -197,7 +197,7 @@ internal static class BlessingVowsTabRenderer
             }
         }
 
-        topY += TreePaneHeight + 6f;
+        topY += TreePaneHeight + UiScale.Scaled(6f);
 
         drawList.PopClipRect();
 
@@ -277,16 +277,16 @@ internal static class BlessingVowsTabRenderer
 
         var h = 0f;
         h += PaneHeaderRenderer.TotalHeight;
-        h += introH + 8f;
+        h += introH + UiScale.Scaled(8f);
         h += DividerSpacing;
         h += SectionLabelHeight;
         h += summaryRows * LeaderRowHeight;
-        h += 4f + DividerSpacing;
-        h += LeaderRowHeight + 4f;
+        h += UiScale.Scaled(4f) + DividerSpacing;
+        h += LeaderRowHeight + UiScale.Scaled(4f);
         if (hasSlotsRow) h += LeaderRowHeight;
-        h += DeitySelectorRenderer.Height + 6f;
+        h += DeitySelectorRenderer.Height + UiScale.Scaled(6f);
         h += DividerSpacing;
-        h += TreePaneHeight + 6f;
+        h += TreePaneHeight + UiScale.Scaled(6f);
         return h;
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/CrossDeitySummaryRenderer.cs
@@ -17,8 +17,8 @@ namespace DivineAscension.GUI.UI.Renderers.Blessing;
 [ExcludeFromCodeCoverage]
 internal static class CrossDeitySummaryRenderer
 {
-    public const float Height = 38f;
-    private const float Padding = 4f;
+    public static float Height => UiScale.Scaled(38f);
+    private static float Padding => UiScale.Scaled(4f);
 
     public static void Draw(float x, float y, float width, IReadOnlyList<DeityBlessingSummary> summaries)
     {
@@ -29,9 +29,9 @@ internal static class CrossDeitySummaryRenderer
         var bgMin = new Vector2(x, y);
         var bgMax = new Vector2(x + width, y + Height);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.DarkBrown, 0.7f));
-        drawList.AddRectFilled(bgMin, bgMax, bgColor, 4f);
+        drawList.AddRectFilled(bgMin, bgMax, bgColor, UiScale.Scaled(4f));
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Gold, 0.4f));
-        drawList.AddRect(bgMin, bgMax, borderColor, 4f, ImDrawFlags.None, 1f);
+        drawList.AddRect(bgMin, bgMax, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(1f));
 
         var colWidth = (width - Padding * 2) / summaries.Count;
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
@@ -41,7 +41,7 @@ internal static class CrossDeitySummaryRenderer
         {
             var s = summaries[i];
             var colX = x + Padding + i * colWidth;
-            var colTop = y + 4f;
+            var colTop = y + UiScale.Scaled(4f);
 
             var label = $"{DomainShort(s.Domain)} {RankRequirements.GetFavorRankName(s.FavorRank)}";
             var labelSize = ImGui.CalcTextSize(label);
@@ -53,14 +53,14 @@ internal static class CrossDeitySummaryRenderer
             var counts = $"P {s.UnlockedPlayer}/{s.TotalPlayer}  R {s.UnlockedReligion}/{s.TotalReligion}";
             var countsSize = ImGui.CalcTextSize(counts);
             drawList.AddText(ImGui.GetFont(), Micro,
-                new Vector2(colX + (colWidth - countsSize.X) / 2f, colTop + 16f),
+                new Vector2(colX + (colWidth - countsSize.X) / 2f, colTop + UiScale.Scaled(16f)),
                 textColor,
                 counts);
 
             if (s.IsPatron)
             {
                 drawList.AddText(ImGui.GetFont(), Micro,
-                    new Vector2(colX + 2f, colTop), gold, "*");
+                    new Vector2(colX + UiScale.Scaled(2f), colTop), gold, "*");
             }
         }
     }

--- a/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/DeitySelectorRenderer.cs
@@ -16,16 +16,16 @@ namespace DivineAscension.GUI.UI.Renderers.Blessing;
 [ExcludeFromCodeCoverage]
 internal static class DeitySelectorRenderer
 {
-    private const float TabSize = 56f;
-    private const float TabSpacing = 6f;
-    private const float PatronBorderThickness = 2.5f;
-    private const float ActiveBorderThickness = 2f;
-    public const float Height = TabSize + 4f;
+    private static float TabSize => UiScale.Scaled(56f);
+    private static float TabSpacing => UiScale.Scaled(6f);
+    private static float PatronBorderThickness => UiScale.Scaled(2.5f);
+    private static float ActiveBorderThickness => UiScale.Scaled(2f);
+    public static float Height => TabSize + UiScale.Scaled(4f);
     // The selectable domains drive both the tab order and the count; Caravan is
     // included only when its feature flag is on (see DeityDomains.Selectable).
     private static readonly IReadOnlyList<DeityDomain> Order = DeityDomains.Selectable;
     public static readonly int TabCount = Order.Count;
-    public static readonly float StripWidth = TabCount * TabSize + (TabCount - 1) * TabSpacing;
+    public static float StripWidth => TabCount * TabSize + (TabCount - 1) * TabSpacing;
 
     /// <summary>
     ///     Draw the deity selector. Returns the deity the user clicked this frame, or null.
@@ -52,9 +52,9 @@ internal static class DeitySelectorRenderer
 
             var bgColor = ImGui.ColorConvertFloat4ToU32(
                 hovered ? ColorPalette.LightBrown : ColorPalette.DarkBrown);
-            drawList.AddRectFilled(min, max, bgColor, 4f);
+            drawList.AddRectFilled(min, max, bgColor, UiScale.Scaled(4f));
 
-            const float pad = 10f;
+            var pad = UiScale.Scaled(10f);
             var glyphMin = new Vector2(min.X + pad, min.Y + pad);
             var glyphMax = new Vector2(max.X - pad, max.Y - pad);
             DomainGlyphRenderer.Draw(drawList, domain, glyphMin, glyphMax, ColorPalette.LightText);
@@ -62,25 +62,25 @@ internal static class DeitySelectorRenderer
             if (isPatron)
             {
                 var patronBorder = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-                drawList.AddRect(min, max, patronBorder, 4f, ImDrawFlags.None, PatronBorderThickness);
+                drawList.AddRect(min, max, patronBorder, UiScale.Scaled(4f), ImDrawFlags.None, PatronBorderThickness);
                 var star = "*";
                 drawList.AddText(ImGui.GetFont(), Secondary,
-                    new Vector2(max.X - 12f, min.Y + 2f),
+                    new Vector2(max.X - UiScale.Scaled(12f), min.Y + UiScale.Scaled(2f)),
                     patronBorder, star);
             }
             else if (isActive)
             {
                 var border = ImGui.ColorConvertFloat4ToU32(ColorPalette.WithAlpha(ColorPalette.Gold, 0.6f));
-                drawList.AddRect(min, max, border, 4f, ImDrawFlags.None, ActiveBorderThickness);
+                drawList.AddRect(min, max, border, UiScale.Scaled(4f), ImDrawFlags.None, ActiveBorderThickness);
             }
 
             if (isActive)
             {
                 var underline = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
                 drawList.AddLine(
-                    new Vector2(min.X, max.Y + 1f),
-                    new Vector2(max.X, max.Y + 1f),
-                    underline, 2f);
+                    new Vector2(min.X, max.Y + UiScale.Scaled(1f)),
+                    new Vector2(max.X, max.Y + UiScale.Scaled(1f)),
+                    underline, UiScale.Scaled(2f));
             }
 
             if (hovered && clicked)

--- a/DivineAscension/GUI/UI/Renderers/Blessing/ReligionHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/ReligionHeaderRenderer.cs
@@ -23,12 +23,12 @@ namespace DivineAscension.GUI.UI.Renderers.Blessing;
 [ExcludeFromCodeCoverage]
 internal static class ReligionHeaderRenderer
 {
-    private const float Padding = 12f;
-    private const float IconSize = 40f;
-    private const float ProgressBarHeight = 12f;
-    private const float ProgressBarMaxWidth = 480f;
-    private const float RowSpacing = 6f;
-    private const float BlockSpacing = 10f;
+    private static float Padding => UiScale.Scaled(12f);
+    private static float IconSize => UiScale.Scaled(40f);
+    private static float ProgressBarHeight => UiScale.Scaled(12f);
+    private static float ProgressBarMaxWidth => UiScale.Scaled(480f);
+    private static float RowSpacing => UiScale.Scaled(6f);
+    private static float BlockSpacing => UiScale.Scaled(10f);
 
     /// <summary>
     ///     Draw the two-block status into the rect at (vm.X, vm.Y, vm.Width).
@@ -61,7 +61,7 @@ internal static class ReligionHeaderRenderer
         {
             var msg = LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_NO_RELIGION);
             drawList.AddText(ImGui.GetFont(), Body, new Vector2(x, y), subColor, msg);
-            return y + 22f;
+            return y + UiScale.Scaled(22f);
         }
 
         // Deity icon + name row.
@@ -76,7 +76,7 @@ internal static class ReligionHeaderRenderer
             drawList.AddRect(iconPos,
                 new Vector2(iconPos.X + IconSize, iconPos.Y + IconSize),
                 ImGui.ColorConvertFloat4ToU32(DomainHelper.GetDeityColor(vm.CurrentDeity) * 0.8f),
-                4f, ImDrawFlags.None, 2f);
+                UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
         }
         else
         {
@@ -86,7 +86,7 @@ internal static class ReligionHeaderRenderer
                 IconSize / 2f, fallback, 16);
         }
 
-        var textX = x + IconSize + 8f;
+        var textX = x + IconSize + UiScale.Scaled(8f);
         var religionName = vm.CurrentReligionName
             ?? LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_UNKNOWN_RELIGION);
         var deityName = !string.IsNullOrEmpty(vm.CurrentDeityName)
@@ -95,7 +95,7 @@ internal static class ReligionHeaderRenderer
 
         drawList.AddText(ImGui.GetFont(), SectionHeader, new Vector2(textX, y),
             labelColor, religionName);
-        drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(textX, y + 22f),
+        drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(textX, y + UiScale.Scaled(22f)),
             textColor, deityName);
 
         var cursorY = y + IconSize + RowSpacing;
@@ -110,7 +110,7 @@ internal static class ReligionHeaderRenderer
             : "";
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(x, cursorY), subColor,
             $"{memberInfo}{roleInfo}");
-        cursorY += 18f;
+        cursorY += UiScale.Scaled(18f);
 
         // Progress bars cap at a comfortable reading width so the label stays
         // legible on wider content panes.
@@ -124,7 +124,7 @@ internal static class ReligionHeaderRenderer
         ProgressBarRenderer.DrawProgressBar(drawList, x, cursorY, barWidth, ProgressBarHeight,
             favor.ProgressPercentage, ColorPalette.Gold, ColorPalette.DarkBrown,
             favorLabel, favor.ProgressPercentage > 0.8f);
-        cursorY += ProgressBarHeight + 6f;
+        cursorY += ProgressBarHeight + UiScale.Scaled(6f);
 
         // Prestige progress — lapis bar so prestige reads as the "second ink"
         // alongside the gold favor bar (gold leaf + lapis blue = the classic
@@ -136,7 +136,7 @@ internal static class ReligionHeaderRenderer
         ProgressBarRenderer.DrawProgressBar(drawList, x, cursorY, barWidth, ProgressBarHeight,
             prestige.ProgressPercentage, ColorPalette.Lapis,
             ColorPalette.DarkBrown, prestigeLabel, prestige.ProgressPercentage > 0.8f);
-        cursorY += ProgressBarHeight + 2f;
+        cursorY += ProgressBarHeight + UiScale.Scaled(2f);
 
         return cursorY;
     }
@@ -146,7 +146,7 @@ internal static class ReligionHeaderRenderer
     {
         var sepColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.3f);
         drawList.AddLine(new Vector2(x, y - BlockSpacing / 2f),
-            new Vector2(x + width, y - BlockSpacing / 2f), sepColor, 1f);
+            new Vector2(x + width, y - BlockSpacing / 2f), sepColor, UiScale.Scaled(1f));
 
         var hasAny = vm.HasCivilization
                      || !string.IsNullOrEmpty(vm.CurrentCivilizationName)
@@ -156,7 +156,7 @@ internal static class ReligionHeaderRenderer
             var msg = LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_UNKNOWN_CIVILIZATION);
             drawList.AddText(ImGui.GetFont(), Body, new Vector2(x, y),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), msg);
-            return y + 22f;
+            return y + UiScale.Scaled(22f);
         }
 
         // Civilization sigil hidden until the ledger redesign — see #385.
@@ -165,7 +165,7 @@ internal static class ReligionHeaderRenderer
         // can return without a schema or loader change. The text below keeps
         // the IconSize offset so the rail's two-row rhythm (deity row above
         // + civ row here) is preserved.
-        var textX = x + IconSize + 8f;
+        var textX = x + IconSize + UiScale.Scaled(8f);
         var civName = vm.CurrentCivilizationName
             ?? LocalizationService.Instance.Get(LocalizationKeys.UI_BLESSING_UNKNOWN_CIVILIZATION);
         var rankName = RankRequirements.GetCivilizationRankName(vm.CivilizationRank);
@@ -173,7 +173,7 @@ internal static class ReligionHeaderRenderer
         // gold-leaf religion name above to give the rail a clear two-ink hierarchy.
         drawList.AddText(ImGui.GetFont(), SectionHeader, new Vector2(textX, y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Lapis), civName);
-        drawList.AddText(ImGui.GetFont(), Body, new Vector2(textX, y + 22f),
+        drawList.AddText(ImGui.GetFont(), Body, new Vector2(textX, y + UiScale.Scaled(22f)),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.8f), $"[{rankName}]");
 
         var cursorY = y + IconSize + RowSpacing;
@@ -183,12 +183,12 @@ internal static class ReligionHeaderRenderer
             LocalizationKeys.UI_BLESSING_RELIGIONS_COUNT, memberCount);
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(x, cursorY),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), memberText);
-        cursorY += 18f;
+        cursorY += UiScale.Scaled(18f);
 
         if (memberCount > 0 && vm.CivilizationMemberReligions != null)
         {
-            const float deityIconSize = 18f;
-            const float deityIconSpacing = 4f;
+            var deityIconSize = UiScale.Scaled(18f);
+            var deityIconSpacing = UiScale.Scaled(4f);
             var deityX = x;
             foreach (var member in vm.CivilizationMemberReligions)
             {
@@ -202,7 +202,7 @@ internal static class ReligionHeaderRenderer
                 deityX += deityIconSize + deityIconSpacing;
                 if (deityX + deityIconSize > x + width) break;
             }
-            cursorY += deityIconSize + 4f;
+            cursorY += deityIconSize + UiScale.Scaled(4f);
         }
 
         if (vm.IsCivilizationFounder)
@@ -211,7 +211,7 @@ internal static class ReligionHeaderRenderer
             // mark titles and people of rank. TODO: localize this label.
             drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(x, cursorY),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Vermilion), "Founder");
-            cursorY += 18f;
+            cursorY += UiScale.Scaled(18f);
         }
 
         return cursorY;

--- a/DivineAscension/GUI/UI/Renderers/Blessing/TooltipRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Blessing/TooltipRenderer.cs
@@ -18,11 +18,11 @@ namespace DivineAscension.GUI.UI.Renderers.Blessing;
 [ExcludeFromCodeCoverage]
 internal static class TooltipRenderer
 {
-    private const float TOOLTIP_MAX_WIDTH = 450f;
-    private const float TOOLTIP_PADDING = 16f;
-    private const float LINE_SPACING = 6f;
-    private const float SECTION_SPACING = 20f;
-    private const float TITLE_TO_SUBTEXT = 10f;
+    private static float TOOLTIP_MAX_WIDTH => UiScale.Scaled(450f);
+    private static float TOOLTIP_PADDING => UiScale.Scaled(16f);
+    private static float LINE_SPACING => UiScale.Scaled(6f);
+    private static float SECTION_SPACING => UiScale.Scaled(20f);
+    private static float TITLE_TO_SUBTEXT => UiScale.Scaled(10f);
 
     /// <summary>
     ///     Draw a tooltip for a blessing node when hovering
@@ -56,8 +56,8 @@ internal static class TooltipRenderer
         var windowPos = ImGui.GetWindowPos();
 
         // Position tooltip (offset from mouse, check screen edges)
-        var offsetX = 16f; // Offset from cursor
-        var offsetY = 16f;
+        var offsetX = UiScale.Scaled(16f); // Offset from cursor
+        var offsetY = UiScale.Scaled(16f);
 
         var tooltipX = mouseX + offsetX;
         var tooltipY = mouseY + offsetY;
@@ -72,21 +72,21 @@ internal static class TooltipRenderer
 
         // Ensure doesn't go off left edge
         if (tooltipX < windowPos.X)
-            tooltipX = windowPos.X + 4f; // Small padding from left edge
+            tooltipX = windowPos.X + UiScale.Scaled(4f); // Small padding from left edge
 
         // Ensure doesn't go off top edge
         if (tooltipY < windowPos.Y)
-            tooltipY = windowPos.Y + 4f; // Small padding from top edge
+            tooltipY = windowPos.Y + UiScale.Scaled(4f); // Small padding from top edge
 
         // Draw tooltip background
         var bgStart = new Vector2(tooltipX, tooltipY);
         var bgEnd = new Vector2(tooltipX + tooltipWidth, tooltipY + tooltipHeight);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
-        drawList.AddRectFilled(bgStart, bgEnd, bgColor, 4f);
+        drawList.AddRectFilled(bgStart, bgEnd, bgColor, UiScale.Scaled(4f));
 
         // Draw border
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f);
-        drawList.AddRect(bgStart, bgEnd, borderColor, 4f, ImDrawFlags.None, 2f);
+        drawList.AddRect(bgStart, bgEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
         // Draw status badge in top-right corner
         if (!tooltipData.IsUnlocked && !tooltipData.CanUnlock)
@@ -381,6 +381,6 @@ internal static class TooltipRenderer
         public bool IsBold { get; set; }
         public float SpacingAfter { get; set; }
 
-        public float Height => FontSize + 4f; // Font size + small buffer
+        public float Height => FontSize + UiScale.Scaled(4f); // Font size + small buffer
     }
 }


### PR DESCRIPTION
Part of epic #584 — per-area layout grind. Scales the Blessing area's leaf renderers so they lay out proportionally at GUIScale > 1.

## Scope (8 files, `Scaled()` convention)
Blessing tree (canvas padding, node seal radius, icon size, connector thickness), `BlessingNodeRenderer`, `ReligionHeaderRenderer`, blessing + vows tabs, `DeitySelectorRenderer` tiles, `CrossDeitySummaryRenderer`, blessing `TooltipRenderer`.

## Notes
- **Hit-rects:** node and deity-tile hit detection uses the same scaled sizes/radii as the drawn shapes → clicks stay aligned.
- `DeitySelectorRenderer.StripWidth` was a `static readonly` computed once at type-init (wouldn't track runtime GUIScale changes) → converted to a property.
- Tooltip wrap-ratio math (`fontSize / GetFontSize()`) left untouched — it self-normalises under FontGlobalScale.
- Left unscaled (verified): `/2f` divisors, `*N` over scaled bases, colour alphas, circle-segment counts, angles, epsilons, `CalcTextSize`/`MeasureWrappedHeight`, font sizes, region params. **No change at Factor 1.0.**

## Tests
8 files via parallel agents; built + diff-sanity-checked + full suite: **2515 passed**, build clean.

Closes #597