### PR TITLE
feat(ui): scale shared Components + Utilities renderers (#600)

### DIFF
--- a/DivineAscension/GUI/UI/Components/Banners/ErrorBannerRenderer.cs
+++ b/DivineAscension/GUI/UI/Components/Banners/ErrorBannerRenderer.cs
@@ -46,24 +46,24 @@ internal static class ErrorBannerRenderer
         var bgEnd = new Vector2(x + width, y + height);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Red * 0.35f);
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Red * 0.8f);
-        drawList.AddRectFilled(bgStart, bgEnd, bgColor, 6f);
-        drawList.AddRect(bgStart, bgEnd, borderColor, 6f, ImDrawFlags.None, 1.5f);
+        drawList.AddRectFilled(bgStart, bgEnd, bgColor, UiScale.Scaled(6f));
+        drawList.AddRect(bgStart, bgEnd, borderColor, UiScale.Scaled(6f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
         // Icon (exclamation) circle
-        var iconCenter = new Vector2(x + 16f, y + height / 2f);
-        drawList.AddCircleFilled(iconCenter, 10f, ImGui.ColorConvertFloat4ToU32(ColorPalette.Red * 0.8f));
-        var exPos = new Vector2(iconCenter.X - 3.5f, iconCenter.Y - 7f);
+        var iconCenter = new Vector2(x + UiScale.Scaled(16f), y + height / 2f);
+        drawList.AddCircleFilled(iconCenter, UiScale.Scaled(10f), ImGui.ColorConvertFloat4ToU32(ColorPalette.Red * 0.8f));
+        var exPos = new Vector2(iconCenter.X - UiScale.Scaled(3.5f), iconCenter.Y - UiScale.Scaled(7f));
         drawList.AddText(exPos, ImGui.ColorConvertFloat4ToU32(ColorPalette.LightText), "!");
 
         // Message text
-        var textX = x + 36f;
+        var textX = x + UiScale.Scaled(36f);
         var textY = y + (height - ImGui.CalcTextSize(message).Y) / 2f;
         drawList.AddText(new Vector2(textX, textY), ImGui.ColorConvertFloat4ToU32(ColorPalette.LightText), message);
 
         // Action buttons on the right
-        var btnW = 86f;
-        var btnH = 28f;
-        var rightPadding = 10f;
+        var btnW = UiScale.Scaled(86f);
+        var btnH = UiScale.Scaled(28f);
+        var rightPadding = UiScale.Scaled(10f);
         var btnY = y + (height - btnH) / 2f;
         var curX = x + width - rightPadding - btnW;
 
@@ -72,7 +72,7 @@ internal static class ErrorBannerRenderer
                 LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_DISMISS), curX, btnY, btnW, btnH,
                 ColorPalette.DarkBrown))
             dismissClicked = true;
-        curX -= btnW + 8f;
+        curX -= btnW + UiScale.Scaled(8f);
 
         if (showRetry)
             if (ButtonRenderer.DrawSmallButton(drawList,
@@ -80,6 +80,6 @@ internal static class ErrorBannerRenderer
                     ColorPalette.Gold * 0.8f))
                 retryClicked = true;
 
-        return height + 8f; // include small spacing after banner
+        return height + UiScale.Scaled(8f); // include small spacing after banner
     }
 }

--- a/DivineAscension/GUI/UI/Components/IconButtonGroup.cs
+++ b/DivineAscension/GUI/UI/Components/IconButtonGroup.cs
@@ -67,10 +67,10 @@ public static class IconButtonGroup
         string iconDirectory,
         string iconName)
     {
-        const float iconSize = 20f;
-        const float leftPadding = 8f;
-        const float iconSpacing = 6f;
-        const float rightPadding = 8f;
+        var iconSize = UiScale.Scaled(20f);
+        var leftPadding = UiScale.Scaled(8f);
+        var iconSpacing = UiScale.Scaled(6f);
+        var rightPadding = UiScale.Scaled(8f);
 
         var topLeft = new Vector2(x, y);
         var bottomRight = new Vector2(x + width, y + height);
@@ -87,10 +87,10 @@ public static class IconButtonGroup
         if (isHovering && !isSelected) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
 
         drawList.AddRectFilled(topLeft, bottomRight,
-            ImGui.ColorConvertFloat4ToU32(bgColor), 4f);
+            ImGui.ColorConvertFloat4ToU32(bgColor), UiScale.Scaled(4f));
         drawList.AddRect(topLeft, bottomRight,
             ImGui.ColorConvertFloat4ToU32(isSelected ? ColorPalette.Gold : ColorPalette.BorderColor),
-            4f, ImDrawFlags.None, 2f);
+            UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
         var hasIcon = !string.IsNullOrEmpty(iconDirectory) && !string.IsNullOrEmpty(iconName);
         if (hasIcon)

--- a/DivineAscension/GUI/UI/Components/IconPicker.cs
+++ b/DivineAscension/GUI/UI/Components/IconPicker.cs
@@ -122,18 +122,18 @@ public static class IconPicker
 
         // Draw background
         var bgColorU32 = ImGui.ColorConvertFloat4ToU32(bgColor);
-        drawList.AddRectFilled(slotStart, slotEnd, bgColorU32, 4f);
+        drawList.AddRectFilled(slotStart, slotEnd, bgColorU32, UiScale.Scaled(4f));
 
         // Draw border
         var borderColor = ImGui.ColorConvertFloat4ToU32(isSelected ? ColorPalette.Gold : ColorPalette.Grey * 0.5f);
-        drawList.AddRect(slotStart, slotEnd, borderColor, 4f, ImDrawFlags.None, isSelected ? 2f : 1f);
+        drawList.AddRect(slotStart, slotEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, isSelected ? UiScale.Scaled(2f) : UiScale.Scaled(1f));
 
         // Draw icon texture
         var iconTextureId = CivilizationIconLoader.GetIconTextureId(iconName);
         if (iconTextureId != IntPtr.Zero)
         {
             // Center the 32x32 icon within the slot
-            const float iconTextureSize = 32f;
+            var iconTextureSize = UiScale.Scaled(32f);
             var padding = (size - iconTextureSize) / 2f;
             var iconMin = new Vector2(x + padding, y + padding);
             var iconMax = new Vector2(iconMin.X + iconTextureSize, iconMin.Y + iconTextureSize);
@@ -177,7 +177,7 @@ public static class IconPicker
         float y,
         float iconSize = 48f)
     {
-        const float spacing = 8f;
+        var spacing = UiScale.Scaled(8f);
 
         // Draw label
         var labelSize = ImGui.CalcTextSize(label);
@@ -191,18 +191,18 @@ public static class IconPicker
         var slotStart = new Vector2(x, iconY);
         var slotEnd = new Vector2(x + iconSize, iconY + iconSize);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.8f);
