### PR TITLE
feat(ui): scale PlayerInfo, HolySites, Caravan + chrome glyphs (#598)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Caravan/CaravanTradeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Caravan/CaravanTradeRenderer.cs
@@ -22,10 +22,10 @@ namespace DivineAscension.GUI.UI.Renderers.Caravan;
 [ExcludeFromCodeCoverage]
 internal static class CaravanTradeRenderer
 {
-    private const float Padding = 18f;
-    private const float ColumnGap = 28f;
-    private const float RowHeight = 26f;
-    private const float SectionGap = 14f;
+    private static float Padding => UiScale.Scaled(18f);
+    private static float ColumnGap => UiScale.Scaled(28f);
+    private static float RowHeight => UiScale.Scaled(26f);
+    private static float SectionGap => UiScale.Scaled(14f);
 
     /// <summary>A pack item the local player can lay on the table.</summary>
     public readonly record struct PackEntry(string Code, string Name, int Quantity);
@@ -65,7 +65,7 @@ internal static class CaravanTradeRenderer
         TextRenderer.DrawInfoText(drawList,
             LocalizationService.Instance.Get("caravantrade.intro"),
             x, y, contentWidth, FontSizes.Body, ColorPalette.Grey);
-        y += RowHeight + 4f;
+        y += RowHeight + UiScale.Scaled(4f);
 
         // Two columns: self on the left.
         var colWidth = (contentWidth - ColumnGap) / 2f;
@@ -105,11 +105,11 @@ internal static class CaravanTradeRenderer
         {
             var entry = pack[i];
             var label = $"{entry.Name} ×{entry.Quantity}";
-            var btnWidth = ImGui.CalcTextSize(label).X + 24f;
+            var btnWidth = ImGui.CalcTextSize(label).X + UiScale.Scaled(24f);
             if (packX + btnWidth > x + contentWidth)
             {
                 packX = x;
-                packTop += RowHeight + 4f;
+                packTop += RowHeight + UiScale.Scaled(4f);
             }
 
             if (ButtonRenderer.DrawButton(drawList, label, packX, packTop, btnWidth, RowHeight,
@@ -118,7 +118,7 @@ internal static class CaravanTradeRenderer
                 addPackIndex = i;
             }
 
-            packX += btnWidth + 6f;
+            packX += btnWidth + UiScale.Scaled(6f);
         }
 
         y = packTop + RowHeight + SectionGap;
@@ -129,10 +129,10 @@ internal static class CaravanTradeRenderer
         TextRenderer.DrawInfoText(drawList,
             LocalizationService.Instance.Get("caravantrade.switcheroo_note"),
             x, y, contentWidth, FontSizes.Secondary, ColorPalette.MutedText);
-        y += RowHeight + 4f;
+        y += RowHeight + UiScale.Scaled(4f);
 
-        const float buttonWidth = 200f;
-        const float buttonHeight = 34f;
+        var buttonWidth = UiScale.Scaled(200f);
+        var buttonHeight = UiScale.Scaled(34f);
         var sealLabel = LocalizationService.Instance.Get(
             state.MyReady(myUid) ? "caravantrade.unseal" : "caravantrade.seal");
         var sealEnabled = state.HasPartner(myUid);
@@ -140,8 +140,8 @@ internal static class CaravanTradeRenderer
 
         var actionsY = windowY + windowHeight - buttonHeight - Padding;
         if (actionsY < y) actionsY = y;
-        var sealX = x + (contentWidth / 2f) - buttonWidth - 10f;
-        var leaveX = x + (contentWidth / 2f) + 10f;
+        var sealX = x + (contentWidth / 2f) - buttonWidth - UiScale.Scaled(10f);
+        var leaveX = x + (contentWidth / 2f) + UiScale.Scaled(10f);
 
         if (ButtonRenderer.DrawButton(drawList, sealLabel, sealX, actionsY, buttonWidth, buttonHeight,
                 isPrimary: true, enabled: sealEnabled))
@@ -171,7 +171,7 @@ internal static class CaravanTradeRenderer
         {
             var slot = offer[i];
             var label = $"{slot.DisplayName} ×{slot.Quantity}";
-            if (ButtonRenderer.DrawButton(drawList, label, x, rowY, width, RowHeight - 4f,
+            if (ButtonRenderer.DrawButton(drawList, label, x, rowY, width, RowHeight - UiScale.Scaled(4f),
                     isPrimary: false, enabled: true))
             {
                 removeIndex = i;
@@ -235,13 +235,13 @@ internal static class CaravanTradeRenderer
         TextRenderer.DrawLabel(drawList, right, rightX, y, FontSizes.Body, ColorPalette.White);
 
         var leftWidth = ImGui.CalcTextSize(left).X;
-        var dotsStart = x + leftWidth + 6f;
-        var dotsEnd = rightX - 6f;
+        var dotsStart = x + leftWidth + UiScale.Scaled(6f);
+        var dotsEnd = rightX - UiScale.Scaled(6f);
         if (dotsEnd <= dotsStart) return;
 
         var color = ImGui.ColorConvertFloat4ToU32(ColorPalette.BorderColor);
         var dotY = y + FontSizes.Body * 0.6f;
-        for (var dx = dotsStart; dx < dotsEnd; dx += 6f)
-            drawList.AddCircleFilled(new Vector2(dx, dotY), 1f, color);
+        for (var dx = dotsStart; dx < dotsEnd; dx += UiScale.Scaled(6f))
+            drawList.AddCircleFilled(new Vector2(dx, dotY), UiScale.Scaled(1f), color);
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/HolySites/HolySiteDetailRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/HolySites/HolySiteDetailRenderer.cs
@@ -24,16 +24,16 @@ namespace DivineAscension.GUI.UI.Renderers.HolySites;
 internal static class HolySiteDetailRenderer
 {
     // Layout constants
-    private const float BackButtonWidth = 160f;
-    private const float BackButtonHeight = 32f;
-    private const float MarkButtonWidth = 130f;
-    private const float MarkButtonHeight = 36f;
-    private const float IconSize = 85f;
-    private const float SectionSpacing = 20f;
-    private const float FieldHeight = 32f;
-    private const float LabelWidth = 150f;
-    private const float EditButtonWidth = 40f;
-    private const float EditButtonHeight = 18f;
+    private static float BackButtonWidth => UiScale.Scaled(160f);
+    private static float BackButtonHeight => UiScale.Scaled(32f);
+    private static float MarkButtonWidth => UiScale.Scaled(130f);
+    private static float MarkButtonHeight => UiScale.Scaled(36f);
+    private static float IconSize => UiScale.Scaled(85f);
+    private static float SectionSpacing => UiScale.Scaled(20f);
+    private static float FieldHeight => UiScale.Scaled(32f);
+    private static float LabelWidth => UiScale.Scaled(150f);
+    private static float EditButtonWidth => UiScale.Scaled(40f);
+    private static float EditButtonHeight => UiScale.Scaled(18f);
     private const float DescriptionMaxChars = 200f;
 
     /// <summary>
@@ -51,7 +51,7 @@ internal static class HolySiteDetailRenderer
         {
             TextRenderer.DrawInfoText(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_DETAIL_LOADING),
-                vm.X, currentY + 8f, vm.Width);
+                vm.X, currentY + UiScale.Scaled(8f), vm.Width);
             return new HolySiteDetailRendererResult(events, vm.Height);
         }
 
@@ -72,7 +72,7 @@ internal static class HolySiteDetailRenderer
         }
 
         // Mark button (top right)
-        var markButtonX = vm.X + vm.Width - MarkButtonWidth - 16f;
+        var markButtonX = vm.X + vm.Width - MarkButtonWidth - UiScale.Scaled(16f);
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_DETAIL_MARK),
                 markButtonX, currentY, MarkButtonWidth, MarkButtonHeight,
@@ -85,45 +85,45 @@ internal static class HolySiteDetailRenderer
 
         // Draw background panel
         var backgroundY = currentY;
-        var backgroundHeight = vm.Height - (currentY - vm.Y) - 8f;
+        var backgroundHeight = vm.Height - (currentY - vm.Y) - UiScale.Scaled(8f);
         drawList.AddRectFilled(
             new Vector2(vm.X, backgroundY),
             new Vector2(vm.X + vm.Width, backgroundY + backgroundHeight),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.TableBackground),
-            4f);
+            UiScale.Scaled(4f));
 
         // Clip content to container boundaries
         drawList.PushClipRect(new Vector2(vm.X, backgroundY),
             new Vector2(vm.X + vm.Width, backgroundY + backgroundHeight), true);
 
-        currentY += 16f;
+        currentY += UiScale.Scaled(16f);
 
         // Two-column layout
-        var leftColumnX = vm.X + 97f;
-        var leftColumnWidth = (vm.Width / 2) - 110f; // Half width minus icon space
-        var rightColumnX = vm.X + (vm.Width / 2) + 20f; // Start right column with padding
-        var dividerX = vm.X + (vm.Width / 2) + 5f; // Vertical divider line
+        var leftColumnX = vm.X + UiScale.Scaled(97f);
+        var leftColumnWidth = (vm.Width / 2) - UiScale.Scaled(110f); // Half width minus icon space
+        var rightColumnX = vm.X + (vm.Width / 2) + UiScale.Scaled(20f); // Start right column with padding
+        var dividerX = vm.X + (vm.Width / 2) + UiScale.Scaled(5f); // Vertical divider line
 
         var leftColumnY = currentY;
         var rightColumnY = currentY;
 
         // Draw vertical divider line between columns
         drawList.AddLine(
-            new Vector2(dividerX, currentY - 10f),
-            new Vector2(dividerX, backgroundY + backgroundHeight - 10f),
+            new Vector2(dividerX, currentY - UiScale.Scaled(10f)),
+            new Vector2(dividerX, backgroundY + backgroundHeight - UiScale.Scaled(10f)),
             ImGui.ColorConvertFloat4ToU32(new Vector4(0.3f, 0.3f, 0.3f, 0.5f)),
-            1f);
+            UiScale.Scaled(1f));
 
         // LEFT COLUMN: Deity icon + Site Info + Coordinates + Description
         DrawDeityIcon(vm, drawList, leftColumnX, leftColumnY);
 
-        var infoStartX = leftColumnX + 123f; // After icon
+        var infoStartX = leftColumnX + UiScale.Scaled(123f); // After icon
 
         // Calculate max width for name field
         // Total available: dividerX - infoStartX - 20f (padding)
         // Need to fit: Label (150f) + Input + Spacing (8f) + Save (60f) + Spacing (8f) + Cancel (60f)
         var nameFieldMaxWidth =
-            dividerX - infoStartX - 150f - 8f - 60f - 8f - 60f - 20f; // LabelWidth + buttons + padding
+            dividerX - infoStartX - UiScale.Scaled(150f) - UiScale.Scaled(8f) - UiScale.Scaled(60f) - UiScale.Scaled(8f) - UiScale.Scaled(60f) - UiScale.Scaled(20f); // LabelWidth + buttons + padding
         DrawHolySiteInfo(vm, drawList, infoStartX, ref leftColumnY, nameFieldMaxWidth, events);
 
         leftColumnY += SectionSpacing;
@@ -132,7 +132,7 @@ internal static class HolySiteDetailRenderer
         leftColumnY += SectionSpacing;
 
         // Calculate max width for description (respect divider boundary)
-        var descriptionMaxWidth = dividerX - infoStartX - 20f; // 20f padding from divider
+        var descriptionMaxWidth = dividerX - infoStartX - UiScale.Scaled(20f); // 20f padding from divider
         DrawDescriptionSection(vm, drawList, infoStartX, ref leftColumnY, descriptionMaxWidth, events);
 
         // RIGHT COLUMN: Ritual section
@@ -161,9 +161,9 @@ internal static class HolySiteDetailRenderer
 
                 // Draw border
                 drawList.AddRect(
-                    new Vector2(x - 1f, y - 1f),
-                    new Vector2(x + IconSize + 1f, y + IconSize + 1f),
-                    borderColor, 4f, ImDrawFlags.None, 2f);
+                    new Vector2(x - UiScale.Scaled(1f), y - UiScale.Scaled(1f)),
+                    new Vector2(x + IconSize + UiScale.Scaled(1f), y + IconSize + UiScale.Scaled(1f)),
+                    borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
 
                 // Draw icon
                 drawList.AddImage(deityTextureId,
@@ -199,7 +199,7 @@ internal static class HolySiteDetailRenderer
             DrawNameDisplay(vm, drawList, x, y, labelColor, valueColor, events);
         }
 
-        y += FieldHeight + 8f;
+        y += FieldHeight + UiScale.Scaled(8f);
 
         // Tier
         DrawLabelValuePair(drawList, "Tier:", vm.SiteDetails.Tier.ToString(), x, y, labelColor, valueColor);
@@ -257,40 +257,40 @@ internal static class HolySiteDetailRenderer
         // Section header
         drawList.AddText(ImGui.GetFont(), TableHeader, new Vector2(x, y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), "Active Ritual");
-        y += 24f;
+        y += UiScale.Scaled(24f);
 
         // Ritual name
         drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x, y), labelColor, ritual.RitualName);
