### PR TITLE
fix(config): clamp blessing-slot overflow instead of resetting config

### DIFF
--- a/DivineAscension.Tests/Configuration/BlessingSlotCalculatorTests.cs
+++ b/DivineAscension.Tests/Configuration/BlessingSlotCalculatorTests.cs
@@ -80,4 +80,50 @@ public class BlessingSlotCalculatorTests
         Assert.Throws<ArgumentNullException>(() =>
             BlessingSlotCalculator.GetMaxUnlocks(null!, FavorRank.Initiate, null));
     }
+
+    [Fact]
+    public void GetMaxUnlocks_ClampsTotalToConfiguredCap()
+    {
+        // favor 7 + bonus 4 = 11, but the cap binds at 8.
+        var config = new GameBalanceConfig
+        {
+            AvatarActiveBlessingSlots = 7,
+            MythicBonusSlots = 4,
+            MaxTotalActiveBlessingSlots = 8
+        };
+
+        var slots = BlessingSlotCalculator.GetMaxUnlocks(config, FavorRank.Avatar, PrestigeRank.Mythic);
+
+        Assert.Equal(8, slots);
+    }
+
+    [Fact]
+    public void GetMaxUnlocks_HonoursRaisedCap()
+    {
+        // Raising the cap lets the same dials yield more slots — the wall moves with the config.
+        var config = new GameBalanceConfig
+        {
+            AvatarActiveBlessingSlots = 7,
+            MythicBonusSlots = 4,
+            MaxTotalActiveBlessingSlots = 16
+        };
+
+        var slots = BlessingSlotCalculator.GetMaxUnlocks(config, FavorRank.Avatar, PrestigeRank.Mythic);
+
+        Assert.Equal(11, slots);
+    }
+
+    [Fact]
+    public void GetMaxUnlocks_ClampsFavorOnlyTotalToCap()
+    {
+        var config = new GameBalanceConfig
+        {
+            AvatarActiveBlessingSlots = 20,
+            MaxTotalActiveBlessingSlots = 8
+        };
+
+        var slots = BlessingSlotCalculator.GetMaxUnlocks(config, FavorRank.Avatar, null);
+
+        Assert.Equal(8, slots);
+    }
 }

--- a/DivineAscension.Tests/Configuration/GameBalanceConfigBlessingSlotsTests.cs
+++ b/DivineAscension.Tests/Configuration/GameBalanceConfigBlessingSlotsTests.cs
@@ -64,16 +64,39 @@ public class GameBalanceConfigBlessingSlotsTests
     [InlineData(nameof(GameBalanceConfig.RenownedBonusSlots))]
     [InlineData(nameof(GameBalanceConfig.LegendaryBonusSlots))]
     [InlineData(nameof(GameBalanceConfig.MythicBonusSlots))]
-    public void Validate_RejectsNegativeSlotValues(string propertyName)
+    [InlineData(nameof(GameBalanceConfig.FledglingReligionBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.MythicReligionBlessingSlots))]
+    public void Validate_AcceptsNegativeSlotValues_WithoutThrowing(string propertyName)
     {
+        // A negative slot field must NOT cause Validate() to throw — that would reset the whole
+        // config to defaults (#616). Repair is the job of ClampBlessingSlots instead.
         var config = new GameBalanceConfig();
         typeof(GameBalanceConfig).GetProperty(propertyName)!.SetValue(config, -1);
 
-        Assert.Throws<InvalidOperationException>(() => config.Validate());
+        var ex = Record.Exception(() => config.Validate());
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(nameof(GameBalanceConfig.InitiateActiveBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.AvatarActiveBlessingSlots))]
+    [InlineData(nameof(GameBalanceConfig.MythicBonusSlots))]
+    [InlineData(nameof(GameBalanceConfig.MythicReligionBlessingSlots))]
+    public void ClampBlessingSlots_ClampsNegativeToZero_AndReports(string propertyName)
+    {
+        var config = new GameBalanceConfig();
+        var property = typeof(GameBalanceConfig).GetProperty(propertyName)!;
+        property.SetValue(config, -5);
+
+        var adjustments = config.ClampBlessingSlots();
+
+        Assert.Equal(0, (int)property.GetValue(config)!);
+        Assert.Contains(adjustments, m => m.Contains(propertyName));
     }
 
     [Fact]