-        drawList.AddRectFilled(slotStart, slotEnd, bgColor, 4f);
+        drawList.AddRectFilled(slotStart, slotEnd, bgColor, UiScale.Scaled(4f));
 
         // Draw icon border
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
-        drawList.AddRect(slotStart, slotEnd, borderColor, 4f, ImDrawFlags.None, 2f);
+        drawList.AddRect(slotStart, slotEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
         // Draw icon texture
         var iconTextureId = CivilizationIconLoader.GetIconTextureId(iconName);
         if (iconTextureId != IntPtr.Zero)
         {
             // Center the 32x32 icon within the slot
-            const float iconTextureSize = 32f;
+            var iconTextureSize = UiScale.Scaled(32f);
             var iconPadding = (iconSize - iconTextureSize) / 2f;
             var iconMin = new Vector2(x + iconPadding, iconY + iconPadding);
             var iconMax = new Vector2(iconMin.X + iconTextureSize, iconMin.Y + iconTextureSize);

--- a/DivineAscension/GUI/UI/Components/Lists/ScrollableList.cs
+++ b/DivineAscension/GUI/UI/Components/Lists/ScrollableList.cs
@@ -48,15 +48,17 @@ public static class ScrollableList
         string? emptyText = null,
         string? loadingText = null,
         Vector4? backgroundColor = null,
-        float scrollbarWidth = 16f,
+        float scrollbarWidth = -1f,
         float wheelSpeed = 30f)
     {
+        if (scrollbarWidth < 0f) scrollbarWidth = UiScale.Scaled(16f);
+
         // Draw background
         var listStart = new Vector2(x, y);
         var listEnd = new Vector2(x + width, y + height);
         var bgColor = backgroundColor ?? ColorPalette.DarkBrown * 0.5f;
         var listBgColor = ImGui.ColorConvertFloat4ToU32(bgColor);
-        drawList.AddRectFilled(listStart, listEnd, listBgColor, 4f);
+        drawList.AddRectFilled(listStart, listEnd, listBgColor, UiScale.Scaled(4f));
 
         // Loading state
         if (loadingText != null)

--- a/DivineAscension/GUI/UI/Components/Lists/Scrollbar.cs
+++ b/DivineAscension/GUI/UI/Components/Lists/Scrollbar.cs
@@ -36,18 +36,18 @@ internal static class Scrollbar
         var trackStart = new Vector2(x, y);
         var trackEnd = new Vector2(x + width, y + height);
         var trackColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.7f);
-        drawList.AddRectFilled(trackStart, trackEnd, trackColor, 4f);
+        drawList.AddRectFilled(trackStart, trackEnd, trackColor, UiScale.Scaled(4f));
 
         // Calculate thumb size and position
         if (maxScroll > 0)
         {
-            var thumbHeight = Math.Max(20f, height * (height / (height + maxScroll)));
+            var thumbHeight = Math.Max(UiScale.Scaled(20f), height * (height / (height + maxScroll)));
             var thumbY = y + scrollY / maxScroll * (height - thumbHeight);
 
-            var thumbStart = new Vector2(x + 2f, thumbY);
-            var thumbEnd = new Vector2(x + width - 2f, thumbY + thumbHeight);
+            var thumbStart = new Vector2(x + UiScale.Scaled(2f), thumbY);
+            var thumbEnd = new Vector2(x + width - UiScale.Scaled(2f), thumbY + thumbHeight);
             var thumbColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
-            drawList.AddRectFilled(thumbStart, thumbEnd, thumbColor, 4f);
+            drawList.AddRectFilled(thumbStart, thumbEnd, thumbColor, UiScale.Scaled(4f));
         }
     }
 
@@ -109,7 +109,7 @@ internal static class Scrollbar
         if (maxScroll <= 0) return currentScrollY;
 
         var mousePos = ImGui.GetMousePos();
-        var thumbHeight = Math.Max(20f, scrollbarHeight * (scrollbarHeight / (scrollbarHeight + maxScroll)));
+        var thumbHeight = Math.Max(UiScale.Scaled(20f), scrollbarHeight * (scrollbarHeight / (scrollbarHeight + maxScroll)));
         var thumbY = scrollbarY + currentScrollY / maxScroll * (scrollbarHeight - thumbHeight);
 
         // Check if clicking on thumb

--- a/DivineAscension/GUI/UI/Components/Overlays/ConfirmOverlay.cs
+++ b/DivineAscension/GUI/UI/Components/Overlays/ConfirmOverlay.cs
@@ -51,31 +51,31 @@ internal static class ConfirmOverlay
         drawList.AddRectFilled(backdropStart, backdropEnd, backdropColor);
 
         // 2) Dialog box
-        var padding = 16f;
+        var padding = UiScale.Scaled(16f);
         var titleSize = ImGui.CalcTextSize(title);
 
         // Compute an adaptive dialog width when caller passes a non-positive width or when the default looks too wide.
         // We consider: title width, message unwrapped width, and total buttons width, then clamp to sensible bounds and window size.
         // Button widths size to the longer of their labels so "Yes, Declare War"
         // and friends don't crowd the text against the border.
-        const float btnMinWidth = 120f;
-        const float btnHorizontalPadding = 28f;
+        var btnMinWidth = UiScale.Scaled(120f);
+        var btnHorizontalPadding = UiScale.Scaled(28f);
         var confirmTextWidth = ImGui.CalcTextSize(confirmLabel).X;
         var cancelTextWidth = ImGui.CalcTextSize(cancelLabel).X;
         var confirmBtnW = MathF.Max(btnMinWidth, confirmTextWidth + btnHorizontalPadding);
         var cancelBtnW = MathF.Max(btnMinWidth, cancelTextWidth + btnHorizontalPadding);
-        var btnH = 36f;
-        var btnSpacing = 10f;
+        var btnH = UiScale.Scaled(36f);
+        var btnSpacing = UiScale.Scaled(10f);
         var totalButtonsWidth = confirmBtnW + cancelBtnW + btnSpacing;
 
         var unwrappedMsgWidth = ImGui.CalcTextSize(message).X;
-        var minWidth = 420f;
-        var maxWidth = Math.Min(640f, winSize.X - 80f); // keep nice margins from window edges
+        var minWidth = UiScale.Scaled(420f);
+        var maxWidth = Math.Min(UiScale.Scaled(640f), winSize.X - UiScale.Scaled(80f)); // keep nice margins from window edges
 
         // Wrap long messages at a comfortable reading measure instead of letting the unwrapped
         // single-line width balloon the box to maxWidth (which left dead space on the right).
         // Short messages still hug their own width; title and buttons remain hard floors.
-        const float preferredMessageWidth = 380f;
+        var preferredMessageWidth = UiScale.Scaled(380f);
 
         var effectiveDialogWidth = dialogWidth;
         if (dialogWidth <= 0f || dialogWidth == 520f) // treat default as auto-size candidate
@@ -94,8 +94,8 @@ internal static class ConfirmOverlay
         var wrappedMsgHeight = TextRenderer.MeasureWrappedHeight(message, messageWidth, 13f);
 
         // Vertical rhythm: title + divider + message + gap + buttons.
-        const float dividerBandHeight = 6f + 16f;
-        var contentHeight = FontSizes.PageTitle + dividerBandHeight + wrappedMsgHeight + 16f + btnH;
+        var dividerBandHeight = UiScale.Scaled(6f) + UiScale.Scaled(16f);
+        var contentHeight = FontSizes.PageTitle + dividerBandHeight + wrappedMsgHeight + UiScale.Scaled(16f) + btnH;
         var dialogHeight = contentHeight + padding * 2f;
 
         var dlgX = winPos.X + (winSize.X - effectiveDialogWidth) / 2f;