-        y += 20f;
+        y += UiScale.Scaled(20f);
 
         // Description
         if (!string.IsNullOrEmpty(ritual.Description))
         {
             drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(x, y),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey), ritual.Description);
-            y += 18f;
+            y += UiScale.Scaled(18f);
         }
 
-        y += 12f;
+        y += UiScale.Scaled(12f);
 
         // Draw all step checkboxes (3-5 steps depending on ritual)
         foreach (var step in ritual.Steps)
         {
             DrawStepCheckbox(drawList, x, ref y, step, labelColor);
-            y += 8f;
+            y += UiScale.Scaled(8f);
         }
 
         // Cancel button (for consecrator only)
         if (vm.IsConsecrator)
         {
-            y += 8f;
+            y += UiScale.Scaled(8f);
             if (ButtonRenderer.DrawButton(drawList, "Cancel Ritual",
-                    x, y, 120f, 28f, isPrimary: false))
+                    x, y, UiScale.Scaled(120f), UiScale.Scaled(28f), isPrimary: false))
             {
                 events.Add(new DetailEvent.CancelRitualClicked());
             }
 
-            y += 36f;
+            y += UiScale.Scaled(36f);
         }
     }
 
@@ -312,7 +312,7 @@ internal static class HolySiteDetailRenderer
         }
 
         // Discovered step rendering with checkbox
