### PR TITLE
chore(skills): type-prefixed branch names, always from master in work-issue

### DIFF
--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -23,8 +23,11 @@ Repo: `quantumheart/divineascension` (the only repo these tools may touch).
   don't guess.
 
 ## 2. Branch
-- Develop on the feature branch the task specifies (e.g. `claude/...`). If none
-  was given, create one: `git checkout -b claude/issue-<N>-<slug>`.
+- Always branch fresh from `master`. Never stack on the currently checked-out
+  branch unless the user explicitly asks: `git fetch origin master && git checkout -b <type>/<slug> origin/master`.
+- Name `<type>` by the nature of the change, matching the commit convention:
+  `feat/`, `bug/`, `refactor/`, or `chore/`. Pick a short `<slug>` from the
+  issue (e.g. `feat/blessing-slot-cap`, `bug/sidebar-scroll`).
 - Never push to `main`/`master` or another contributor's branch without explicit
   permission.
 


### PR DESCRIPTION
## What

Update the **work-issue** skill's branching rules (`.claude/skills/work-issue/SKILL.md` §2):

- Branch names are now **type-prefixed** — `feat/`, `bug/`, `refactor/`, `chore/` + short slug — mirroring the repo's Conventional Commit style, replacing the old `claude/issue-<N>-<slug>` convention.
- Always **branch fresh from `master`** (`git fetch origin master && git checkout -b <type>/<slug> origin/master`) instead of stacking on whatever branch is currently checked out.

## Why

The old rule created branches off the current HEAD, which is how a stale `claude/...` branch stayed checked out across sessions. Type prefixes also align branch names with commit prefixes.

## Scope

Docs/skill only — no code or behavior change.