@@ -107,17 +107,17 @@ internal static class ConfirmOverlay
         // overlays read as a smaller page laid atop the dimmed main page.
         var dlgBg = ImGui.ColorConvertFloat4ToU32(ColorPalette.Background);
         var dlgBorder = ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor);
-        drawList.AddRectFilled(dlgStart, dlgEnd, dlgBg, 6f);
-        drawList.AddRect(dlgStart, dlgEnd, dlgBorder, 6f, ImDrawFlags.None, 1.5f);
+        drawList.AddRectFilled(dlgStart, dlgEnd, dlgBg, UiScale.Scaled(6f));
+        drawList.AddRect(dlgStart, dlgEnd, dlgBorder, UiScale.Scaled(6f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
         var curX = dlgX + padding;
         var curY = dlgY + padding;
 
         // Title — gold rubric on parchment, matching the role-edit dialog.
         TextRenderer.DrawLabel(drawList, title, curX, curY, FontSizes.PageTitle, ColorPalette.Gold);
-        curY += FontSizes.PageTitle + 6f;
+        curY += FontSizes.PageTitle + UiScale.Scaled(6f);
         ChromeRenderer.DrawDivider(drawList, curX, curY, messageWidth);
-        curY += 16f;
+        curY += UiScale.Scaled(16f);
 
         // Message — ink on parchment (palette §5).
         TextRenderer.DrawInfoText(drawList, message, curX, curY, messageWidth, 13f, ColorPalette.White);

--- a/DivineAscension/GUI/UI/Components/Overlays/RankUpNotificationOverlay.cs
+++ b/DivineAscension/GUI/UI/Components/Overlays/RankUpNotificationOverlay.cs
@@ -19,10 +19,10 @@ namespace DivineAscension.GUI.UI.Components.Overlays;
 [ExcludeFromCodeCoverage]
 internal static class RankUpNotificationOverlay
 {
-    private const float PanelWidth = 320f;
-    private const float IconSize = 36f;
-    private const float Padding = 12f;
-    private const float EdgeMargin = 24f;
+    private static float PanelWidth => UiScale.Scaled(320f);
+    private static float IconSize => UiScale.Scaled(36f);
+    private static float Padding => UiScale.Scaled(12f);
+    private static float EdgeMargin => UiScale.Scaled(24f);
 
     internal static void Draw(NotificationState state, out bool dismissed, out bool viewBlessingsClicked,
         float windowWidth, float windowHeight)
@@ -39,8 +39,8 @@ internal static class RankUpNotificationOverlay
         var descriptionHeight = TextRenderer.MeasureWrappedHeight(state.RankDescription, bodyWidth, Body);
 
         var contentHeight =
-            SubsectionLabel + 4f +
-            SubsectionLabel + 6f +
+            SubsectionLabel + UiScale.Scaled(4f) +
+            SubsectionLabel + UiScale.Scaled(6f) +
             descriptionHeight;
         var iconBlockHeight = IconSize;
         var panelHeight = Padding + MathF.Max(contentHeight, iconBlockHeight) + Padding;
@@ -52,9 +52,9 @@ internal static class RankUpNotificationOverlay
 
         // Parchment surface + faded-ink edge (matches vestments modal).
         drawList.AddRectFilled(panelMin, panelMax,
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), 6f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.Background), UiScale.Scaled(6f));
         drawList.AddRect(panelMin, panelMax,
-            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), 6f, ImDrawFlags.None, 1.5f);
+            ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor), UiScale.Scaled(6f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
         var iconX = panelX + Padding;
         var iconY = panelY + (panelHeight - IconSize) / 2f;
@@ -75,10 +75,10 @@ internal static class RankUpNotificationOverlay
             : LocalizationKeys.UI_RANKUP_TITLE;
         var titleText = LocalizationService.Instance.Get(titleKey);
         TextRenderer.DrawLabel(drawList, titleText, textX, textY, SubsectionLabel, ColorPalette.Gold);
-        textY += SubsectionLabel + 4f;
+        textY += SubsectionLabel + UiScale.Scaled(4f);
 
         TextRenderer.DrawLabel(drawList, state.RankName, textX, textY, SubsectionLabel, ColorPalette.White);
-        textY += SubsectionLabel + 6f;
+        textY += SubsectionLabel + UiScale.Scaled(6f);
 
         TextRenderer.DrawInfoText(drawList, state.RankDescription,
             textX, textY, bodyWidth, Body, ColorPalette.White);

--- a/DivineAscension/GUI/UI/Renderers/Components/BanListRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/BanListRenderer.cs
@@ -43,15 +43,15 @@ public static class BanListRenderer
         float scrollY,
         Action<string>? onUnbanPlayer = null)
     {
-        const float itemHeight = 40f; // Taller to fit two lines of text
-        const float itemSpacing = 4f;
-        const float scrollbarWidth = 16f;
+        var itemHeight = UiScale.Scaled(40f); // Taller to fit two lines of text
+        var itemSpacing = UiScale.Scaled(4f);
+        var scrollbarWidth = UiScale.Scaled(16f);
 
         // Draw background
         var listStart = new Vector2(x, y);
         var listEnd = new Vector2(x + width, y + height);
         var listBgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.5f);
-        drawList.AddRectFilled(listStart, listEnd, listBgColor, 4f);
+        drawList.AddRectFilled(listStart, listEnd, listBgColor, UiScale.Scaled(4f));
 
         if (bannedPlayers.Count == 0)
         {
@@ -74,7 +74,7 @@ public static class BanListRenderer
         if (isMouseOver)
         {
             var wheel = ImGui.GetIO().MouseWheel;
-            if (wheel != 0) scrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+            if (wheel != 0) scrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
         }
 
         // Clip to bounds
@@ -92,7 +92,8 @@ public static class BanListRenderer
                 continue;
             }
 
-            DrawBannedPlayerItem(drawList, api, bannedPlayer, x, itemY, width - scrollbarWidth - 4f, itemHeight,
+            DrawBannedPlayerItem(drawList, api, bannedPlayer, x, itemY, width - scrollbarWidth - UiScale.Scaled(4f),
+                itemHeight,
                 onUnbanPlayer);
             itemY += itemHeight + itemSpacing;
         }
@@ -119,14 +120,14 @@ public static class BanListRenderer
         float height,
         Action<string>? onUnbanPlayer)
     {
-        const float padding = 8f;
-        const float buttonWidth = 60f;
+        var padding = UiScale.Scaled(8f);
+        var buttonWidth = UiScale.Scaled(60f);
 
         // Draw background
         var itemStart = new Vector2(x, y);
         var itemEnd = new Vector2(x + width, y + height);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.8f);
-        drawList.AddRectFilled(itemStart, itemEnd, bgColor, 3f);
+        drawList.AddRectFilled(itemStart, itemEnd, bgColor, UiScale.Scaled(3f));
 
         // Player name and reason (first line)
         var nameText = $"{bannedPlayer.PlayerName} - {bannedPlayer.Reason}";