-        var checkboxSize = 18f;
+        var checkboxSize = UiScale.Scaled(18f);
 
         // Checkbox background (green if complete, dark gray if not)
         var bgColor = step.IsComplete
@@ -322,36 +322,36 @@ internal static class HolySiteDetailRenderer
         drawList.AddRectFilled(
             new Vector2(x, y),
             new Vector2(x + checkboxSize, y + checkboxSize),
-            bgColor, 3f);
+            bgColor, UiScale.Scaled(3f));
 
         // Checkbox border
         drawList.AddRect(
             new Vector2(x, y),
             new Vector2(x + checkboxSize, y + checkboxSize),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.MutedText),
-            3f, ImDrawFlags.None, 1.5f);
+            UiScale.Scaled(3f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
         // Checkmark (if complete)
         if (step.IsComplete)
         {
             var checkColor = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f));
             drawList.AddLine(
-                new Vector2(x + 3f, y + checkboxSize / 2),
-                new Vector2(x + checkboxSize / 2, y + checkboxSize - 3f),
-                checkColor, 2f);
+                new Vector2(x + UiScale.Scaled(3f), y + checkboxSize / 2),
+                new Vector2(x + checkboxSize / 2, y + checkboxSize - UiScale.Scaled(3f)),
+                checkColor, UiScale.Scaled(2f));
             drawList.AddLine(
-                new Vector2(x + checkboxSize / 2, y + checkboxSize - 3f),
-                new Vector2(x + checkboxSize - 3f, y + 3f),
-                checkColor, 2f);
+                new Vector2(x + checkboxSize / 2, y + checkboxSize - UiScale.Scaled(3f)),
+                new Vector2(x + checkboxSize - UiScale.Scaled(3f), y + UiScale.Scaled(3f)),
+                checkColor, UiScale.Scaled(2f));
         }
 
         // Step name
-        var textX = x + checkboxSize + 10f;
+        var textX = x + checkboxSize + UiScale.Scaled(10f);
         var textColor = step.IsComplete
             ? ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold)
             : labelColor;
         drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(textX, y), textColor, step.StepName);
-        y += 20f;
+        y += UiScale.Scaled(20f);
 
         // Contributors (only for discovered steps)
         if (step.TopContributors != null && step.TopContributors.Count > 0)
@@ -361,7 +361,7 @@ internal static class HolySiteDetailRenderer
             drawList.AddText(ImGui.GetFont(), Small, new Vector2(textX, y),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.DisabledGray),
                 contributorsText);
-            y += 16f;
+            y += UiScale.Scaled(16f);
         }
     }
 
@@ -370,37 +370,37 @@ internal static class HolySiteDetailRenderer
     /// </summary>
     private static void DrawUndiscoveredStep(ImDrawListPtr drawList, float x, ref float y)
     {
-        var iconSize = 18f;
+        var iconSize = UiScale.Scaled(18f);
         var mysteryColor = ImGui.ColorConvertFloat4ToU32(new Vector4(0.5f, 0.4f, 0.6f, 0.9f)); // Purple tint
 
         // Question mark icon background
         drawList.AddRectFilled(
             new Vector2(x, y),
             new Vector2(x + iconSize, y + iconSize),
-            mysteryColor, 3f);
+            mysteryColor, UiScale.Scaled(3f));
 
         // Question mark icon border
         drawList.AddRect(
             new Vector2(x, y),
             new Vector2(x + iconSize, y + iconSize),
             ImGui.ColorConvertFloat4ToU32(new Vector4(0.6f, 0.5f, 0.7f, 1f)),
-            3f, ImDrawFlags.None, 1.5f);
+            UiScale.Scaled(3f), ImDrawFlags.None, UiScale.Scaled(1.5f));
 
         // Question mark symbol
         var questionMarkColor = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f));
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x + 4f, y + 1f), questionMarkColor, "?");
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x + UiScale.Scaled(4f), y + UiScale.Scaled(1f)), questionMarkColor, "?");
 
         // "Undiscovered Step" text