-    public void Validate_RejectsTotalAboveHardCap()
+    public void ClampBlessingSlots_LeavesValidConfigUntouched()
     {
         var config = new GameBalanceConfig
         {
@@ -81,15 +104,36 @@ public class GameBalanceConfigBlessingSlotsTests
             MythicBonusSlots = 2
         };
 
-        Assert.Throws<InvalidOperationException>(() => config.Validate());
+        var adjustments = config.ClampBlessingSlots();
+
+        Assert.Empty(adjustments);
+        // High-but-non-negative values survive — the cap is enforced at runtime, not by reset.
+        Assert.Equal(7, config.AvatarActiveBlessingSlots);
+        Assert.Equal(2, config.MythicBonusSlots);
+    }
+
+    [Theory]
+    [InlineData(0, GameBalanceConfig.MinAllowedMaxTotalActiveBlessingSlots)]
+    [InlineData(-3, GameBalanceConfig.MinAllowedMaxTotalActiveBlessingSlots)]
+    [InlineData(9999, GameBalanceConfig.MaxAllowedMaxTotalActiveBlessingSlots)]
+    public void ClampBlessingSlots_ClampsCapToAllowedRange(int input, int expected)
+    {
+        var config = new GameBalanceConfig { MaxTotalActiveBlessingSlots = input };
+
+        var adjustments = config.ClampBlessingSlots();
+
+        Assert.Equal(expected, config.MaxTotalActiveBlessingSlots);
+        Assert.Contains(adjustments, m => m.Contains(nameof(GameBalanceConfig.MaxTotalActiveBlessingSlots)));
     }
 
     [Fact]
-    public void Validate_AcceptsTotalAtHardCap()
+    public void Validate_AcceptsTotalAboveDefaultCap_WithoutThrowing()
     {
+        // Previously this reset the entire config; now an over-cap total is tolerated and clamped
+        // at runtime instead of rejected at load (#616).
         var config = new GameBalanceConfig
         {
-            AvatarActiveBlessingSlots = 6,
+            AvatarActiveBlessingSlots = 7,
             MythicBonusSlots = 2
         };
 
@@ -99,20 +143,19 @@ public class GameBalanceConfigBlessingSlotsTests
     }
 
     [Fact]
-    public void Validate_RejectsCrossPairAboveHardCap()
+    public void MaxTotalActiveBlessingSlots_DefaultsTo8()
     {
-        var config = new GameBalanceConfig
-        {
-            ChampionActiveBlessingSlots = 6,
-            RenownedBonusSlots = 3
-        };
-
-        Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Equal(8, new GameBalanceConfig().MaxTotalActiveBlessingSlots);
     }
 
     [Fact]
-    public void HardCapConstant_Is8()
+    public void MaxTotalActiveBlessingSlots_IsConfigurable()
     {
-        Assert.Equal(8, GameBalanceConfig.MaxTotalBlessingSlots);
+        var config = new GameBalanceConfig { MaxTotalActiveBlessingSlots = 12 };
+
+        var adjustments = config.ClampBlessingSlots();
+
+        Assert.Empty(adjustments);
+        Assert.Equal(12, config.MaxTotalActiveBlessingSlots);
     }
 }

--- a/DivineAscension/Configuration/BlessingSlotCalculator.cs
+++ b/DivineAscension/Configuration/BlessingSlotCalculator.cs
@@ -19,12 +19,13 @@ public static class BlessingSlotCalculator
         ArgumentNullException.ThrowIfNull(config);
 
         var favorSlots = GetFavorSlots(config, favorRank);
-        if (prestigeRank is null)
-        {
-            return favorSlots;
-        }
+        var total = prestigeRank is null
+            ? favorSlots
+            : favorSlots + GetPrestigeBonus(config, prestigeRank.Value);
 