@@ -141,7 +142,7 @@ public static class BanListRenderer
         var bannedLabel = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INFO_BANNED_AT_LABEL);
         var expiresLabel = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INFO_BANNED_EXPIRES_LABEL);
         var detailsText = $"{bannedLabel} {bannedPlayer.BannedAt} | {expiresLabel} {expiryText}";
-        var detailsPos = new Vector2(x + padding + 10f, y + padding + 16f);
+        var detailsPos = new Vector2(x + padding + UiScale.Scaled(10f), y + padding + UiScale.Scaled(16f));
         var detailsColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey * 0.9f);
 
         // Use smaller font for details if available
@@ -150,12 +151,13 @@ public static class BanListRenderer
         // Unban button (only if callback provided)
         if (onUnbanPlayer != null)
         {
-            var buttonY = y + (height - 22f) / 2;
+            var buttonHeight = UiScale.Scaled(22f);
+            var buttonY = y + (height - buttonHeight) / 2;
             var unbanButtonX = x + width - buttonWidth - padding;
 
             if (ButtonRenderer.DrawSmallButton(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INFO_UNBAN_BUTTON),
-                    unbanButtonX, buttonY, buttonWidth, 22f))
+                    unbanButtonX, buttonY, buttonWidth, buttonHeight))
             {
                 onUnbanPlayer.Invoke(bannedPlayer.PlayerUID);
             }

--- a/DivineAscension/GUI/UI/Renderers/Components/CheckboxRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/CheckboxRenderer.cs
@@ -17,9 +17,12 @@ internal static class CheckboxRenderer
         float x,
         float y,
         bool isChecked,
-        float checkboxSize = 20f,
-        float labelPadding = 8f)
+        float checkboxSize = -1f,
+        float labelPadding = -1f)
     {
+        if (checkboxSize < 0f) checkboxSize = UiScale.Scaled(20f);
+        if (labelPadding < 0f) labelPadding = UiScale.Scaled(8f);
+
         var checkboxStart = new Vector2(x, y);
         var checkboxEnd = new Vector2(x + checkboxSize, y + checkboxSize);
 
@@ -31,11 +34,11 @@ internal static class CheckboxRenderer
         var bgColor = isHovering
             ? ImGui.ColorConvertFloat4ToU32(ColorPalette.LightBrown * 0.7f)
             : ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.7f);
-        drawList.AddRectFilled(checkboxStart, checkboxEnd, bgColor, 3f);
+        drawList.AddRectFilled(checkboxStart, checkboxEnd, bgColor, UiScale.Scaled(3f));
 
         // Draw border
         var borderColor = ImGui.ColorConvertFloat4ToU32(isChecked ? ColorPalette.Gold : ColorPalette.Grey * 0.5f);
-        drawList.AddRect(checkboxStart, checkboxEnd, borderColor, 3f, ImDrawFlags.None, 1.5f);
+        drawList.AddRect(checkboxStart, checkboxEnd, borderColor, UiScale.Scaled(3f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
         if (isHovering) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
 
@@ -44,19 +47,19 @@ internal static class CheckboxRenderer
         {
             var checkColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold);
             drawList.AddLine(
-                new Vector2(x + 4f, y + checkboxSize / 2),
-                new Vector2(x + checkboxSize / 2 - 1f, y + checkboxSize - 5f),
-                checkColor, 2f
+                new Vector2(x + UiScale.Scaled(4f), y + checkboxSize / 2),
+                new Vector2(x + checkboxSize / 2 - UiScale.Scaled(1f), y + checkboxSize - UiScale.Scaled(5f)),
+                checkColor, UiScale.Scaled(2f)
             );
             drawList.AddLine(
-                new Vector2(x + checkboxSize / 2 - 1f, y + checkboxSize - 5f),
-                new Vector2(x + checkboxSize - 4f, y + 4f),
-                checkColor, 2f
+                new Vector2(x + checkboxSize / 2 - UiScale.Scaled(1f), y + checkboxSize - UiScale.Scaled(5f)),
+                new Vector2(x + checkboxSize - UiScale.Scaled(4f), y + UiScale.Scaled(4f)),
+                checkColor, UiScale.Scaled(2f)
             );
         }
 
         // Draw label
-        var labelPos = new Vector2(x + checkboxSize + labelPadding, y + (checkboxSize - 14f) / 2);
+        var labelPos = new Vector2(x + checkboxSize + labelPadding, y + (checkboxSize - UiScale.Scaled(14f)) / 2);
         var labelColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
         drawList.AddText(labelPos, labelColor, label);
 

--- a/DivineAscension/GUI/UI/Renderers/Components/CivilizationTableRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/CivilizationTableRenderer.cs
@@ -27,22 +27,22 @@ internal static class CivilizationTableRenderer
     private const float NameWeight = 0.30f;
     private const float ReligionsWeight = 0.15f;
     private const float DescriptionWeight = 0.55f;
-    private const float MinNameColumnWidth = 160f;
-    private const float MinReligionsColumnWidth = 80f;
-    private const float MinDescriptionColumnWidth = 240f;
-    private const float HeaderHeight = 27f;
-    private const float MinRowHeight = 80f;
-    private const float RowPaddingVertical = 12f;
-    private const float RowSpacing = 8f;
-    private const float ScrollbarWidth = 16f;
+    private static float MinNameColumnWidth => UiScale.Scaled(160f);
+    private static float MinReligionsColumnWidth => UiScale.Scaled(80f);
+    private static float MinDescriptionColumnWidth => UiScale.Scaled(240f);
+    private static float HeaderHeight => UiScale.Scaled(27f);
+    private static float MinRowHeight => UiScale.Scaled(80f);
+    private static float RowPaddingVertical => UiScale.Scaled(12f);
+    private static float RowSpacing => UiScale.Scaled(8f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
     // Civ sigil column hidden until the ledger redesign — see #385. Set to 0
     // so the Name column reclaims the space; the loader and asset PNGs are
     // intentionally left in place.
     private const float CivIconSize = 0f;
-    private const float DeityIconSize = 12f;
-    private const float DeityIconSpacing = 4f;
-    private const float DescriptionPaddingHorizontal = 12f;
-    private const float NamePadding = 12f;
+    private static float DeityIconSize => UiScale.Scaled(12f);
+    private static float DeityIconSpacing => UiScale.Scaled(4f);
+    private static float DescriptionPaddingHorizontal => UiScale.Scaled(12f);
+    private static float NamePadding => UiScale.Scaled(12f);
 
     public static CivilizationTableRenderResult Draw(
         CivilizationTableViewModel viewModel,
@@ -183,7 +183,7 @@ internal static class CivilizationTableRenderer
         var start = new Vector2(x, y);
         var end = new Vector2(x + width, y + height);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.TableBackground);
-        drawList.AddRectFilled(start, end, bgColor, 4f);
+        drawList.AddRectFilled(start, end, bgColor, UiScale.Scaled(4f));
     }
 
     private static void DrawTableHeader(ImDrawListPtr drawList, float x, float y,
@@ -198,17 +198,17 @@ internal static class CivilizationTableRenderer
         var nameTextAreaWidth = nameColumnWidth - NamePadding * 2;
         DrawCenteredText(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_BROWSE_HEADER_NAME),
-            nameTextAreaX, y + 8f, nameTextAreaWidth, headerColor, fontSize);
+            nameTextAreaX, y + UiScale.Scaled(8f), nameTextAreaWidth, headerColor, fontSize);
 
         // Column 2: "Religions" — centered
         DrawCenteredText(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_BROWSE_HEADER_RELIGIONS),