-        var textX = x + iconSize + 10f;
+        var textX = x + iconSize + UiScale.Scaled(10f);
         var textColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DisabledGray);
         drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(textX, y), textColor, "??? Undiscovered Step");
-        y += 20f;
+        y += UiScale.Scaled(20f);
 
         // Hint text
         var hintText = "  Offer sacred items to discover this step";
         var hintColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.MutedText);
         drawList.AddText(ImGui.GetFont(), Small, new Vector2(textX, y), hintColor, hintText);
-        y += 16f;
+        y += UiScale.Scaled(16f);
     }
 
     /// <summary>
@@ -418,7 +418,7 @@ internal static class HolySiteDetailRenderer
         // Section header
         drawList.AddText(ImGui.GetFont(), TableHeader, new Vector2(x, y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), "Ritual Progress");
-        y += 24f;
+        y += UiScale.Scaled(24f);
 
         // Calculate completed rituals (tier - 1, since tier 1 is base)
         var completedRituals = currentTier - 1;
@@ -431,7 +431,7 @@ internal static class HolySiteDetailRenderer
         var completionText = $"{completedRituals} Rituals Completed / {undiscoveredRituals} Undiscovered";
         drawList.AddText(ImGui.GetFont(), Body, new Vector2(x, y),
             labelColor, completionText);
-        y += 20f;
+        y += UiScale.Scaled(20f);
 
         // Show discovery hint if not max tier
         if (currentTier < 3)
@@ -439,7 +439,7 @@ internal static class HolySiteDetailRenderer
             drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(x, y),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey),
                 "Offer sacred items at the altar to discover new rituals.");
-            y += 18f;
+            y += UiScale.Scaled(18f);
         }
         else
         {
@@ -447,7 +447,7 @@ internal static class HolySiteDetailRenderer
             drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(x, y),
                 ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold),
                 "All rituals completed! This is a Cathedral.");
-            y += 18f;
+            y += UiScale.Scaled(18f);
         }
     }
 
@@ -464,20 +464,20 @@ internal static class HolySiteDetailRenderer
         List<DetailEvent> events)
     {
         // Label
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x, y + 8f), labelColor,
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x, y + UiScale.Scaled(8f)), labelColor,
             LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_DETAIL_NAME));
 
         // Value
         var valueX = x + LabelWidth;
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(valueX, y + 8f),
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(valueX, y + UiScale.Scaled(8f)),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold), vm.SiteDetails.SiteName);
 
         // Edit button (for consecrator)
         if (vm.IsConsecrator)
         {
-            var editButtonX = valueX + ImGui.CalcTextSize(vm.SiteDetails.SiteName).X + 12f;
+            var editButtonX = valueX + ImGui.CalcTextSize(vm.SiteDetails.SiteName).X + UiScale.Scaled(12f);
             if (ButtonRenderer.DrawButton(drawList, LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_EDIT),
-                    editButtonX, y + 7f, EditButtonWidth, EditButtonHeight,
+                    editButtonX, y + UiScale.Scaled(7f), EditButtonWidth, EditButtonHeight,
                     isPrimary: false))
             {
                 events.Add(new DetailEvent.RenameClicked());
@@ -497,7 +497,7 @@ internal static class HolySiteDetailRenderer
         List<DetailEvent> events)
     {
         // Label
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x, y + 8f),
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x, y + UiScale.Scaled(8f)),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown),
             LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_DETAIL_NAME));
 
@@ -515,19 +515,19 @@ internal static class HolySiteDetailRenderer
         }
 
         // Save button
-        var saveButtonX = inputX + maxWidth + 8f;
+        var saveButtonX = inputX + maxWidth + UiScale.Scaled(8f);
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_SAVE),
-                saveButtonX, y, 60f, FieldHeight, isPrimary: true))
+                saveButtonX, y, UiScale.Scaled(60f), FieldHeight, isPrimary: true))
         {
             events.Add(new DetailEvent.RenameSave(newValue));
         }
 
         // Cancel button
-        var cancelButtonX = saveButtonX + 68f;
+        var cancelButtonX = saveButtonX + UiScale.Scaled(68f);
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_CANCEL),
-                cancelButtonX, y, 60f, FieldHeight))
+                cancelButtonX, y, UiScale.Scaled(60f), FieldHeight))
         {
             events.Add(new DetailEvent.RenameCancel());
         }
@@ -572,16 +572,16 @@ internal static class HolySiteDetailRenderer
         if (vm.IsConsecrator && !vm.IsEditingDescription)
         {
             var editButtonX = x + ImGui.CalcTextSize(
-                LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_DETAIL_DESCRIPTION)).X + 12f;
+                LocalizationService.Instance.Get(LocalizationKeys.UI_HOLYSITES_DETAIL_DESCRIPTION)).X + UiScale.Scaled(12f);
             if (ButtonRenderer.DrawButton(drawList, LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_EDIT),
-                    editButtonX, y - 1f, EditButtonWidth, EditButtonHeight,
+                    editButtonX, y - UiScale.Scaled(1f), EditButtonWidth, EditButtonHeight,
                     isPrimary: false))
             {
                 events.Add(new DetailEvent.EditDescriptionClicked());
             }
         }
 
-        y += 32f;
+        y += UiScale.Scaled(32f);
 
         if (vm.IsEditingDescription)
         {
@@ -613,7 +613,7 @@ internal static class HolySiteDetailRenderer
         ImGui.PopTextWrapPos();
 
         var textSize = ImGui.CalcTextSize(descriptionText, maxWidth);
-        y += textSize.Y + 8f;
+        y += textSize.Y + UiScale.Scaled(8f);
     }
 
     /// <summary>