-        return favorSlots + GetPrestigeBonus(config, prestigeRank.Value);
+        // Enforce the balance ceiling here rather than rejecting out-of-range config at load time,
+        // so admins can raise the dials (or the cap) without one bad value resetting the config (#616).
+        return Math.Clamp(total, 0, config.MaxTotalActiveBlessingSlots);
     }
 
     private static int GetFavorSlots(GameBalanceConfig config, FavorRank rank) => rank switch

--- a/DivineAscension/Configuration/GameBalanceConfig.cs
+++ b/DivineAscension/Configuration/GameBalanceConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace DivineAscension.Configuration;
 
@@ -116,8 +117,20 @@ public class GameBalanceConfig
     /// <summary>Bonus active blessing slots from Mythic religion prestige (default: 2)</summary>
     public int MythicBonusSlots { get; set; } = 2;
 
-    /// <summary>Hard cap on total active blessing slots (favor + prestige bonus).</summary>
-    public const int MaxTotalBlessingSlots = 8;
+    /// <summary>
+    /// Balance ceiling on total active blessing slots (favor + prestige bonus). Default 8.
+    /// This is a soft cap enforced by clamping at runtime (see <see cref="BlessingSlotCalculator"/>),
+    /// not a structural constraint — raising it lets a player unlock more slots, lowering it caps them.
+    /// Out-of-range slot fields are clamped (not rejected) so one bad value never discards the rest
+    /// of the config. Range: 1..64.
+    /// </summary>
+    public int MaxTotalActiveBlessingSlots { get; set; } = 8;
+
+    /// <summary>Lower bound enforced on <see cref="MaxTotalActiveBlessingSlots"/>.</summary>
+    public const int MinAllowedMaxTotalActiveBlessingSlots = 1;
+
+    /// <summary>Upper bound enforced on <see cref="MaxTotalActiveBlessingSlots"/>.</summary>
+    public const int MaxAllowedMaxTotalActiveBlessingSlots = 64;
 
     // === RELIGION BLESSING SLOTS ===
 
@@ -281,8 +294,10 @@ public class GameBalanceConfig
             throw new InvalidOperationException("Holy site tier multipliers must be ascending");
         }
 
-        ValidateBlessingSlots();
-        ValidateReligionBlessingSlots();
+        // Blessing-slot bounds are NOT validated here: out-of-range slot values are clamped
+        // (see ClampBlessingSlots) rather than thrown, so one bad slot field never causes the
+        // entire config to be discarded and reset to defaults. The balance ceiling is enforced
+        // at runtime by BlessingSlotCalculator.
 
         if (UnlearnRefundPercent < 0f || UnlearnRefundPercent > 1f)
         {
@@ -301,72 +316,74 @@ public class GameBalanceConfig
         }
     }
 