-            x + nameColumnWidth, y + 8f, religionsColumnWidth, headerColor, fontSize);
+            x + nameColumnWidth, y + UiScale.Scaled(8f), religionsColumnWidth, headerColor, fontSize);
 
         // Column 3: "Description" — centered like other table headers
         DrawCenteredText(drawList,
             LocalizationService.Instance.Get(LocalizationKeys.UI_CIVILIZATION_BROWSE_HEADER_DESCRIPTION),
-            x + nameColumnWidth + religionsColumnWidth, y + 8f, descriptionColumnWidth, headerColor, fontSize);
+            x + nameColumnWidth + religionsColumnWidth, y + UiScale.Scaled(8f), descriptionColumnWidth, headerColor, fontSize);
     }
 
     private static string? DrawTableRow(
@@ -247,10 +247,10 @@ internal static class CivilizationTableRenderer
         }
 
         var bgColorU32 = ImGui.ColorConvertFloat4ToU32(bgColor);
-        drawList.AddRectFilled(rowStart, rowEnd, bgColorU32, 4f);
+        drawList.AddRectFilled(rowStart, rowEnd, bgColorU32, UiScale.Scaled(4f));
 
         var borderColor = ImGui.ColorConvertFloat4ToU32(isSelected ? ColorPalette.Gold : ColorPalette.DarkBrown);
-        drawList.AddRect(rowStart, rowEnd, borderColor, 4f, ImDrawFlags.None, 2f);
+        drawList.AddRect(rowStart, rowEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
         string? clickedCivId = null;
         if (isHovering && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
@@ -298,20 +298,20 @@ internal static class CivilizationTableRenderer
         if (civ.MemberDeities == null || civ.MemberDeities.Count == 0)
             return;
 
-        var iconX = colX + 8f;
+        var iconX = colX + UiScale.Scaled(8f);
         var iconY = rowY + RowPaddingVertical;
 
         var currentX = iconX;
         var currentY = iconY;
-        const float iconTotalWidth = DeityIconSize + DeityIconSpacing;
+        var iconTotalWidth = DeityIconSize + DeityIconSpacing;
 
         foreach (var deityName in civ.MemberDeities)
         {
             // Wrap to next row when we'd overflow the column.
-            if (currentX + DeityIconSize > colX + columnWidth - 8f)
+            if (currentX + DeityIconSize > colX + columnWidth - UiScale.Scaled(8f))
             {
                 currentX = iconX;
-                currentY += DeityIconSize + 4f;
+                currentY += DeityIconSize + UiScale.Scaled(4f);
             }
 
             if (Enum.TryParse<DeityDomain>(deityName, out var deityType))

--- a/DivineAscension/GUI/UI/Renderers/Components/LettersRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/LettersRenderer.cs
@@ -28,40 +28,40 @@ namespace DivineAscension.GUI.UI.Renderers.Components;
 internal static class LettersRenderer
 {
     // Chapter-level layout.
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float ScrollbarWidth = 16f;
-    private const float ClosingLineHeight = 24f;
-    private const float ClosingLineTopSpacing = 6f;
-    private const float IntroLineHeight = 18f;
-    private const float IntroBottomSpacing = 10f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
+    private static float ClosingLineHeight => UiScale.Scaled(24f);
+    private static float ClosingLineTopSpacing => UiScale.Scaled(6f);
+    private static float IntroLineHeight => UiScale.Scaled(18f);
+    private static float IntroBottomSpacing => UiScale.Scaled(10f);
 
     // Letter-row layout — see DrawLetter for the geometry.
-    private const float EnvelopeSize = 18f;
-    private const float GlyphSize = 16f;
-    private const float GlyphGap = 6f;
-    private const float MarkColumnWidth = EnvelopeSize + GlyphGap + GlyphSize + 8f;
-    private const float HeaderLineHeight = 22f;
-    private const float QuoteLineHeight = 20f;
-    private const float ButtonHeight = 26f;
-    private const float ButtonWidth = 88f;
-    private const float ButtonGap = 10f;
-    private const float ButtonTopSpacing = 6f;
-    private const float ButtonBottomSpacing = 8f;
-    private const float RowLeftPadding = 16f;
+    private static float EnvelopeSize => UiScale.Scaled(18f);
+    private static float GlyphSize => UiScale.Scaled(16f);
+    private static float GlyphGap => UiScale.Scaled(6f);
+    private static float MarkColumnWidth => EnvelopeSize + GlyphGap + GlyphSize + UiScale.Scaled(8f);
+    private static float HeaderLineHeight => UiScale.Scaled(22f);
+    private static float QuoteLineHeight => UiScale.Scaled(20f);
+    private static float ButtonHeight => UiScale.Scaled(26f);
+    private static float ButtonWidth => UiScale.Scaled(88f);
+    private static float ButtonGap => UiScale.Scaled(10f);
+    private static float ButtonTopSpacing => UiScale.Scaled(6f);
+    private static float ButtonBottomSpacing => UiScale.Scaled(8f);
+    private static float RowLeftPadding => UiScale.Scaled(16f);
 
-    private const float RowHeight =
+    private static float RowHeight =>
         HeaderLineHeight + QuoteLineHeight + ButtonTopSpacing + ButtonHeight + ButtonBottomSpacing;
 
     /// <summary>
     ///     Row height for read-only / informational letters (no Accept/Refuse).
     ///     Used by holiday-notice letters projected from the chronicle.
     /// </summary>
-    private const float ReadOnlyRowHeight =
+    private static float ReadOnlyRowHeight =>
         HeaderLineHeight + QuoteLineHeight + ButtonBottomSpacing;
 
-    private const float SlimDividerHeight = 18f;
-    private const float SlimDividerYPadding = 4f;
+    private static float SlimDividerHeight => UiScale.Scaled(18f);
+    private static float SlimDividerYPadding => UiScale.Scaled(4f);
 
     public static LettersRenderResult Draw(
         ImDrawListPtr drawList,
@@ -91,7 +91,7 @@ internal static class LettersRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -188,7 +188,7 @@ internal static class LettersRenderer
 
         var textX = x + MarkColumnWidth;
         drawList.AddText(ImGui.GetFont(), Body,
-            new Vector2(textX, y + 2f),
+            new Vector2(textX, y + UiScale.Scaled(2f)),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White), letter.SenderText);
 
         var quoteY = y + HeaderLineHeight;

--- a/DivineAscension/GUI/UI/Renderers/Components/MemberListRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/MemberListRenderer.cs
@@ -36,15 +36,15 @@ public static class MemberListRenderer
         var scrollY = viewModel.ScrollY;
         var currentPlayerUid = viewModel.CurrentPlayerUID;
 
-        const float itemHeight = 30f;
-        const float itemSpacing = 4f;
-        const float scrollbarWidth = 16f;
+        var itemHeight = UiScale.Scaled(30f);
+        var itemSpacing = UiScale.Scaled(4f);
+        var scrollbarWidth = UiScale.Scaled(16f);
 
         // Draw background
         var listStart = new Vector2(x, y);
         var listEnd = new Vector2(x + width, y + height);
         var listBgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.5f);
-        drawList.AddRectFilled(listStart, listEnd, listBgColor, 4f);
+        drawList.AddRectFilled(listStart, listEnd, listBgColor, UiScale.Scaled(4f));
 
         if (members.Count == 0)
         {
@@ -69,7 +69,7 @@ public static class MemberListRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScroll = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScroll = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScroll - scrollY) > 0.001f)
                 {
                     scrollY = newScroll;
@@ -93,7 +93,7 @@ public static class MemberListRenderer
                 continue;
             }
 
-            DrawMemberItem(drawList, member, x, itemY, width - scrollbarWidth - 4f, itemHeight,
+            DrawMemberItem(drawList, member, x, itemY, width - scrollbarWidth - UiScale.Scaled(4f), itemHeight,
                 currentPlayerUid, events);
             itemY += itemHeight + itemSpacing;
         }
@@ -120,19 +120,19 @@ public static class MemberListRenderer
         string currentPlayerUid,
         List<MemberListEvent> events)
     {
-        const float padding = 8f;
-        const float buttonWidth = 50f;
-        const float buttonSpacing = 5f;
+        var padding = UiScale.Scaled(8f);
+        var buttonWidth = UiScale.Scaled(50f);
+        var buttonSpacing = UiScale.Scaled(5f);
 
         // Draw background
         var itemStart = new Vector2(x, y);
         var itemEnd = new Vector2(x + width, y + height);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.8f);
-        drawList.AddRectFilled(itemStart, itemEnd, bgColor, 3f);
+        drawList.AddRectFilled(itemStart, itemEnd, bgColor, UiScale.Scaled(3f));
 
         // Player name with role
         var nameText = $"{member.PlayerName} [{member.RoleName}]";
-        var namePos = new Vector2(x + padding, y + (height - 14f) / 2);
+        var namePos = new Vector2(x + padding, y + (height - UiScale.Scaled(14f)) / 2);
         var nameColor = ImGui.ColorConvertFloat4ToU32(member.IsFounder ? ColorPalette.Gold : ColorPalette.White);
         drawList.AddText(namePos, nameColor, nameText);
 
@@ -142,21 +142,21 @@ public static class MemberListRenderer
 
         var buttonAreaWidth = buttonWidth + buttonSpacing + padding;
 
-        var rankPos = new Vector2(x + width - buttonAreaWidth - rankSize.X, y + (height - 14f) / 2);
+        var rankPos = new Vector2(x + width - buttonAreaWidth - rankSize.X, y + (height - UiScale.Scaled(14f)) / 2);
         var rankColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
         drawList.AddText(rankPos, rankColor, rankText);
 
         // Action buttons (only if not founder and not self)
         if (!member.IsFounder && member.PlayerUID != currentPlayerUid)
         {
-            var buttonY = y + (height - 22f) / 2;
+            var buttonY = y + (height - UiScale.Scaled(22f)) / 2;
 
             // Ban button (leftmost if both buttons present)
             var banButtonX = x + width - buttonWidth - padding;
 
             if (ButtonRenderer.DrawSmallButton(drawList,
                     LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_INFO_BAN_BUTTON),
-                    banButtonX, buttonY, buttonWidth, 22f))
+                    banButtonX, buttonY, buttonWidth, UiScale.Scaled(22f)))
             {
                 events.Add(new MemberListEvent.BanClicked(member.PlayerUID));
             }