@@ -627,7 +627,7 @@ internal static class HolySiteDetailRenderer
         float maxWidth,
         List<DetailEvent> events)
     {
-        var inputHeight = 100f;
+        var inputHeight = UiScale.Scaled(100f);
 
         var editValue = vm.EditingDescriptionValue ?? vm.SiteDetails.Description;
         var newValue = TextInput.DrawMultiline(drawList, "##holysite_description_edit", editValue, x, y, maxWidth,
@@ -639,7 +639,7 @@ internal static class HolySiteDetailRenderer
             events.Add(new DetailEvent.DescriptionValueChanged(newValue));
         }
 
-        y += inputHeight + 8f;
+        y += inputHeight + UiScale.Scaled(8f);
 
         // Character count
         var charCount = newValue?.Length ?? 0;
@@ -647,29 +647,29 @@ internal static class HolySiteDetailRenderer
         var charCountColor = charCount > DescriptionMaxChars
             ? ImGui.ColorConvertFloat4ToU32(ColorPalette.Red)
             : ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
-        drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(x + maxWidth - 60f, y), charCountColor, charCountText);
+        drawList.AddText(ImGui.GetFont(), Secondary, new Vector2(x + maxWidth - UiScale.Scaled(60f), y), charCountColor, charCountText);
 
-        y += 24f;
+        y += UiScale.Scaled(24f);
 
         // Save button
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_SAVE),
-                x, y, 80f, FieldHeight, isPrimary: true,
+                x, y, UiScale.Scaled(80f), FieldHeight, isPrimary: true,
                 enabled: charCount <= DescriptionMaxChars))
         {
             events.Add(new DetailEvent.DescriptionSave(newValue ?? ""));
         }
 
         // Cancel button
-        var cancelButtonX = x + 88f;
+        var cancelButtonX = x + UiScale.Scaled(88f);
         if (ButtonRenderer.DrawButton(drawList,
                 LocalizationService.Instance.Get(LocalizationKeys.UI_COMMON_CANCEL),
-                cancelButtonX, y, 80f, FieldHeight))
+                cancelButtonX, y, UiScale.Scaled(80f), FieldHeight))
         {
             events.Add(new DetailEvent.DescriptionCancel());
         }
 
-        y += FieldHeight + 8f;
+        y += FieldHeight + UiScale.Scaled(8f);
     }
 
     /// <summary>
@@ -685,11 +685,11 @@ internal static class HolySiteDetailRenderer
         uint valueColor)
     {
         // Label
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x, y + 8f), labelColor, label);
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(x, y + UiScale.Scaled(8f)), labelColor, label);
 
         // Value
         var valueX = x + LabelWidth;
-        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(valueX, y + 8f), valueColor, value);
+        drawList.AddText(ImGui.GetFont(), SubsectionLabel, new Vector2(valueX, y + UiScale.Scaled(8f)), valueColor, value);
     }
 
     /// <summary>

--- a/DivineAscension/GUI/UI/Renderers/PlayerInfo/NotificationFeedRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/PlayerInfo/NotificationFeedRenderer.cs
@@ -23,8 +23,8 @@ namespace DivineAscension.GUI.UI.Renderers.PlayerInfo;
 [ExcludeFromCodeCoverage]
 internal static class NotificationFeedRenderer
 {
-    private const float HeaderHeight = 27f;
-    private const float InnerPadding = 12f;
+    private static float HeaderHeight => UiScale.Scaled(27f);
+    private static float InnerPadding => UiScale.Scaled(12f);
 
     public static void Draw(
         float x, float y, float width, float height,
@@ -39,9 +39,9 @@ internal static class NotificationFeedRenderer
         drawList.AddRectFilled(
             new Vector2(x, y),
             new Vector2(x + width, y + height),
-            bg, 4f);
+            bg, UiScale.Scaled(4f));
 
-        DrawHeader(x + InnerPadding, y + 4f, width - InnerPadding * 2f, showUnreadOnly, events);
+        DrawHeader(x + InnerPadding, y + UiScale.Scaled(4f), width - InnerPadding * 2f, showUnreadOnly, events);
 
         var listTop = y + HeaderHeight;
         var listHeight = y + height - listTop - InnerPadding;
@@ -124,17 +124,17 @@ internal static class NotificationFeedRenderer
     private static void DrawNotificationRow(int index, NotificationHistoryEntry entry,
         float width, List<PlayerInfoEvent> events)
     {
-        const float iconSize = 20f;
-        const float iconRightGap = 8f;
-        const float verticalPadding = 4f;
-        const float rowSpacing = 4f;
+        var iconSize = UiScale.Scaled(20f);
+        var iconRightGap = UiScale.Scaled(8f);
+        var verticalPadding = UiScale.Scaled(4f);
+        var rowSpacing = UiScale.Scaled(4f);
 
         var fontHeight = ImGui.GetFontSize();
-        var textColumnWidth = MathF.Max(0f, width - iconSize - iconRightGap - 4f);
+        var textColumnWidth = MathF.Max(0f, width - iconSize - iconRightGap - UiScale.Scaled(4f));
 
         var titleLine = $"{entry.Timestamp:HH:mm}  {entry.Title}";
         var hasBody = !string.IsNullOrEmpty(entry.Body);
-        var rowHeight = verticalPadding * 2f + fontHeight + (hasBody ? fontHeight + 2f : 0f);
+        var rowHeight = verticalPadding * 2f + fontHeight + (hasBody ? fontHeight + UiScale.Scaled(2f) : 0f);
         rowHeight = MathF.Max(rowHeight, iconSize + verticalPadding * 2f);
 
         var rowStart = ImGui.GetCursorScreenPos();
@@ -158,7 +158,7 @@ internal static class NotificationFeedRenderer
             var fill = hovered
                 ? ColorPalette.WithAlpha(ColorPalette.Gold, 0.18f)
                 : ColorPalette.WithAlpha(ColorPalette.Gold, 0.08f);
-            drawList.AddRectFilled(rowStart, rowEnd, ImGui.ColorConvertFloat4ToU32(fill), 3f);
+            drawList.AddRectFilled(rowStart, rowEnd, ImGui.ColorConvertFloat4ToU32(fill), UiScale.Scaled(3f));
         }
 
         var iconY = rowStart.Y + verticalPadding;
@@ -184,10 +184,10 @@ internal static class NotificationFeedRenderer
 
         if (hasBody)
         {
-            var bodyY = rowStart.Y + verticalPadding + fontHeight + 2f;
+            var bodyY = rowStart.Y + verticalPadding + fontHeight + UiScale.Scaled(2f);
             var bodyColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Grey);
             drawList.PushClipRect(new Vector2(textX, bodyY),
-                new Vector2(textX + textColumnWidth, bodyY + fontHeight + 2f), true);
+                new Vector2(textX + textColumnWidth, bodyY + fontHeight + UiScale.Scaled(2f)), true);
             drawList.AddText(new Vector2(textX, bodyY), bodyColor, entry.Body);
             drawList.PopClipRect();
         }