-    private void ValidateBlessingSlots()
+    /// <summary>
+    /// Brings every blessing-slot field into a usable range in place, returning a human-readable
+    /// message for each field that had to be adjusted. Negative slot counts are clamped to 0 and
+    /// <see cref="MaxTotalActiveBlessingSlots"/> is clamped to [<see cref="MinAllowedMaxTotalActiveBlessingSlots"/>,
+    /// <see cref="MaxAllowedMaxTotalActiveBlessingSlots"/>].
+    ///
+    /// The balance ceiling itself (favor + prestige bonus exceeding the cap) is intentionally NOT
+    /// clamped here — it is enforced gracefully at runtime by <see cref="BlessingSlotCalculator"/>,
+    /// so an admin can raise the dials and the cap moves with them. This method only repairs values
+    /// that are structurally invalid, never rejecting the whole config.
+    /// </summary>
+    /// <returns>Empty when nothing was changed; otherwise one message per adjusted field.</returns>
+    public IReadOnlyList<string> ClampBlessingSlots()
     {
-        int[] favorSlots =
-        {
-            InitiateActiveBlessingSlots,
-            DiscipleActiveBlessingSlots,
-            ZealotActiveBlessingSlots,
-            ChampionActiveBlessingSlots,
-            AvatarActiveBlessingSlots
-        };
+        var adjustments = new List<string>();
 
-        int[] prestigeBonus =
-        {
-            FledglingBonusSlots,
-            EstablishedBonusSlots,
-            RenownedBonusSlots,
-            LegendaryBonusSlots,
-            MythicBonusSlots
-        };
+        ClampNonNegative(nameof(InitiateActiveBlessingSlots), InitiateActiveBlessingSlots,
+            v => InitiateActiveBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(DiscipleActiveBlessingSlots), DiscipleActiveBlessingSlots,
+            v => DiscipleActiveBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(ZealotActiveBlessingSlots), ZealotActiveBlessingSlots,
+            v => ZealotActiveBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(ChampionActiveBlessingSlots), ChampionActiveBlessingSlots,
+            v => ChampionActiveBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(AvatarActiveBlessingSlots), AvatarActiveBlessingSlots,
+            v => AvatarActiveBlessingSlots = v, adjustments);
 
-        foreach (var slots in favorSlots)
+        ClampNonNegative(nameof(FledglingBonusSlots), FledglingBonusSlots,
+            v => FledglingBonusSlots = v, adjustments);
+        ClampNonNegative(nameof(EstablishedBonusSlots), EstablishedBonusSlots,
+            v => EstablishedBonusSlots = v, adjustments);
+        ClampNonNegative(nameof(RenownedBonusSlots), RenownedBonusSlots,
+            v => RenownedBonusSlots = v, adjustments);
+        ClampNonNegative(nameof(LegendaryBonusSlots), LegendaryBonusSlots,
+            v => LegendaryBonusSlots = v, adjustments);
+        ClampNonNegative(nameof(MythicBonusSlots), MythicBonusSlots,
+            v => MythicBonusSlots = v, adjustments);
+
+        ClampNonNegative(nameof(FledglingReligionBlessingSlots), FledglingReligionBlessingSlots,
+            v => FledglingReligionBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(EstablishedReligionBlessingSlots), EstablishedReligionBlessingSlots,
+            v => EstablishedReligionBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(RenownedReligionBlessingSlots), RenownedReligionBlessingSlots,
+            v => RenownedReligionBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(LegendaryReligionBlessingSlots), LegendaryReligionBlessingSlots,
+            v => LegendaryReligionBlessingSlots = v, adjustments);
+        ClampNonNegative(nameof(MythicReligionBlessingSlots), MythicReligionBlessingSlots,
+            v => MythicReligionBlessingSlots = v, adjustments);
+
+        var clampedCap = Math.Clamp(MaxTotalActiveBlessingSlots,
+            MinAllowedMaxTotalActiveBlessingSlots, MaxAllowedMaxTotalActiveBlessingSlots);
+        if (clampedCap != MaxTotalActiveBlessingSlots)
         {
-            if (slots < 0)
-            {
-                throw new InvalidOperationException("Active blessing slot counts must be >= 0");
-            }
+            adjustments.Add(
+                $"{nameof(MaxTotalActiveBlessingSlots)} {MaxTotalActiveBlessingSlots} out of range " +
+                $"[{MinAllowedMaxTotalActiveBlessingSlots}, {MaxAllowedMaxTotalActiveBlessingSlots}] — clamped to {clampedCap}");
+            MaxTotalActiveBlessingSlots = clampedCap;
         }
 
-        foreach (var bonus in prestigeBonus)
-        {
-            if (bonus < 0)
-            {
-                throw new InvalidOperationException("Prestige bonus blessing slot counts must be >= 0");
-            }
-        }
-
-        foreach (var favor in favorSlots)
-        {
-            foreach (var bonus in prestigeBonus)
-            {
-                if (favor + bonus > MaxTotalBlessingSlots)
-                {
-                    throw new InvalidOperationException(
-                        $"Total active blessing slots (favor + prestige bonus) must not exceed {MaxTotalBlessingSlots}");
-                }
-            }
-        }
+        return adjustments;
     }
 