--- a/DivineAscension/GUI/UI/Renderers/Components/ProgressBarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/ProgressBarRenderer.cs
@@ -38,7 +38,7 @@ internal static class ProgressBarRenderer
         var bgMin = new Vector2(x, y);
         var bgMax = new Vector2(x + width, y + height);
         var bgColorU32 = ImGui.ColorConvertFloat4ToU32(backgroundColor);
-        drawList.AddRectFilled(bgMin, bgMax, bgColorU32, 4f);
+        drawList.AddRectFilled(bgMin, bgMax, bgColorU32, UiScale.Scaled(4f));
 
         // Fill (progress)
         if (percentage > 0)
@@ -46,7 +46,7 @@ internal static class ProgressBarRenderer
             var fillWidth = width * Math.Clamp(percentage, 0f, 1f);
             var fillMax = new Vector2(x + fillWidth, y + height);
             var fillColorU32 = ImGui.ColorConvertFloat4ToU32(fillColor);
-            drawList.AddRectFilled(bgMin, fillMax, fillColorU32, 4f);
+            drawList.AddRectFilled(bgMin, fillMax, fillColorU32, UiScale.Scaled(4f));
 
             // Glow effect (if >80% progress)
             if (showGlow && percentage > 0.8f)
@@ -54,13 +54,13 @@ internal static class ProgressBarRenderer
                 var glowAlpha = (float)(Math.Sin(ImGui.GetTime() * 3.0) * 0.3 + 0.7);
                 var glowColor = new Vector4(fillColor.X, fillColor.Y, fillColor.Z, glowAlpha);
                 var glowColorU32 = ImGui.ColorConvertFloat4ToU32(glowColor);
-                drawList.AddRect(bgMin, fillMax, glowColorU32, 4f, ImDrawFlags.None, 2f);
+                drawList.AddRect(bgMin, fillMax, glowColorU32, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
             }
         }
 
         // Border
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.5f);
-        drawList.AddRect(bgMin, bgMax, borderColor, 4f, ImDrawFlags.None, 1f);
+        drawList.AddRect(bgMin, bgMax, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(1f));
 
         // Label text — drawn twice with clipping so each half reads against
         // whatever background sits behind it. Dark ink on the gold fill,

--- a/DivineAscension/GUI/UI/Renderers/Components/ReligionListRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Components/ReligionListRenderer.cs
@@ -37,15 +37,15 @@ public static class ReligionListRenderer
         var scrollY = viewModel.ScrollY;
         var selectedReligionUID = viewModel.SelectedReligionUID;
 
-        const float itemHeight = 80f;
-        const float itemSpacing = 8f;
-        const float scrollbarWidth = 16f;
+        var itemHeight = UiScale.Scaled(80f);
+        var itemSpacing = UiScale.Scaled(8f);
+        var scrollbarWidth = UiScale.Scaled(16f);
 
         // Draw list background
         var listStart = new Vector2(x, y);
         var listEnd = new Vector2(x + width, y + height);
         var listBgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown * 0.5f);
-        drawList.AddRectFilled(listStart, listEnd, listBgColor, 4f);
+        drawList.AddRectFilled(listStart, listEnd, listBgColor, UiScale.Scaled(4f));
 
         // Loading state
         if (isLoading)