--- a/DivineAscension/GUI/UI/Renderers/PlayerInfo/PlayerInfoRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/PlayerInfo/PlayerInfoRenderer.cs
@@ -34,25 +34,25 @@ namespace DivineAscension.GUI.UI.Renderers.PlayerInfo;
 [ExcludeFromCodeCoverage]
 internal static class PlayerInfoRenderer
 {
-    private const float DividerHeight = 18f;
-    private const float DividerYPadding = 6f;
-    private const float SectionLabelHeight = 22f;
-    private const float ProseLineHeight = 18f;
-    private const float ProseBottomSpacing = 12f;
-    private const float StatRowHeight = 22f;
-    private const float StatBlockBottomSpacing = 6f;
-    private const float ProgressRowHeight = 22f;
-    private const float ProgressBarHeight = 12f;
-    private const float ScrollbarWidth = 16f;
+    private static float DividerHeight => UiScale.Scaled(18f);
+    private static float DividerYPadding => UiScale.Scaled(6f);
+    private static float SectionLabelHeight => UiScale.Scaled(22f);
+    private static float ProseLineHeight => UiScale.Scaled(18f);
+    private static float ProseBottomSpacing => UiScale.Scaled(12f);
+    private static float StatRowHeight => UiScale.Scaled(22f);
+    private static float StatBlockBottomSpacing => UiScale.Scaled(6f);
+    private static float ProgressRowHeight => UiScale.Scaled(22f);
+    private static float ProgressBarHeight => UiScale.Scaled(12f);
+    private static float ScrollbarWidth => UiScale.Scaled(16f);
 
     // Recent Tidings — the player-scoped activity tail (#334).
     private const int TidingsCap = 5;
-    private const float TidingsRowHeight = 22f;
-    private const float TidingsLeftPadding = 16f;
-    private const float TidingsGlyphSize = 14f;
-    private const float TidingsGlyphGap = 8f;
-    private const float TidingsFooterTopSpacing = 6f;
-    private const float TidingsFooterHeight = 20f;
+    private static float TidingsRowHeight => UiScale.Scaled(22f);
+    private static float TidingsLeftPadding => UiScale.Scaled(16f);
+    private static float TidingsGlyphSize => UiScale.Scaled(14f);
+    private static float TidingsGlyphGap => UiScale.Scaled(8f);
+    private static float TidingsFooterTopSpacing => UiScale.Scaled(6f);
+    private static float TidingsFooterHeight => UiScale.Scaled(20f);
 
     public static IReadOnlyList<PlayerInfoEvent> Draw(PlayerInfoViewModel vm)
     {
@@ -78,7 +78,7 @@ internal static class PlayerInfoRenderer
             var wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0)
             {
-                var newScrollY = Math.Clamp(scrollY - wheel * 30f, 0f, maxScroll);
+                var newScrollY = Math.Clamp(scrollY - wheel * UiScale.Scaled(30f), 0f, maxScroll);
                 if (Math.Abs(newScrollY - scrollY) > 0.001f)
                 {
                     scrollY = newScrollY;
@@ -298,11 +298,11 @@ internal static class PlayerInfoRenderer
         drawList.AddText(new Vector2(x, y),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White), rankName);
 
-        const float padding = 8f;
+        var padding = UiScale.Scaled(8f);
         var barLeft = x + rankSize.X + padding;
         var barRight = rightX - padding;
         var availableBarWidth = barRight - barLeft;
-        if (availableBarWidth > 24f)
+        if (availableBarWidth > UiScale.Scaled(24f))
         {
             var barY = y + (rightSize.Y - ProgressBarHeight) / 2f;
             ProgressBarRenderer.DrawProgressBar(drawList, barLeft, barY,
@@ -380,7 +380,7 @@ internal static class PlayerInfoRenderer
         var line = BuildTidingLine(entry);
         drawList.PushClipRect(new Vector2(textX, y),
             new Vector2(x + width, y + TidingsRowHeight), true);
-        drawList.AddText(new Vector2(textX, y + 2f),
+        drawList.AddText(new Vector2(textX, y + UiScale.Scaled(2f)),
             ImGui.ColorConvertFloat4ToU32(ColorPalette.White), line);
         drawList.PopClipRect();
     }

--- a/DivineAscension/GUI/UI/Renderers/Utilities/ChromeRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/ChromeRenderer.cs
@@ -31,9 +31,9 @@ internal static class ChromeRenderer
         ImGui.PushStyleColor(ImGuiCol.PopupBg, ColorPalette.DarkBrown);
         ImGui.PushStyleColor(ImGuiCol.Border, ColorPalette.Gold * 0.6f);
         ImGui.PushStyleColor(ImGuiCol.Text, ColorPalette.LightText);
-        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 2f);
-        ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 4f);
-        ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(10f, 6f));
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, UiScale.Scaled(2f));
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, UiScale.Scaled(4f));
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(UiScale.Scaled(10f), UiScale.Scaled(6f)));
         ImGui.BeginTooltip();
         return new StyledTooltipScope();
     }
@@ -181,12 +181,12 @@ internal static class ChromeRenderer
 
         if (leftLineEnd > x)
         {
-            drawList.AddLine(new Vector2(x, lineY), new Vector2(leftLineEnd, lineY), colorU32, 1f);
+            drawList.AddLine(new Vector2(x, lineY), new Vector2(leftLineEnd, lineY), colorU32, UiScale.Scaled(1f));
         }
         if (rightLineStart < x + width)
         {
             drawList.AddLine(new Vector2(rightLineStart, lineY),
-                new Vector2(x + width, lineY), colorU32, 1f);
+                new Vector2(x + width, lineY), colorU32, UiScale.Scaled(1f));
         }
 
         DrawDiamond(drawList, centerX, lineY, diamondHalfSize, color);