-    private void ValidateReligionBlessingSlots()
+    private static void ClampNonNegative(string fieldName, int value, Action<int> setter, List<string> adjustments)
     {
-        int[] religionSlots =
+        if (value < 0)
         {
-            FledglingReligionBlessingSlots,
-            EstablishedReligionBlessingSlots,
-            RenownedReligionBlessingSlots,
-            LegendaryReligionBlessingSlots,
-            MythicReligionBlessingSlots
-        };
-
-        foreach (var slots in religionSlots)
-        {
-            if (slots < 0)
-            {
-                throw new InvalidOperationException("Religion blessing slot counts must be >= 0");
-            }
+            adjustments.Add($"{fieldName} {value} is negative — clamped to 0");
+            setter(0);
         }
     }
 }

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -123,6 +123,13 @@ public class DivineAscensionModSystem : ModSystem
         // Register with ConfigLib if available
         TryRegisterWithConfigLib(api);
 
+        // Clamp blessing-slot fields in place first so out-of-range slot values are repaired
+        // (and logged per field) instead of tripping Validate() and discarding the whole config (#616).
+        foreach (var adjustment in _gameBalanceConfig.ClampBlessingSlots())
+        {
+            api.Logger.Warning($"[DivineAscension] Blessing slot config adjusted: {adjustment}");
+        }
+
         // Validate config regardless of ConfigLib presence
         try
         {
@@ -516,6 +523,11 @@ public class DivineAscensionModSystem : ModSystem
     {
         try
         {
+            foreach (var adjustment in _gameBalanceConfig.ClampBlessingSlots())
+            {
+                _sapi?.Logger.Warning($"[DivineAscension] Blessing slot config adjusted: {adjustment}");
+            }
+
             _gameBalanceConfig.Validate();
             _sapi?.Logger.Notification($"[DivineAscension] Configuration updated: {settingCode}");
 


### PR DESCRIPTION
## Summary

Fixes #616. The active-blessing-slot ceiling was a hardcoded `const` (`MaxTotalBlessingSlots = 8`), and exceeding it made `GameBalanceConfig.Validate()` throw — which the load path caught by **discarding the entire config and resetting to defaults**. One out-of-range slot field silently wiped all admin tuning (the "my edit doesn't take" symptom).

### What changed

1. **Configurable ceiling** — replaced the `const` with a `MaxTotalActiveBlessingSlots` config field (default **8**, range 1..64). Nothing structural depends on 8; it's a balance ceiling, so admins can now raise/lower it. Leaving it untouched preserves current balance.
2. **No more whole-config reset** — removed slot-bound throws from `Validate()`. New `ClampBlessingSlots()` repairs out-of-range values **in place** (negatives → 0, cap → [1,64]) and returns one message per adjusted field. `Start()` and `OnConfigChanged` call it and log each adjustment, so valid values survive and admins get feedback.
3. **Runtime enforcement** — `BlessingSlotCalculator.GetMaxUnlocks` clamps the effective total via `Math.Clamp(total, 0, cap)`. Raising the dials (or the cap) just works; over-cap values clamp gracefully instead of detonating the config.

### Not addressed

Issue #3 (ConfigLib GUI range hint): there's no config schema asset or attribute layer wired up — ConfigLib reflects the bare object, so no field has bounds/descriptions today. Surfacing the cap in the GUI would mean building that path from scratch; left out of scope. Feedback is provided via server-log warnings on clamp instead.

## Test plan

- `dotnet build DivineAscension.sln -c Debug` — clean.
- `dotnet test` — all 2527 pass.
- Updated `GameBalanceConfigBlessingSlotsTests` (clamp behavior replaces throw expectations) and added runtime-clamp / raised-cap cases to `BlessingSlotCalculatorTests`.
- UI not verified headless: the in-game ConfigLib menu reflects stored dial values; it does not visually warn when a total exceeds the cap (see "Not addressed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)