@@ -88,7 +88,7 @@ public static class ReligionListRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScroll = Math.Clamp(scrollY - wheel * 40f, 0f, maxScroll);
+                var newScroll = Math.Clamp(scrollY - wheel * UiScale.Scaled(40f), 0f, maxScroll);
                 if (Math.Abs(newScroll - scrollY) > 0.01f)
                 {
                     scrollY = newScroll;
@@ -148,7 +148,7 @@ public static class ReligionListRenderer
         float height,
         string? currentSelectedUID)
     {
-        const float padding = 12f;
+        var padding = UiScale.Scaled(12f);
 
         var itemStart = new Vector2(x, y);
         var itemEnd = new Vector2(x + width, y + height);
@@ -176,11 +176,11 @@ public static class ReligionListRenderer
 
         // Draw background
         var bgColorU32 = ImGui.ColorConvertFloat4ToU32(bgColor);
-        drawList.AddRectFilled(itemStart, itemEnd, bgColorU32, 4f);
+        drawList.AddRectFilled(itemStart, itemEnd, bgColorU32, UiScale.Scaled(4f));
 
         // Draw border
         var borderColor = ImGui.ColorConvertFloat4ToU32(isSelected ? ColorPalette.Gold : ColorPalette.Grey * 0.5f);
-        drawList.AddRect(itemStart, itemEnd, borderColor, 4f, ImDrawFlags.None, isSelected ? 2f : 1f);
+        drawList.AddRect(itemStart, itemEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, isSelected ? UiScale.Scaled(2f) : UiScale.Scaled(1f));
 
         // Handle click
         string? clickedUID = null;
@@ -190,7 +190,7 @@ public static class ReligionListRenderer
         }
 
         // Draw deity icon (with fallback to colored circle)
-        const float iconSize = 48f;
+        var iconSize = UiScale.Scaled(48f);
         var deityType = DomainHelper.ParseDeityType(religion.Domain);
         var deityTextureId = DeityIconLoader.GetDeityTextureId(deityType);
 
@@ -208,7 +208,7 @@ public static class ReligionListRenderer
             // Add subtle border around icon for visual cohesion
             var deityColor = DomainHelper.GetDeityColor(religion.Domain);
             var iconBorderColor = ImGui.ColorConvertFloat4ToU32(deityColor * 0.8f);
-            drawList.AddRect(iconMin, iconMax, iconBorderColor, 4f, ImDrawFlags.None, 2f);
+            drawList.AddRect(iconMin, iconMax, iconBorderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
         }
         else
         {
@@ -228,7 +228,7 @@ public static class ReligionListRenderer
         var deityText = !string.IsNullOrWhiteSpace(religion.DeityName)
             ? $"{religion.DeityName} ({religion.Domain})"
             : $"{religion.Domain} - {DomainHelper.GetDeityTitle(religion.Domain)}";
-        var deityPos = new Vector2(x + padding * 2 + iconSize, y + padding + 22f);
+        var deityPos = new Vector2(x + padding * 2 + iconSize, y + padding + UiScale.Scaled(22f));
         var deityColorU32 = ImGui.ColorConvertFloat4ToU32(ColorPalette.White);
         drawList.AddText(ImGui.GetFont(), Body, deityPos, deityColorU32, deityText);
 
@@ -238,7 +238,7 @@ public static class ReligionListRenderer
             : LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_PRIVATE);
         var infoText = LocalizationService.Instance.Get(LocalizationKeys.UI_RELIGION_LIST_INFO_SHORT,
             religion.MemberCount, religion.PrestigeRank, statusText);
-        var infoPos = new Vector2(x + padding * 2 + iconSize, y + padding + 42f);
+        var infoPos = new Vector2(x + padding * 2 + iconSize, y + padding + UiScale.Scaled(42f));
         var infoColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
         drawList.AddText(ImGui.GetFont(), Secondary, infoPos, infoColor, infoText);
 
@@ -255,9 +255,9 @@ public static class ReligionListRenderer
         float windowWidth,
         float windowHeight)
     {
-        const float tooltipMaxWidth = 300f;
-        const float tooltipPadding = 12f;
-        const float lineSpacing = 6f;
+        var tooltipMaxWidth = UiScale.Scaled(300f);
+        var tooltipPadding = UiScale.Scaled(12f);
+        var lineSpacing = UiScale.Scaled(6f);
 
         var drawList = ImGui.GetForegroundDrawList();
 
@@ -303,7 +303,7 @@ public static class ReligionListRenderer
         }
 
         // Calculate tooltip dimensions
-        var lineHeight = 16f;
+        var lineHeight = UiScale.Scaled(16f);
         var tooltipHeight = tooltipPadding * 2 + lines.Count * lineHeight;
         var tooltipWidth = tooltipMaxWidth;
 
@@ -311,8 +311,8 @@ public static class ReligionListRenderer
         var windowPos = ImGui.GetWindowPos();
 
         // Position tooltip (offset from mouse, check screen edges)
-        var offsetX = 16f;
-        var offsetY = 16f;
+        var offsetX = UiScale.Scaled(16f);
+        var offsetY = UiScale.Scaled(16f);
 
         var tooltipX = mouseX + offsetX;
         var tooltipY = mouseY + offsetY;
@@ -327,21 +327,21 @@ public static class ReligionListRenderer
 
         // Ensure doesn't go off left edge
         if (tooltipX < windowPos.X)
-            tooltipX = windowPos.X + 4f;
+            tooltipX = windowPos.X + UiScale.Scaled(4f);
 
         // Ensure doesn't go off top edge
         if (tooltipY < windowPos.Y)
-            tooltipY = windowPos.Y + 4f;
+            tooltipY = windowPos.Y + UiScale.Scaled(4f);
 
         // Draw tooltip background
         var bgStart = new Vector2(tooltipX, tooltipY);
         var bgEnd = new Vector2(tooltipX + tooltipWidth, tooltipY + tooltipHeight);
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
-        drawList.AddRectFilled(bgStart, bgEnd, bgColor, 4f);
+        drawList.AddRectFilled(bgStart, bgEnd, bgColor, UiScale.Scaled(4f));
 
         // Draw border
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f);
-        drawList.AddRect(bgStart, bgEnd, borderColor, 4f, ImDrawFlags.None, 2f);
+        drawList.AddRect(bgStart, bgEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
         // Draw content
         var currentY = tooltipY + tooltipPadding;

--- a/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/ChapterStripRenderer.cs
@@ -28,15 +28,15 @@ internal static class ChapterStripRenderer
     ///     pane width so chrome lines up regardless of whether the page is
     ///     actually scrolling right now.
     /// </summary>
-    public const float ScrollbarGutter = 20f;
+    public static float ScrollbarGutter => UiScale.Scaled(20f);
 
     /// <summary>Top padding above the title strip — first line of vellum.</summary>
-    public const float TopPadding = 8f;
+    public static float TopPadding => UiScale.Scaled(8f);
 
-    private const float GlyphGap = 8f;
-    private const float PencilGap = 8f;
-    private const float PencilWidth = 22f;
-    private const float PencilHeight = 22f;
+    private static float GlyphGap => UiScale.Scaled(8f);
+    private static float PencilGap => UiScale.Scaled(8f);
+    private static float PencilWidth => UiScale.Scaled(22f);
+    private static float PencilHeight => UiScale.Scaled(22f);
 
     public readonly record struct Result(float ContentWidth, float BodyY, bool PencilClicked);
 
@@ -96,7 +96,7 @@ internal static class ChapterStripRenderer
             var anchorX = x + contentWidth - pencilReservation - glyphReservation;
             if (glyphReservation > 0f) anchorX -= GlyphGap;
             var rightX = anchorX - rightTextWidth;
-            TextRenderer.DrawSerifLabel(drawList, rightTitle, rightX, stripY + 4f,
+            TextRenderer.DrawSerifLabel(drawList, rightTitle, rightX, stripY + UiScale.Scaled(4f),
                 FontSizes.PageTitle, ColorPalette.Gold);
         }
 
@@ -109,14 +109,14 @@ internal static class ChapterStripRenderer
             DomainGlyphRenderer.Draw(drawList, rightGlyph.Value, glyphMin, glyphMax);
             drawList.AddRect(glyphMin, glyphMax,
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f),
-                4f, ImDrawFlags.None, 1f);
+                UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(1f));
         }
 
         var pencilClicked = false;
         if (showPencil)
         {
             var px = x + contentWidth - PencilWidth;
-            var py = stripY + 6f;
+            var py = stripY + UiScale.Scaled(6f);
             if (ButtonRenderer.DrawButton(drawList, string.Empty,
                     px, py, PencilWidth, PencilHeight,
                     isPrimary: false, enabled: true))
@@ -126,7 +126,7 @@ internal static class ChapterStripRenderer
             ChromeRenderer.DrawPencil(drawList,
                 px + PencilWidth / 2f,
                 py + PencilHeight / 2f,
-                PencilHeight - 8f,
+                PencilHeight - UiScale.Scaled(8f),
                 ColorPalette.LightText);
         }
 