@@ -219,7 +219,7 @@ internal static class ChromeRenderer
         void Segment(float startX, float endX)
         {
             if (endX > startX)
-                drawList.AddLine(new Vector2(startX, lineY), new Vector2(endX, lineY), colorU32, 1f);
+                drawList.AddLine(new Vector2(startX, lineY), new Vector2(endX, lineY), colorU32, UiScale.Scaled(1f));
         }
 
         Segment(x, d0X - diamondHalfSize - sideGap);
@@ -601,7 +601,7 @@ internal static class ChromeRenderer
         drawList.AddText(new Vector2(x, y), labelCol, label);
         drawList.AddText(new Vector2(x + width - valueSize.X, y), valueCol, value);
 
-        const float padding = 6f;
+        var padding = UiScale.Scaled(6f);
         var leadersStart = x + labelSize.X + padding;
         var leadersEnd = x + width - valueSize.X - padding;
         var leadersWidth = leadersEnd - leadersStart;

--- a/DivineAscension/GUI/UI/Renderers/Utilities/DeityTooltipRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/DeityTooltipRenderer.cs
@@ -14,10 +14,10 @@ namespace DivineAscension.GUI.UI.Renderers.Utilities;
 [ExcludeFromCodeCoverage]
 internal static class DeityTooltipRenderer
 {
-    private const float TOOLTIP_MAX_WIDTH = 280f;
-    private const float TOOLTIP_PADDING = 12f;
-    private const float LINE_SPACING = 4f;
-    private const float SECTION_SPACING = 8f;
+    private static float TOOLTIP_MAX_WIDTH => UiScale.Scaled(280f);
+    private static float TOOLTIP_PADDING => UiScale.Scaled(12f);
+    private static float LINE_SPACING => UiScale.Scaled(4f);
+    private static float SECTION_SPACING => UiScale.Scaled(8f);
 
     /// <summary>
     /// Draw a tooltip for a deity when hovering over deity tabs
@@ -105,8 +105,8 @@ internal static class DeityTooltipRenderer
         float tooltipWidth, float tooltipHeight)
     {
         var windowPos = ImGui.GetWindowPos();
-        var offsetX = 16f;
-        var offsetY = 16f;
+        var offsetX = UiScale.Scaled(16f);
+        var offsetY = UiScale.Scaled(16f);
 
         var tooltipX = mouseX + offsetX;
         var tooltipY = mouseY + offsetY;
@@ -121,11 +121,11 @@ internal static class DeityTooltipRenderer
 
         // Ensure doesn't go off left edge
         if (tooltipX < windowPos.X)
-            tooltipX = windowPos.X + 4f;
+            tooltipX = windowPos.X + UiScale.Scaled(4f);
 
         // Ensure doesn't go off top edge
         if (tooltipY < windowPos.Y)
-            tooltipY = windowPos.Y + 4f;
+            tooltipY = windowPos.Y + UiScale.Scaled(4f);
 
         return (tooltipX, tooltipY);
     }
@@ -140,11 +140,11 @@ internal static class DeityTooltipRenderer
 
         // Dark brown background
         var bgColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.DarkBrown);
-        drawList.AddRectFilled(bgStart, bgEnd, bgColor, 4f);
+        drawList.AddRectFilled(bgStart, bgEnd, bgColor, UiScale.Scaled(4f));
 
         // Gold border
         var borderColor = ImGui.ColorConvertFloat4ToU32(ColorPalette.Gold * 0.6f);
-        drawList.AddRect(bgStart, bgEnd, borderColor, 4f, ImDrawFlags.None, 2f);
+        drawList.AddRect(bgStart, bgEnd, borderColor, UiScale.Scaled(4f), ImDrawFlags.None, UiScale.Scaled(2f));
     }
 
     /// <summary>
@@ -209,6 +209,6 @@ internal static class DeityTooltipRenderer
     /// </summary>
     private record TooltipLine(string Text, Vector4 Color, float FontSize, bool IsBold, float SpacingAfter)
     {
-        public float Height => FontSize + 4f; // Font size + small buffer
+        public float Height => FontSize + UiScale.Scaled(4f); // Font size + small buffer
     }
 }

--- a/DivineAscension/GUI/UI/Renderers/Utilities/DomainGlyphRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/DomainGlyphRenderer.cs
@@ -53,7 +53,7 @@ internal static class DomainGlyphRenderer
                 DrawCompassRose(drawList, cx, cy, s, color);
                 return;
             default:
-                drawList.AddCircle(new Vector2(cx, cy), s * 0.3f, color, 16, 1.5f);
+                drawList.AddCircle(new Vector2(cx, cy), s * 0.3f, color, 16, UiScale.Scaled(1.5f));
                 return;
         }
     }
@@ -70,11 +70,11 @@ internal static class DomainGlyphRenderer
 
         var headMin = new Vector2(cx - headW * 0.5f, topY);
         var headMax = new Vector2(cx + headW * 0.5f, topY + headH);
-        drawList.AddRectFilled(headMin, headMax, color, 2f);
+        drawList.AddRectFilled(headMin, headMax, color, UiScale.Scaled(2f));
 
         var handleMin = new Vector2(cx - handleW * 0.5f, headMax.Y);
         var handleMax = new Vector2(cx + handleW * 0.5f, headMax.Y + handleH);
-        drawList.AddRectFilled(handleMin, handleMax, color, 1f);
+        drawList.AddRectFilled(handleMin, handleMax, color, UiScale.Scaled(1f));
     }
 
     private static void DrawLeaf(ImDrawListPtr drawList, float cx, float cy, float s, uint color)
@@ -83,8 +83,8 @@ internal static class DomainGlyphRenderer
         // skull plate at the base, each antler a curved beam with two
         // outward-up tines. More legible at 32px than the old leaf, which
         // read as just a diamond when domain-tinted.
-        var beam = MathF.Max(2f, s * 0.07f);
-        var tine = MathF.Max(1.5f, s * 0.055f);
+        var beam = MathF.Max(UiScale.Scaled(2f), s * 0.07f);
+        var tine = MathF.Max(UiScale.Scaled(1.5f), s * 0.055f);
         var baseY = cy + s * 0.30f;
 
         // Skull plate.
