### PR TITLE
refactor(logging): route remaining raw ILogger users through ILoggerWrapper

### DIFF
--- a/DivineAscension.Tests/Commands/Helpers/CivilizationCommandsTestHelpers.cs
+++ b/DivineAscension.Tests/Commands/Helpers/CivilizationCommandsTestHelpers.cs
@@ -3,6 +3,7 @@ using DivineAscension.API.Interfaces;
 using DivineAscension.Commands;
 using DivineAscension.Data;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Systems.Interfaces;
 using DivineAscension.Tests.Helpers;
 using Moq;
@@ -18,6 +19,7 @@ public class CivilizationCommandsTestHelpers
     protected Mock<ICivilizationManager> _civilizationManager;
     protected Mock<IChatCommandApi> _mockChatCommands;
     protected Mock<ILogger> _mockLogger;
+    protected Mock<ILoggerWrapper> _mockLoggerWrapper;
     protected Mock<ICoreServerAPI> _mockSapi;
     protected Mock<IServerWorldAccessor> _mockWorld;
     protected Mock<IPlayerProgressionDataManager> _playerProgressionDataManager;
@@ -33,6 +35,7 @@ public class CivilizationCommandsTestHelpers
 
         _mockSapi = new Mock<ICoreServerAPI>();
         _mockLogger = new Mock<ILogger>();
+        _mockLoggerWrapper = new Mock<ILoggerWrapper>();
         _mockChatCommands = new Mock<IChatCommandApi>();
         _mockWorld = new Mock<IServerWorldAccessor>();
         _mockMessengerService = new Mock<IPlayerMessengerService>();
@@ -64,7 +67,7 @@ public class CivilizationCommandsTestHelpers
             mockCooldownManager.Object,
             _mockMessengerService.Object,
             _mockWorldService.Object,
-            _mockLogger.Object);
+            _mockLoggerWrapper.Object);
     }
 
     /// <summary>

--- a/DivineAscension.Tests/Commands/Helpers/ReligionCommandsTestHelpers.cs
+++ b/DivineAscension.Tests/Commands/Helpers/ReligionCommandsTestHelpers.cs
@@ -4,6 +4,7 @@ using DivineAscension.Commands;
 using DivineAscension.Data;
 using DivineAscension.Models;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Systems;
 using DivineAscension.Systems.Interfaces;
 using DivineAscension.Tests.Helpers;
@@ -19,6 +20,7 @@ public class ReligionCommandsTestHelpers
 {
     protected Mock<IChatCommandApi> _mockChatCommands;
     protected Mock<ILogger> _mockLogger;
+    protected Mock<ILoggerWrapper> _mockLoggerWrapper;
     protected Mock<ICoreServerAPI> _mockSapi;
     protected Mock<IServerWorldAccessor> _mockWorld;
     protected Mock<IPlayerProgressionDataManager> _playerProgressionDataManager;
@@ -36,6 +38,7 @@ public class ReligionCommandsTestHelpers
 
         _mockSapi = new Mock<ICoreServerAPI>();
         _mockLogger = new Mock<ILogger>();
+        _mockLoggerWrapper = new Mock<ILoggerWrapper>();
         _mockChatCommands = new Mock<IChatCommandApi>();
         _mockWorld = new Mock<IServerWorldAccessor>();
 
@@ -77,7 +80,7 @@ public class ReligionCommandsTestHelpers
             mockCooldownManager.Object,
             _mockMessengerService.Object,
             _mockWorldService.Object,
-            _mockLogger.Object);
+            _mockLoggerWrapper.Object);
     }
 
     /// <summary>

--- a/DivineAscension.Tests/Commands/Religion/ReligionCommandAdminTests.cs
+++ b/DivineAscension.Tests/Commands/Religion/ReligionCommandAdminTests.cs
@@ -43,7 +43,7 @@ public class ReligionCommandAdminTests : ReligionCommandsTestHelpers
             _mockCooldownManager.Object,
             _mockMessengerService.Object,
             _mockWorldService.Object,
-            _mockLogger.Object);
+            _mockLoggerWrapper.Object);
     }
 
     #region /religion admin repair tests

--- a/DivineAscension.Tests/Commands/Religion/ReligionCommandsTests.cs
+++ b/DivineAscension.Tests/Commands/Religion/ReligionCommandsTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Commands;
+using DivineAscension.Services;
 using DivineAscension.Systems.Interfaces;
 using DivineAscension.Tests.Commands.Helpers;
 using DivineAscension.Tests.Helpers;
