### PR TITLE
fix(ui): scroll the sidebar chapter nav when it overflows (#614)

### DIFF
--- a/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
+++ b/DivineAscension/GUI/UI/Renderers/Sidebar/SidebarRenderer.cs
@@ -60,8 +60,19 @@ internal static class SidebarRenderer
         ImGui.SetCursorScreenPos(new Vector2(rect.X, rect.Y));
         ImGui.PushStyleColor(ImGuiCol.ChildBg, ColorPalette.TableBackground);
         ImGui.PushStyleColor(ImGuiCol.HeaderHovered, ColorPalette.Gold * 0.18f);
-        ImGui.BeginChild("##da-sidebar", new Vector2(rect.W, rect.H), false,
-            ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
+        // Codex-themed scrollbar for when the chapter list overflows the pane.
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarBg, new Vector4(0f, 0f, 0f, 0f));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrab, ColorPalette.Gold * 0.35f);
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabHovered, ColorPalette.Gold * 0.55f);
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabActive, ColorPalette.Gold);
+
+        // Allow the nav to scroll when it overflows. The collapsed strip is too
+        // narrow for a visible bar, so it scrolls by wheel only; expanded shows
+        // the themed scrollbar.
+        var scrollFlags = vm.IsCollapsed
+            ? ImGuiWindowFlags.NoScrollbar
+            : ImGuiWindowFlags.None;
+        ImGui.BeginChild("##da-sidebar", new Vector2(rect.W, rect.H), false, scrollFlags);
 
         DrawHideToggle(vm, events);
 
@@ -85,7 +96,7 @@ internal static class SidebarRenderer
             spineColor, UiScale.Scaled(1f));
 
         ImGui.EndChild();
-        ImGui.PopStyleColor(2);
+        ImGui.PopStyleColor(6);
         return events;
     }
 


### PR DESCRIPTION
## Problem
The sidebar nav `BeginChild` used `NoScrollbar | NoScrollWithMouse`, so with all groups expanded — or at higher GUIScale where rows are taller — the bottom chapters ("III. OF REALMS" and below) were clipped with no way to reach them.

## Fix
- **Expanded:** drop both no-scroll flags → wheel scroll + a scrollbar, themed to the codex palette (transparent track, gold grab/hover/active).
- **Collapsed strip (~40px):** wheel scroll only (keep `NoScrollbar`) so the bar doesn't eat the narrow width.
- Content height is already tracked by ImGui (rows use `Selectable`/`Indent`/`Dummy`), so the bar appears only when the list overflows.

`PopStyleColor` count updated (2 → 6) for the 4 added scrollbar colors.

## Tests
Build clean, full suite **2515 passed**. Rebase-merge repo.

Closes #614