@@ -124,10 +124,10 @@ internal static class DomainGlyphRenderer
         const float invSqrt2 = 0.70710677f;
         // Tip = arm out along sword axis; HiltEnd = arm out the opposite way.
         var arm = s * 0.42f;
-        var bladeHalf = MathF.Max(1.5f, s * 0.045f);
+        var bladeHalf = MathF.Max(UiScale.Scaled(1.5f), s * 0.045f);
         var guardArm = s * 0.10f;
-        var guardThick = MathF.Max(1.5f, s * 0.035f);
-        var pommelR = MathF.Max(2f, s * 0.06f);
+        var guardThick = MathF.Max(UiScale.Scaled(1.5f), s * 0.035f);
+        var pommelR = MathF.Max(UiScale.Scaled(2f), s * 0.06f);
         // Where the blade ends and the grip begins along the sword axis.
         var bladeBaseFromCenter = -arm * 0.35f;
 
@@ -171,7 +171,7 @@ internal static class DomainGlyphRenderer
     {
         var stemTop = new Vector2(cx, cy - s * 0.40f);
         var stemBot = new Vector2(cx, cy + s * 0.40f);
-        drawList.AddLine(stemTop, stemBot, color, MathF.Max(1.5f, s * 0.04f));
+        drawList.AddLine(stemTop, stemBot, color, MathF.Max(UiScale.Scaled(1.5f), s * 0.04f));
         // Three pairs of angled grain marks centered on cy.
         var spread = s * 0.18f;
         var step = s * 0.18f;
@@ -180,9 +180,9 @@ internal static class DomainGlyphRenderer
         {
             var y = startY + i * step;
             drawList.AddLine(new Vector2(cx, y),
-                new Vector2(cx - spread, y - step * 0.5f), color, MathF.Max(1.2f, s * 0.03f));
+                new Vector2(cx - spread, y - step * 0.5f), color, MathF.Max(UiScale.Scaled(1.2f), s * 0.03f));
             drawList.AddLine(new Vector2(cx, y),
-                new Vector2(cx + spread, y - step * 0.5f), color, MathF.Max(1.2f, s * 0.03f));
+                new Vector2(cx + spread, y - step * 0.5f), color, MathF.Max(UiScale.Scaled(1.2f), s * 0.03f));
         }
     }
 
@@ -192,9 +192,9 @@ internal static class DomainGlyphRenderer
         // compass rose at glyph scale. Each cardinal arm is a tall narrow
         // diamond; diagonals are short kite-pairs. Pommel-style center dot.
         var arm = s * 0.42f;
-        var half = MathF.Max(1.5f, s * 0.075f);
+        var half = MathF.Max(UiScale.Scaled(1.5f), s * 0.075f);
         var diag = s * 0.22f;
-        var diagHalf = MathF.Max(1.5f, s * 0.05f);
+        var diagHalf = MathF.Max(UiScale.Scaled(1.5f), s * 0.05f);
 
         // Cardinal arms: N, E, S, W as diamonds meeting at center.
         drawList.AddTriangleFilled(
@@ -225,7 +225,7 @@ internal static class DomainGlyphRenderer
             drawList.AddTriangleFilled(tip, pLeft, pRight, color);
         }
 
-        drawList.AddCircleFilled(new Vector2(cx, cy), MathF.Max(1.5f, s * 0.06f), color);
+        drawList.AddCircleFilled(new Vector2(cx, cy), MathF.Max(UiScale.Scaled(1.5f), s * 0.06f), color);
     }
 
     private static void DrawMountain(ImDrawListPtr drawList, float cx, float cy, float s, uint color)

--- a/DivineAscension/GUI/UI/Renderers/Utilities/EthosGlyphRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Utilities/EthosGlyphRenderer.cs
@@ -47,7 +47,7 @@ internal static class EthosGlyphRenderer
                 DrawSun(drawList, cx, cy, s, color);
                 return;
             default:
-                drawList.AddCircle(new Vector2(cx, cy), s * 0.3f, color, 16, 1.5f);
+                drawList.AddCircle(new Vector2(cx, cy), s * 0.3f, color, 16, UiScale.Scaled(1.5f));
                 return;
         }
     }
@@ -73,7 +73,7 @@ internal static class EthosGlyphRenderer
         drawList.AddRectFilled(
             new Vector2(cx - halfW, baseY - bandH * 0.5f),
             new Vector2(cx + halfW, baseY + bandH * 0.5f),
-            color, 1f);
+            color, UiScale.Scaled(1f));
     }
 
     private static void DrawScales(ImDrawListPtr drawList, float cx, float cy, float s, uint color)


### PR DESCRIPTION
Part of epic #584 — the final per-area layout wave. Scales the remaining content renderers and the shared glyph/primitive helpers.

## Scope (8 files, `Scaled()` convention)
`PlayerInfoRenderer`, `NotificationFeedRenderer` (incl. InvisibleButton row hit-rect), `HolySiteDetailRenderer`, `CaravanTradeRenderer`, plus the chrome primitives `ChromeRenderer`, `DomainGlyphRenderer`, `EthosGlyphRenderer`, `DeityTooltipRenderer`.

## Glyph/primitive handling (the careful part)
`DomainGlyphRenderer`/`EthosGlyphRenderer`/`ChromeRenderer` draw shapes **inside a caller-supplied, already-scaled rect** using proportional math. Only the genuinely **absolute** pixel literals were scaled — stroke/line thicknesses, corner radii, min-stroke floors (`MathF.Max(Nf, s*ratio)`), and the styled-tooltip border/rounding/padding. **Every ratio of the passed-in size/rect was left untouched** (verified per-file). `DrawDropCap` untouched (its drift fix shipped in #588). The wrap-ratio math (`fontSize / GetFontSize()`) left as-is — self-normalising under FontGlobalScale.

Left unscaled (verified): `/2f` divisors, `*N` over scaled bases, colour alphas, loop/segment counts, angles, epsilons, `CalcTextSize`/`MeasureWrappedHeight`, font sizes, region params. **No change at Factor 1.0.**

## Tests
8 files via parallel agents (glyphs given surgical prompts); built + diff-sanity-checked + full suite: **2515 passed**, build clean.

Closes #598