@@ -32,7 +33,7 @@ public class ReligionCommandsTests : ReligionCommandsTestHelpers
         var mockNetworkService = new Mock<INetworkService>();
         var mockMessengerService = new Mock<IPlayerMessengerService>();
         var mockWorldService = new Mock<IWorldService>();
-        var mockLogger = new Mock<ILogger>();
+        var mockLogger = new Mock<ILoggerWrapper>();
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new ReligionCommands(
             null!,
@@ -56,7 +57,7 @@ public class ReligionCommandsTests : ReligionCommandsTestHelpers
         var mockNetworkService = new Mock<INetworkService>();
         var mockMessengerService = new Mock<IPlayerMessengerService>();
         var mockWorldService = new Mock<IWorldService>();
-        var mockLogger = new Mock<ILogger>();
+        var mockLogger = new Mock<ILoggerWrapper>();
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new ReligionCommands(
             _mockSapi.Object,
@@ -80,7 +81,7 @@ public class ReligionCommandsTests : ReligionCommandsTestHelpers
         var mockNetworkService = new Mock<INetworkService>();
         var mockMessengerService = new Mock<IPlayerMessengerService>();
         var mockWorldService = new Mock<IWorldService>();
-        var mockLogger = new Mock<ILogger>();
+        var mockLogger = new Mock<ILoggerWrapper>();
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new ReligionCommands(
             _mockSapi.Object,
@@ -103,7 +104,7 @@ public class ReligionCommandsTests : ReligionCommandsTestHelpers
         var mockCooldownManager = TestFixtures.CreateMockCooldownManager();
         var mockMessengerService = new Mock<IPlayerMessengerService>();
         var mockWorldService = new Mock<IWorldService>();
-        var mockLogger = new Mock<ILogger>();
+        var mockLogger = new Mock<ILoggerWrapper>();
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new ReligionCommands(
             _mockSapi.Object,
@@ -127,7 +128,7 @@ public class ReligionCommandsTests : ReligionCommandsTestHelpers
         var mockNetworkService = new Mock<INetworkService>();
         var mockMessengerService = new Mock<IPlayerMessengerService>();
         var mockWorldService = new Mock<IWorldService>();
-        var mockLogger = new Mock<ILogger>();
+        var mockLogger = new Mock<ILoggerWrapper>();
         // Act
         var commands = new ReligionCommands(
             _mockSapi.Object,
@@ -176,7 +177,7 @@ public class ReligionCommandsTests : ReligionCommandsTestHelpers
         // Assert
         Assert.Null(exception);
         _mockChatCommands.Verify(c => c.Create("religion"), Times.Once);
-        _mockLogger.Verify(l => l.Notification(It.Is<string>(s => s.Contains("Religion commands registered"))),
+        _mockLoggerWrapper.Verify(l => l.Notification(It.Is<string>(s => s.Contains("Religion commands registered"))),
             Times.Once);
     }
 

--- a/DivineAscension.Tests/Helpers/TestFixtures.cs
+++ b/DivineAscension.Tests/Helpers/TestFixtures.cs
@@ -257,6 +257,30 @@ public static class TestFixtures
         );
     }
 
+    /// <summary>
+    ///     Verifies that a wrapped-logger notification was called with the expected message substring
+    /// </summary>
+    public static void VerifyLoggerNotification(Mock<ILoggerWrapper> mockLogger, string expectedSubstring)
+    {
+        mockLogger.Verify(
+            l => l.Notification(It.Is<string>(s => s.Contains(expectedSubstring))),
+            Times.AtLeastOnce(),
+            $"Expected logger notification containing: {expectedSubstring}"
+        );
+    }
+
+    /// <summary>
+    ///     Verifies that a wrapped-logger debug message was called with the expected message substring
+    /// </summary>
+    public static void VerifyLoggerDebug(Mock<ILoggerWrapper> mockLogger, string expectedSubstring)
+    {
+        mockLogger.Verify(
+            l => l.Debug(It.Is<string>(s => s.Contains(expectedSubstring))),
+            Times.AtLeastOnce(),
+            $"Expected logger debug containing: {expectedSubstring}"
+        );
+    }
+
     #endregion
 
     #region Localization Helpers

--- a/DivineAscension.Tests/Systems/BuffSystem/BuffManagerTests.cs
+++ b/DivineAscension.Tests/Systems/BuffSystem/BuffManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Services;
 using DivineAscension.Systems.BuffSystem;
 using DivineAscension.Tests.Helpers;
 using Moq;
@@ -16,13 +17,12 @@ public class BuffManagerTests
 {
     private readonly BuffManager _buffManager;
     private readonly Mock<ICoreServerAPI> _mockAPI;
-    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<ILoggerWrapper> _mockLogger;
 
     public BuffManagerTests()
     {
         _mockAPI = TestFixtures.CreateMockServerAPI();
-        _mockLogger = new Mock<ILogger>();
-        _mockAPI.Setup(a => a.Logger).Returns(_mockLogger.Object);
+        _mockLogger = new Mock<ILoggerWrapper>();
 
         var fakeWorldService = new FakeWorldService();
         _buffManager = new BuffManager(_mockLogger.Object, fakeWorldService);

--- a/DivineAscension.Tests/Systems/CooldownManagerTests.cs
+++ b/DivineAscension.Tests/Systems/CooldownManagerTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using DivineAscension.Data;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Systems;
 using DivineAscension.Tests.Helpers;
 using Moq;
@@ -20,11 +21,11 @@ public class CooldownManagerTests
     private readonly CooldownManager _cooldownManager;
     private readonly FakeEventService _fakeEventService;
     private readonly FakeWorldService _fakeWorldService;
-    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<ILoggerWrapper> _mockLogger;
 
     public CooldownManagerTests()
     {
-        _mockLogger = new Mock<ILogger>();
+        _mockLogger = new Mock<ILoggerWrapper>();
         _fakeEventService = new FakeEventService();
         _fakeWorldService = new FakeWorldService();
         _config = new ModConfigData();

--- a/DivineAscension.Tests/Systems/Networking/Server/HolySiteNetworkHandlerTests.cs
+++ b/DivineAscension.Tests/Systems/Networking/Server/HolySiteNetworkHandlerTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using DivineAscension.Data;
 using DivineAscension.Models.Enum;
 using DivineAscension.Network.HolySite;
+using DivineAscension.Services;
 using DivineAscension.Services.Interfaces;
 using DivineAscension.Systems.Interfaces;
 using DivineAscension.Systems.Networking.Server;
@@ -20,7 +21,7 @@ public class HolySiteNetworkHandlerTests
 {
     private readonly HolySiteNetworkHandler _handler;
     private readonly Mock<IHolySiteManager> _mockHolySiteManager;
-    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<ILoggerWrapper> _mockLogger;
     private readonly Mock<IServerPlayer> _mockPlayer;
     private readonly Mock<IReligionManager> _mockReligionManager;
     private readonly Mock<IRitualProgressManager> _mockRitualProgressManager;
@@ -34,7 +35,7 @@ public class HolySiteNetworkHandlerTests
         _mockPlayer.Setup(p => p.PlayerUID).Returns("player1");
         _mockPlayer.Setup(p => p.PlayerName).Returns("Player One");
 
-        _mockLogger = new Mock<ILogger>();
+        _mockLogger = new Mock<ILoggerWrapper>();
         _mockHolySiteManager = new Mock<IHolySiteManager>();
         _mockReligionManager = new Mock<IReligionManager>();
         _mockRitualProgressManager = new Mock<IRitualProgressManager>();

--- a/DivineAscension.Tests/Systems/Networking/Server/PlayerDataNetworkHandlerTests.cs
+++ b/DivineAscension.Tests/Systems/Networking/Server/PlayerDataNetworkHandlerTests.cs
@@ -27,7 +27,6 @@ public class PlayerDataNetworkHandlerTests
     private readonly FakePersistenceService _persistenceService;
     private readonly FakeTimeService _timeService;
     private readonly FakeWorldService _worldService;
-    private readonly Mock<ILogger> _mockLogger;
     private readonly Mock<ILoggerWrapper> _mockLoggerWrapper;
     private readonly Mock<IReligionManager> _mockReligionManager;
     private readonly SpyNetworkService _networkService;
@@ -38,7 +37,6 @@ public class PlayerDataNetworkHandlerTests
     public PlayerDataNetworkHandlerTests()
     {
         _config = new GameBalanceConfig();
-        _mockLogger = new Mock<ILogger>();
         _mockLoggerWrapper = new Mock<ILoggerWrapper>();
         _mockReligionManager = new Mock<IReligionManager>();
         _eventService = new FakeEventService();
@@ -53,7 +51,6 @@ public class PlayerDataNetworkHandlerTests
             _mockReligionManager.Object, _config);
 
         _handler = new PlayerDataNetworkHandler(
-            _mockLogger.Object,
             _worldService,
             _eventService,
             _networkService,

--- a/DivineAscension.Tests/Systems/ReligionChronicleTests.cs
+++ b/DivineAscension.Tests/Systems/ReligionChronicleTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using DivineAscension.Data;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Systems;
 using DivineAscension.Tests.Helpers;
 using Moq;
@@ -24,7 +25,7 @@ public class ReligionChronicleTests
 
     public ReligionChronicleTests()
     {
-        var mockLogger = new Mock<ILogger>();
+        var mockLogger = new Mock<ILoggerWrapper>();
         _religionManager = new ReligionManager(mockLogger.Object, new FakeEventService(),
             new FakePersistenceService(), new FakeWorldService());
     }

--- a/DivineAscension.Tests/Systems/ReligionManagerTests.cs
+++ b/DivineAscension.Tests/Systems/ReligionManagerTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Systems;
 using DivineAscension.Systems.Interfaces;
 using DivineAscension.Tests.Helpers;
@@ -23,14 +24,13 @@ public class ReligionManagerTests
     private readonly FakePersistenceService _fakePersistenceService;
     private readonly FakeWorldService _fakeWorldService;
     private readonly Mock<ICoreServerAPI> _mockAPI;
-    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<ILoggerWrapper> _mockLogger;
     private readonly ReligionManager _religionManager;
 
     public ReligionManagerTests()
     {
         _mockAPI = TestFixtures.CreateMockServerAPI();
-        _mockLogger = new Mock<ILogger>();
-        _mockAPI.Setup(a => a.Logger).Returns(_mockLogger.Object);
+        _mockLogger = new Mock<ILoggerWrapper>();
 
         _fakeEventService = new FakeEventService();
         _fakePersistenceService = new FakePersistenceService();

--- a/DivineAscension.Tests/Systems/SacredCalendarTests.cs
+++ b/DivineAscension.Tests/Systems/SacredCalendarTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using DivineAscension.Models;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Systems;
 using DivineAscension.Tests.Helpers;
 using Moq;
@@ -21,7 +22,7 @@ public class SacredCalendarTests
     private readonly FakeEventService _events = new();
     private readonly FakePersistenceService _persistence = new();
     private readonly FakeWorldService _world = new();
-    private readonly Mock<ILogger> _logger = new();
+    private readonly Mock<ILoggerWrapper> _logger = new();
 
     private ReligionManager NewManager() =>
         new(_logger.Object, _events, _persistence, _world);

--- a/DivineAscension/Commands/CivilizationCommands.cs
+++ b/DivineAscension/Commands/CivilizationCommands.cs
@@ -27,7 +27,7 @@ public class CivilizationCommands(
     ICooldownManager cooldownManager,
     IPlayerMessengerService messengerService,
     IWorldService worldService,
-    ILogger logger)
+    ILoggerWrapper logger)
 {
     private readonly ICivilizationManager _civilizationManager =
         civilizationManager ?? throw new ArgumentNullException(nameof(civilizationManager));
@@ -49,7 +49,7 @@ public class CivilizationCommands(
     private readonly IWorldService _worldService =
         worldService ?? throw new ArgumentNullException(nameof(worldService));
 
-    private readonly ILogger _logger =
+    private readonly ILoggerWrapper _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <summary>

--- a/DivineAscension/Commands/ReligionCommands.cs
+++ b/DivineAscension/Commands/ReligionCommands.cs
@@ -32,7 +32,7 @@ public class ReligionCommands(
     ICooldownManager cooldownManager,
     IPlayerMessengerService messengerService,
     IWorldService worldService,
-    ILogger logger)
+    ILoggerWrapper logger)
 {
     private readonly IPlayerProgressionDataManager _playerProgressionDataManager =
         playerReligionDataManager ?? throw new ArgumentNullException(nameof(playerReligionDataManager));
@@ -60,7 +60,7 @@ public class ReligionCommands(
     private readonly IWorldService _worldService =
         worldService ?? throw new ArgumentNullException(nameof(worldService));
 
-    private readonly ILogger _logger =
+    private readonly ILoggerWrapper _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <summary>

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -95,7 +95,10 @@ public class DivineAscensionModSystem : ModSystem
         // Initialize logging service FIRST (before any logging occurs)
         var loggingConfig = LoggingConfig.Default(); // or LoggingConfig.Silent()
         LoggingService.Instance.Initialize(api.Logger, loggingConfig);
-        
+
+        // ModSystem startup intentionally logs through the raw api.Logger: these lines run
+        // during Start/StartServerSide bootstrap, where the per-category ILoggerWrapper
+        // instances aren't created yet. Everything past initialization uses ILoggerWrapper.
         api.Logger.Notification("[DivineAscension] Mod loaded!");
 
         // Initialize profanity filter service

--- a/DivineAscension/Systems/BuffSystem/BuffManager.cs
+++ b/DivineAscension/Systems/BuffSystem/BuffManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using DivineAscension.API.Interfaces;
+using DivineAscension.Services;
 using DivineAscension.Systems.BuffSystem.Interfaces;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -13,10 +14,10 @@ namespace DivineAscension.Systems.BuffSystem;
 /// </summary>
 public class BuffManager : IBuffManager
 {
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly IWorldService _worldService;
 
-    public BuffManager(ILogger logger, IWorldService worldService)
+    public BuffManager(ILoggerWrapper logger, IWorldService worldService)
     {
         _logger = logger;
         _worldService = worldService;

--- a/DivineAscension/Systems/CooldownManager.cs
+++ b/DivineAscension/Systems/CooldownManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Data;
 using DivineAscension.Models.Enum;
+using DivineAscension.Services;
 using DivineAscension.Systems.Interfaces;
 using DivineAscension.Utilities;
 using Vintagestory.API.Common;
@@ -21,7 +22,7 @@ public class CooldownManager : ICooldownManager
     private readonly ModConfigData _config;
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<CooldownType, long>> _cooldowns = new();
     private readonly IEventService _eventService;
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly IWorldService _worldService;
     private long _cleanupCallbackId;
 
@@ -32,7 +33,7 @@ public class CooldownManager : ICooldownManager
     /// <param name="eventService">Event service for periodic callbacks</param>
     /// <param name="worldService">World service for player and time access</param>
     /// <param name="config">Mod configuration containing cooldown durations</param>
-    public CooldownManager(ILogger logger, IEventService eventService, IWorldService worldService, ModConfigData config)
+    public CooldownManager(ILoggerWrapper logger, IEventService eventService, IWorldService worldService, ModConfigData config)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -48,7 +48,6 @@ public static class DivineAscensionSystemInitializer
         api.Logger.Notification("[DivineAscension] Starting server-side system initialization...");
 
         // Create API wrapper services
-        var logger = api.Logger;
         var eventService = new ServerEventService(api.Event);
         var persistenceService = new ServerPersistenceService(api.WorldManager.SaveGame);
         var worldService = new ServerWorldService(api.World);
@@ -60,7 +59,8 @@ public static class DivineAscensionSystemInitializer
         LocalizationService.Instance.InitializeServer(api);
 
         // Initialize cooldown manager (early to prevent griefing attacks)
-        var cooldownManager = new CooldownManager(logger, eventService, worldService, modConfig);
+        var cooldownManager = new CooldownManager(LoggingService.Instance.CreateLogger("CooldownManager"),
+            eventService, worldService, modConfig);
         cooldownManager.Initialize();
 
         // Step 1: Clear any static event subscribers from previous loads
@@ -82,7 +82,8 @@ public static class DivineAscensionSystemInitializer
 
         api.RegisterEntityBehaviorClass("DivineAscensionBuffTracker", typeof(EntityBehaviorBuffTracker));
 
-        var religionManager = new ReligionManager(logger, eventService, persistenceService, worldService);
+        var religionManager = new ReligionManager(LoggingService.Instance.CreateLogger("ReligionManager"),
+            eventService, persistenceService, worldService);
         religionManager.Initialize();
 
         // Migrate existing religions with empty deity names (for backward compatibility)
@@ -259,7 +260,7 @@ public static class DivineAscensionSystemInitializer
         milestoneLoader.LoadMilestones();
 
         // Initialize Buff Manager (must be before AltarPrayerHandler)
-        var buffManager = new BuffManager(logger, worldService);
+        var buffManager = new BuffManager(LoggingService.Instance.CreateLogger("BuffManager"), worldService);
 
         // Create progression service facade (encapsulates favor, prestige, and activity logging)
         IPlayerProgressionService progressionService = new PlayerProgressionService(
@@ -402,7 +403,7 @@ public static class DivineAscensionSystemInitializer
 
         var religionCommands = new ReligionCommands(api, religionManager, playerReligionDataManager,
             religionPrestigeManager, networkService, roleManager, cooldownManager, messengerService, worldService,
-            logger);
+            LoggingService.Instance.CreateLogger("ReligionCommands"));
         religionCommands.RegisterCommands();
 
         var roleCommands =
@@ -411,7 +412,8 @@ public static class DivineAscensionSystemInitializer
 
         var civilizationCommands =
             new CivilizationCommands(api, civilizationManager, religionManager, playerReligionDataManager,
-                cooldownManager, messengerService, worldService, logger);
+                cooldownManager, messengerService, worldService,
+                LoggingService.Instance.CreateLogger("CivilizationCommands"));
         civilizationCommands.RegisterCommands();
 
         var holySiteCommands = new HolySiteCommands(
@@ -422,7 +424,6 @@ public static class DivineAscensionSystemInitializer
 
         // Create and initialize network handlers
         var playerDataHandler = new PlayerDataNetworkHandler(
-            logger,
             worldService,
             eventService,
             networkService,
@@ -450,7 +451,7 @@ public static class DivineAscensionSystemInitializer
             freeRespecWindow);
 
         var blessingHandler = new BlessingNetworkHandler(
-            logger,
+            LoggingService.Instance.CreateLogger("BlessingNetworkHandler"),
             blessingRegistry,
             blessingEffectSystem,
             playerReligionDataManager,
@@ -466,7 +467,7 @@ public static class DivineAscensionSystemInitializer
         blessingHandler.RegisterHandlers();
 
         var religionHandler = new ReligionNetworkHandler(
-            logger,
+            LoggingService.Instance.CreateLogger("ReligionNetworkHandler"),
             religionManager,
             playerReligionDataManager,
             roleManager,
@@ -477,7 +478,7 @@ public static class DivineAscensionSystemInitializer
         religionHandler.RegisterHandlers();
 
         var civilizationHandler = new CivilizationNetworkHandler(
-            logger,
+            LoggingService.Instance.CreateLogger("CivilizationNetworkHandler"),
             api,
             civilizationManager,
             religionManager,
@@ -488,7 +489,7 @@ public static class DivineAscensionSystemInitializer
         civilizationHandler.RegisterHandlers();
 
         var diplomacyHandler = new DiplomacyNetworkHandler(
-            logger,
+            LoggingService.Instance.CreateLogger("DiplomacyNetworkHandler"),
             diplomacyManager,
             civilizationManager,
             religionManager,
@@ -499,14 +500,14 @@ public static class DivineAscensionSystemInitializer
         diplomacyHandler.RegisterHandlers();
 
         var activityHandler = new ActivityNetworkHandler(
-            logger,
+            LoggingService.Instance.CreateLogger("ActivityNetworkHandler"),
             activityLogManager,
             religionManager,
             networkService);
         activityHandler.RegisterHandlers();
 
         var holySiteHandler = new HolySiteNetworkHandler(
-            logger,
+            LoggingService.Instance.CreateLogger("HolySiteNetworkHandler"),
             holySiteManager,
             religionManager,
             networkService,
@@ -515,7 +516,7 @@ public static class DivineAscensionSystemInitializer
         holySiteHandler.RegisterHandlers();
 
         var milestoneHandler = new MilestoneNetworkHandler(
-            logger,
+            LoggingService.Instance.CreateLogger("MilestoneNetworkHandler"),
             civilizationMilestoneManager,
             civilizationManager,
             religionManager,

--- a/DivineAscension/Systems/Networking/Server/ActivityNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/ActivityNetworkHandler.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Network;
+using DivineAscension.Services;
 using DivineAscension.Systems.Interfaces;
 using Vintagestory.API.Common;
 using Vintagestory.API.Server;
@@ -12,13 +13,13 @@ namespace DivineAscension.Systems.Networking.Server;
 /// </summary>
 public class ActivityNetworkHandler
 {
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly IActivityLogManager _activityLogManager;
     private readonly IReligionManager _religionManager;
     private readonly INetworkService _networkService;
 
     public ActivityNetworkHandler(
-        ILogger logger,
+        ILoggerWrapper logger,
         IActivityLogManager activityLogManager,
         IReligionManager religionManager,
         INetworkService networkService)

--- a/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/BlessingNetworkHandler.cs
@@ -24,7 +24,7 @@ public class BlessingNetworkHandler : IServerNetworkHandler
 {
     private static readonly IReadOnlyList<DeityDomain> AllDeities = DeityDomains.All;
 
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly BlessingRegistry _blessingRegistry;
     private readonly BlessingEffectSystem _blessingEffectSystem;
     private readonly IPlayerProgressionDataManager _playerProgressionDataManager;
@@ -39,7 +39,7 @@ public class BlessingNetworkHandler : IServerNetworkHandler
     private readonly IFreeRespecWindow _freeRespecWindow;
 
     public BlessingNetworkHandler(
-        ILogger logger,
+        ILoggerWrapper logger,
         BlessingRegistry blessingRegistry,
         BlessingEffectSystem blessingEffectSystem,
         IPlayerProgressionDataManager playerProgressionDataManager,

--- a/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/CivilizationNetworkHandler.cs
@@ -22,7 +22,7 @@ namespace DivineAscension.Systems.Networking.Server;
 /// </summary>
 [ExcludeFromCodeCoverage]
 public class CivilizationNetworkHandler(
-    ILogger logger,
+    ILoggerWrapper logger,
     ICoreServerAPI sapi,
     CivilizationManager civilizationManager,
     IReligionManager religionManager,
@@ -32,7 +32,7 @@ public class CivilizationNetworkHandler(
     ICivilizationMilestoneManager milestoneManager)
     : IServerNetworkHandler
 {
-    private readonly ILogger _logger = logger;
+    private readonly ILoggerWrapper _logger = logger;
     private readonly ICoreServerAPI _sapi = sapi;
     private readonly INetworkService _networkService = networkService;
     private readonly IDiplomacyManager _diplomacyManager = diplomacyManager;

--- a/DivineAscension/Systems/Networking/Server/DiplomacyNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/DiplomacyNetworkHandler.cs
@@ -23,7 +23,7 @@ namespace DivineAscension.Systems.Networking.Server;
 [ExcludeFromCodeCoverage]
 public class DiplomacyNetworkHandler : IServerNetworkHandler
 {
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly IDiplomacyManager _diplomacyManager;
     private readonly CivilizationManager _civilizationManager;
     private readonly IReligionManager _religionManager;
@@ -33,7 +33,7 @@ public class DiplomacyNetworkHandler : IServerNetworkHandler
     private readonly IWorldService _worldService;
 
     public DiplomacyNetworkHandler(
-        ILogger logger,
+        ILoggerWrapper logger,
         IDiplomacyManager diplomacyManager,
         CivilizationManager civilizationManager,
         IReligionManager religionManager,

--- a/DivineAscension/Systems/Networking/Server/HolySiteNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/HolySiteNetworkHandler.cs
@@ -23,14 +23,14 @@ namespace DivineAscension.Systems.Networking.Server;
 public class HolySiteNetworkHandler : IServerNetworkHandler
 {
     private readonly IHolySiteManager _holySiteManager;
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly INetworkService _networkService;
     private readonly IReligionManager _religionManager;
     private readonly IRitualProgressManager _ritualProgressManager;
     private readonly Services.Interfaces.IRitualLoader _ritualLoader;
 
     public HolySiteNetworkHandler(
-        ILogger logger,
+        ILoggerWrapper logger,
         IHolySiteManager holySiteManager,
         IReligionManager religionManager,
         INetworkService networkService,

--- a/DivineAscension/Systems/Networking/Server/MilestoneNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/MilestoneNetworkHandler.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using DivineAscension.API.Interfaces;
 using DivineAscension.Models;
 using DivineAscension.Network;
+using DivineAscension.Services;
 using DivineAscension.Services.Interfaces;
 using DivineAscension.Systems.Interfaces;
 using Vintagestory.API.Common;
@@ -14,7 +15,7 @@ namespace DivineAscension.Systems.Networking.Server;
 /// </summary>
 public class MilestoneNetworkHandler
 {
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly ICivilizationMilestoneManager _milestoneManager;
     private readonly ICivilizationManager _civilizationManager;
     private readonly IReligionManager _religionManager;
@@ -24,7 +25,7 @@ public class MilestoneNetworkHandler
     private readonly IBlessingRegistry _blessingRegistry;
 
     public MilestoneNetworkHandler(
-        ILogger logger,
+        ILoggerWrapper logger,
         ICivilizationMilestoneManager milestoneManager,
         ICivilizationManager civilizationManager,
         IReligionManager religionManager,

--- a/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/PlayerDataNetworkHandler.cs
@@ -25,7 +25,6 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
     private readonly IPlayerProgressionDataManager? _playerProgressionDataManager;
     private readonly IReligionManager? _religionManager;
     private readonly IReligionPrestigeManager? _religionPrestigeManager;
-    private readonly ILogger? _logger;
     private readonly IWorldService? _worldService;
     private readonly IEventService? _eventService;
     private readonly INetworkService? _networkService;
@@ -35,7 +34,7 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
     ///     Initialize the handler with all required dependencies.
     ///     This must be called before RegisterHandlers.
     /// </summary>
-    public PlayerDataNetworkHandler(ILogger logger,
+    public PlayerDataNetworkHandler(
         IWorldService worldService,
         IEventService eventService,
         INetworkService networkService,
@@ -44,7 +43,6 @@ public class PlayerDataNetworkHandler : IServerNetworkHandler
         IReligionPrestigeManager religionPrestigeManager,
         GameBalanceConfig config)
     {
-        _logger = logger;
         _worldService = worldService;
         _eventService = eventService;
         _networkService = networkService;

--- a/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
+++ b/DivineAscension/Systems/Networking/Server/ReligionNetworkHandler.cs
@@ -24,7 +24,7 @@ public class ReligionNetworkHandler : IServerNetworkHandler
     private readonly IPlayerProgressionDataManager _playerProgressionDataManager;
     private readonly IReligionManager _religionManager;
     private readonly IRoleManager _roleManager;
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly INetworkService _networkService;
     private readonly IPlayerMessengerService _messengerService;
     private readonly ICooldownManager _cooldownManager;
@@ -34,7 +34,7 @@ public class ReligionNetworkHandler : IServerNetworkHandler
     ///     Constructor for dependency injection
     /// </summary>
     public ReligionNetworkHandler(
-        ILogger logger,
+        ILoggerWrapper logger,
         IReligionManager religionManager,
         IPlayerProgressionDataManager playerProgressionDataManager,
         IRoleManager roleManager,

--- a/DivineAscension/Systems/ReligionManager.cs
+++ b/DivineAscension/Systems/ReligionManager.cs
@@ -22,7 +22,7 @@ public class ReligionManager : IReligionManager
     private const string DATA_KEY = "divineascension_religions";
     private const string INVITE_DATA_KEY = "divineascension_religion_invites";
     private readonly IEventService _eventService;
-    private readonly ILogger _logger;
+    private readonly ILoggerWrapper _logger;
     private readonly IPersistenceService _persistenceService;
     private readonly ConcurrentDictionary<string, string> _playerToReligionIndex = new();
     private readonly ConcurrentDictionary<string, ReligionData> _religions = new();
@@ -31,7 +31,7 @@ public class ReligionManager : IReligionManager
     private ReligionWorldData _inviteData = new();
 
     public ReligionManager(
-        ILogger logger,
+        ILoggerWrapper logger,
         IEventService eventService,
         IPersistenceService persistenceService,
         IWorldService worldService)


### PR DESCRIPTION
## Summary

Closes #619.

The 13 classes that still took a raw Vintage Story `ILogger` bypassed `LoggingConfig`, so their output couldn't be level- or category-filtered at runtime. This routes them through the existing `ILoggerWrapper` so all of them honor runtime logging config.

- **12 classes** swap ctor `ILogger` → `ILoggerWrapper`: `ReligionManager`, `CooldownManager`, `BuffManager`, `ReligionCommands`, `CivilizationCommands`, and the 7 server network handlers (`Blessing`, `Religion`, `Civilization`, `Diplomacy`, `Activity`, `HolySite`, `Milestone`). Added `using DivineAscension.Services;` to the 4 that lacked it.
- **`PlayerDataNetworkHandler`**: its `_logger` was assigned but never read — dropped the field/param entirely (and its construction arg).
- **`DivineAscensionSystemInitializer`**: each class now receives a per-category wrapper via `LoggingService.Instance.CreateLogger("<Name>")`; removed the now-unused `var logger = api.Logger`.
- **`DivineAscensionModSystem`**: startup still logs through raw `api.Logger` (those lines run before the wrappers exist) — now documented inline.

All 13 use only `Debug/Notification/Warning/Error`, every one present on `ILoggerWrapper`, so the swap is mechanical with no message changes. The `[DivineAscension]` prefixes are unchanged.

## Test plan

- Tests swap `Mock<ILogger>` → `Mock<ILoggerWrapper>` on the affected constructors; `Verify(l => l.Notification(...))` calls survive unchanged since the method names match.
- Command test helpers keep a separate `ILogger` mock for `api.Logger` and add a wrapper mock for the injected logger; the "commands registered" assertion now targets the wrapper.
- Added `Mock<ILoggerWrapper>` overloads of `TestFixtures.VerifyLoggerNotification/Debug`.
- `dotnet build` (main + tests): 0 errors.
- `dotnet test`: **2527 passed, 0 failed**.
- Final audit: no production class outside `LoggingService.cs` references the raw `ILogger` type.

## Out of scope

Structured logging, audit-level logging, and exposing `LoggingConfig` to admins (tracked in #620) are not part of this change.