--- a/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/PaneHeaderRenderer.cs
@@ -19,12 +19,12 @@ namespace DivineAscension.GUI.UI.Renderers.Utilities;
 [ExcludeFromCodeCoverage]
 internal static class PaneHeaderRenderer
 {
-    public const float IconSize = 32f;
-    public const float RowHeight = 36f; // Math.Max(IconSize + 4f, 32f)
-    public const float DropCapRowHeight = 44f; // Math.Max(ChromeRenderer.DropCapSize + 4f, RowHeight)
-    public const float DividerBelowSpacing = 20f;
-    public const float TotalHeight = RowHeight + DividerBelowSpacing;
-    private const float DropCapGap = 12f;
+    public static float IconSize => UiScale.Scaled(32f);
+    public static float RowHeight => UiScale.Scaled(36f); // Math.Max(IconSize + 4f, 32f)
+    public static float DropCapRowHeight => UiScale.Scaled(44f); // Math.Max(ChromeRenderer.DropCapSize + 4f, RowHeight)
+    public static float DividerBelowSpacing => UiScale.Scaled(20f);
+    public static float TotalHeight => RowHeight + DividerBelowSpacing;
+    private static float DropCapGap => UiScale.Scaled(12f);
 
     public static float Draw(
         ImDrawListPtr drawList,
@@ -39,7 +39,7 @@ internal static class PaneHeaderRenderer
         Vector4? dropCapColor = null)
     {
         var hasIcon = iconTextureId != IntPtr.Zero || iconPainter != null;
-        var titleX = hasIcon ? x + IconSize + 12f : x;
+        var titleX = hasIcon ? x + IconSize + UiScale.Scaled(12f) : x;
 
         // Drop cap takes the lead position on the left when requested. Caller
         // supplies the domain/deity color; we strip the first character from
@@ -70,7 +70,7 @@ internal static class PaneHeaderRenderer
                 drawList.AddImage(iconTextureId, iconMin, iconMax, Vector2.Zero, Vector2.One, tint);
             }
             var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f);
-            drawList.AddRect(iconMin, iconMax, borderColor, 4f, ImDrawFlags.None, 1f);
+            drawList.AddRect(iconMin, iconMax, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(1f));
         }
 
         // Chapter title uses Cinzel Regular at the nearest baked size; rank
@@ -79,7 +79,7 @@ internal static class PaneHeaderRenderer
         // the title's right edge regardless of Cinzel vs default metrics.
         // When a drop cap leads the row, the title baseline shifts down so
         // small caps sit on the cap's optical midline.
-        var titleBaselineY = dropCapPresent ? y + 12f : y + 4f;
+        var titleBaselineY = dropCapPresent ? y + UiScale.Scaled(12f) : y + UiScale.Scaled(4f);
         var titleWidth = TextRenderer.DrawSerifLabel(drawList, displayTitle, titleX, titleBaselineY,
             FontSizes.PageTitle, titleColor ?? ColorPalette.White);
 
@@ -87,7 +87,7 @@ internal static class PaneHeaderRenderer
         {
             var rankText = $"[{rankTag}]";
             drawList.AddText(ImGui.GetFont(), FontSizes.SubsectionLabel,
-                new Vector2(titleX + titleWidth + 8f, y + 6f),
+                new Vector2(titleX + titleWidth + UiScale.Scaled(8f), y + UiScale.Scaled(6f)),
                 ImGui.ColorConvertFloat4ToU32(rankColor ?? ColorPalette.Gold), rankText);
         }
 
@@ -96,7 +96,7 @@ internal static class PaneHeaderRenderer
             // Right-aligned entity name at the same baseline as the title.
             var rightWidth = TextRenderer.MeasureSerifLabel(rightTitle, FontSizes.PageTitle);
             var rightX = x + width - rightWidth;
-            TextRenderer.DrawSerifLabel(drawList, rightTitle, rightX, y + 4f,
+            TextRenderer.DrawSerifLabel(drawList, rightTitle, rightX, y + UiScale.Scaled(4f),
                 FontSizes.PageTitle, ColorPalette.Gold);
         }
 


### PR DESCRIPTION
Part of epic #584 — per-area layout grind. Scales the shared widgets used across every area so they lay out proportionally at GUIScale > 1.

## Scope (16 files changed, `Scaled()` convention)
Civilization/Religion list tables, letters, member/ban lists, progress bar, checkbox, icon picker, icon-button group, pane-header + chapter-strip (their public heights become scaled properties so callers reserve scaled space), error banner, **ConfirmOverlay modal**, rank-up toast, scrollable list + scrollbar. `TextInput` needed no changes (native widget sized by font + ImGui style padding, which #606 scales).

## Notes
- **Custom-widget defaults** that can't call `Scaled()` (Checkbox `size`/`padding`, ScrollableList `scrollbarWidth`) use a `-1f` sentinel resolved to a scaled value in the body.
- **Hit-rects:** list/table/icon-grid cells use the same scaled sizes as the drawn rows → clicks stay aligned.
- **Fractions left untouched:** progress-bar fill (`width * pct`), scrollbar thumb position/size ratios.
- Left unscaled (verified): `/2f` divisors, `*N` over scaled bases, colour alphas, loop/segment counts, epsilons, `CalcTextSize`/`MeasureWrappedHeight`, font sizes, region params. **No change at Factor 1.0.**

## Tests
17 files via parallel agents; built + diff-sanity-checked + full suite: **2515 passed**, build clean.

Closes #600