### PR TITLE
feat(logging): admin logging toggles in GameBalanceConfig

### DIFF
--- a/DivineAscension.Tests/Configuration/GameBalanceConfigResetTests.cs
+++ b/DivineAscension.Tests/Configuration/GameBalanceConfigResetTests.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+
+namespace DivineAscension.Tests.Configuration;
+
+/// <summary>
+///     CopyFrom resets values in place without replacing the instance (#620). ConfigLib holds a
+///     reference to the registered config and writes GUI changes into it; the validation-failure
+///     fallback must reset that same object, not swap it, or every later config change is stranded.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class GameBalanceConfigResetTests
+{
+    [Fact]
+    public void CopyFrom_ResetsValuesInPlaceForExistingReferenceHolders()
+    {
+        var config = new GameBalanceConfig
+        {
+            EnableDebugLogs = false,
+            DeathPenalty = 999,
+            PassiveFavorRate = 9f
+        };
+
+        // Simulates ConfigLib (and the mod) holding a reference to the registered instance.
+        var heldReference = config;
+
+        config.CopyFrom(new GameBalanceConfig());
+
+        // Same object, defaults restored — the holder sees the reset.
+        Assert.Same(config, heldReference);
+        Assert.True(heldReference.EnableDebugLogs);
+        Assert.Equal(50, heldReference.DeathPenalty);
+        Assert.Equal(0.5f, heldReference.PassiveFavorRate);
+    }
+
+    [Fact]
+    public void CopyFrom_CopiesProvidedValues()
+    {
+        var target = new GameBalanceConfig();
+        var source = new GameBalanceConfig
+        {
+            EnableErrorLogs = false,
+            DeathPenalty = 123
+        };
+
+        target.CopyFrom(source);
+
+        Assert.False(target.EnableErrorLogs);
+        Assert.Equal(123, target.DeathPenalty);
+    }
+}

--- a/DivineAscension.Tests/Configuration/LoggingConfigTests.cs
+++ b/DivineAscension.Tests/Configuration/LoggingConfigTests.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+
+namespace DivineAscension.Tests.Configuration;
+
+[ExcludeFromCodeCoverage]
+public class LoggingConfigTests
+{
+    [Fact]
+    public void GameBalanceConfig_DefaultsToAllLevelsEnabled()
+    {
+        // No-config / legacy worlds must keep full logging.
+        var config = new GameBalanceConfig();
+
+        Assert.True(config.EnableDebugLogs);
+        Assert.True(config.EnableNotificationLogs);
+        Assert.True(config.EnableWarningLogs);
+        Assert.True(config.EnableErrorLogs);
+    }
+
+    [Fact]
+    public void BuildLoggingConfig_MapsTogglesToLevels()
+    {
+        var config = new GameBalanceConfig
+        {
+            EnableDebugLogs = false,
+            EnableNotificationLogs = false,
+            EnableWarningLogs = true,
+            EnableErrorLogs = true
+        };
+
+        var logging = config.BuildLoggingConfig();
+
+        Assert.False(logging.EnableDebug);
+        Assert.False(logging.EnableNotification);
+        Assert.True(logging.EnableWarning);
+        Assert.True(logging.EnableError);
+    }
+
+    [Fact]
+    public void BuildLoggingConfig_AllTogglesOff_IsCompletelySilent()
+    {
+        var config = new GameBalanceConfig
+        {
+            EnableDebugLogs = false,
+            EnableNotificationLogs = false,
+            EnableWarningLogs = false,
+            EnableErrorLogs = false
+        };
+
+        var logging = config.BuildLoggingConfig();
+
+        Assert.False(logging.EnableDebug);
+        Assert.False(logging.EnableNotification);
+        Assert.False(logging.EnableWarning);
+        Assert.False(logging.EnableError);
+        // Event/Build/Chat follow the notification toggle, so silence is total.
+        Assert.False(logging.EnableEvent);
+        Assert.False(logging.EnableBuild);
+        Assert.False(logging.EnableChat);
+    }
+
+    [Fact]
+    public void BuildLoggingConfig_IsIndependentOfBalanceValidation()
+    {
+        // A balance-invalid config (out-of-order favor thresholds) must still produce the
+        // requested logging levels — OnConfigChanged applies logging before Validate() so a bad
+        // balance value saved in the same batch cannot leave the logs un-silenced (#620 regression).
+        var config = new GameBalanceConfig
+        {
+            DiscipleThreshold = 999999, // breaks the ascending-threshold rule
+            EnableDebugLogs = false
+        };
+
+        Assert.Throws<System.InvalidOperationException>(() => config.Validate());
+        Assert.False(config.BuildLoggingConfig().EnableDebug);
+    }
+
+    [Fact]
+    public void CopyFrom_OverwritesLevelTogglesInPlace()
+    {
+        var target = LoggingConfig.Default();
+
+        target.CopyFrom(LoggingConfig.Silent());
+
+        Assert.False(target.EnableError);
+        Assert.False(target.EnableNotification);
+    }
+
+    [Fact]
+    public void CopyFrom_CopiesCategoryFiltersWithoutSharingReferences()
+    {
+        var source = LoggingConfig.Default();
+        source.ExcludedCategories.Add("ReligionManager");
+        var target = LoggingConfig.Default();
+
+        target.CopyFrom(source);
+
+        Assert.Contains("ReligionManager", target.ExcludedCategories);
+        // Mutating the source afterwards must not bleed into the target.
+        source.ExcludedCategories.Add("FavorSystem");
+        Assert.DoesNotContain("FavorSystem", target.ExcludedCategories);
+    }
+}

--- a/DivineAscension.Tests/Services/LoggingServiceTests.cs
+++ b/DivineAscension.Tests/Services/LoggingServiceTests.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.Configuration;
+using DivineAscension.Services;
+using Moq;
+using Vintagestory.API.Common;
+
+namespace DivineAscension.Tests.Services;
+
+/// <summary>
+///     Verifies the admin-facing logging toggles (#620): ApplyConfig mutates the shared config in
+///     place so loggers already handed out honor the new levels without a restart — this is the
+///     path the live ConfigLib GUI change drives via OnConfigChanged.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class LoggingServiceTests
+{
+    [Fact]
+    public void ApplyConfig_Silent_SuppressesAlreadyCreatedLogger()
+    {
+        var underlying = new Mock<ILogger>();
+        LoggingService.Instance.Initialize(underlying.Object, LoggingConfig.Default());
+
+        // Logger handed out BEFORE the config change (mirrors systems built at startup).
+        var logger = LoggingService.Instance.CreateLogger("FavorSystem");
+        logger.Notification("before");
+        underlying.Verify(l => l.Notification("before"), Times.Once);
+
+        LoggingService.Instance.ApplyConfig(LoggingConfig.Silent());
+
+        logger.Notification("after");
+        logger.Debug("after");
+        logger.Error("after");
+
+        underlying.Verify(l => l.Notification("after"), Times.Never);
+        underlying.Verify(l => l.Debug("after"), Times.Never);
+        underlying.Verify(l => l.Error("after"), Times.Never);
+    }
+
+    [Fact]
+    public void ApplyConfig_FromGameBalanceToggles_TakesEffectLive()
+    {
+        var underlying = new Mock<ILogger>();
+        LoggingService.Instance.Initialize(underlying.Object, LoggingConfig.Default());
+        var logger = LoggingService.Instance.CreateLogger("FavorSystem");
+
+        // Admin unchecks debug + notification in the ConfigLib GUI, keeps warning + error.
+        var balance = new GameBalanceConfig
+        {
+            EnableDebugLogs = false,
+            EnableNotificationLogs = false,
+            EnableWarningLogs = true,
+            EnableErrorLogs = true
+        };
+        LoggingService.Instance.ApplyConfig(balance.BuildLoggingConfig());
+
+        logger.Debug("d");
+        logger.Error("e");
+
+        underlying.Verify(l => l.Debug("d"), Times.Never);
+        underlying.Verify(l => l.Error("e"), Times.Once);
+    }
+
+    [Fact]
+    public void ApplyConfig_AfterReInitialize_StillSuppressesExistingLogger()
+    {
+        // Single-player runs client AND server ModSystems in one process, both calling Initialize on
+        // this shared singleton. The second Initialize must not strand loggers handed out after the
+        // first — otherwise a Silent applied later never reaches them (the actual #620 field bug).
+        var underlying = new Mock<ILogger>();
+        LoggingService.Instance.Initialize(underlying.Object, LoggingConfig.Default());
+        var logger = LoggingService.Instance.CreateLogger("FavorSystem");
+
+        // Other game side re-initializes the singleton with a fresh Default config.
+        LoggingService.Instance.Initialize(underlying.Object, LoggingConfig.Default());
+
+        LoggingService.Instance.ApplyConfig(LoggingConfig.Silent());
+
+        logger.Debug("after");
+        logger.Notification("after");
+        underlying.Verify(l => l.Debug("after"), Times.Never);
+        underlying.Verify(l => l.Notification("after"), Times.Never);
+    }
+
+    [Fact]
+    public void ApplyConfig_BackToDefault_RestoresLogging()
+    {
+        var underlying = new Mock<ILogger>();
+        LoggingService.Instance.Initialize(underlying.Object, LoggingConfig.Default());
+        var logger = LoggingService.Instance.CreateLogger("FavorSystem");
+
+        LoggingService.Instance.ApplyConfig(LoggingConfig.Silent());
+        LoggingService.Instance.ApplyConfig(LoggingConfig.Default());
+
+        logger.Notification("restored");
+
+        underlying.Verify(l => l.Notification("restored"), Times.Once);
+    }
+}

--- a/DivineAscension/Configuration/GameBalanceConfig.cs
+++ b/DivineAscension/Configuration/GameBalanceConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace DivineAscension.Configuration;
 
@@ -213,6 +214,62 @@ public class GameBalanceConfig
 
     /// <summary>Favor/Prestige multiplier for Tier 3 holy sites (default: 1.75)</summary>
     public float HolySiteTier3Multiplier { get; set; } = 1.75f;
+
+    // === LOGGING ===
+    //
+    // Per-level toggles for the mod's category loggers. Booleans render as checkboxes in the
+    // ConfigLib GUI and round-trip reliably through YAML. Defaults are all-on, matching prior
+    // behaviour. Uncheck all four for complete silence. Applied at startup and re-applied live
+    // when changed via the ConfigLib GUI. Event/Build/Chat levels follow the notification toggle.
+
+    /// <summary>Enable Debug-level logs — verbose, highest volume (default: true).</summary>
+    public bool EnableDebugLogs { get; set; } = true;
+
+    /// <summary>Enable Notification-level logs — startup and major events (default: true).</summary>
+    public bool EnableNotificationLogs { get; set; } = true;
+
+    /// <summary>Enable Warning-level logs (default: true).</summary>
+    public bool EnableWarningLogs { get; set; } = true;
+
+    /// <summary>Enable Error-level logs — recommended to keep on (default: true).</summary>
+    public bool EnableErrorLogs { get; set; } = true;
+
+    /// <summary>
+    /// Builds the <see cref="LoggingConfig" /> described by the per-level toggles above.
+    /// Event/Build/Chat (rarely used) follow the notification toggle.
+    /// </summary>
+    public LoggingConfig BuildLoggingConfig()
+    {
+        return new LoggingConfig
+        {
+            EnableDebug = EnableDebugLogs,
+            EnableNotification = EnableNotificationLogs,
+            EnableWarning = EnableWarningLogs,
+            EnableError = EnableErrorLogs,
+            EnableEvent = EnableNotificationLogs,
+            EnableBuild = EnableNotificationLogs,
+            EnableChat = EnableNotificationLogs
+        };
+    }
+
+    // === RESET ===
+
+    /// <summary>
+    /// Copies every settable property from <paramref name="other" /> into this instance.
+    /// Used to reset to defaults in place after a failed validation WITHOUT replacing the object
+    /// reference — ConfigLib holds a reference to the registered instance and writes GUI changes
+    /// into it, so swapping the reference would strand ConfigLib's updates on an orphaned object.
+    /// </summary>
+    public void CopyFrom(GameBalanceConfig other)
+    {
+        foreach (var property in typeof(GameBalanceConfig).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (property.CanRead && property.CanWrite)
+            {
+                property.SetValue(this, property.GetValue(other));
+            }
+        }
+    }
 
     // === VALIDATION ===
 

--- a/DivineAscension/Configuration/LoggingConfig.cs
+++ b/DivineAscension/Configuration/LoggingConfig.cs
@@ -124,4 +124,22 @@ public class LoggingConfig
     {
         return new LoggingConfig();
     }
+
+    /// <summary>
+    ///     Copies the level toggles and category filters from another config into this instance,
+    ///     mutating it in place. Lets a shared config object be re-tuned at runtime without
+    ///     replacing the reference held by already-created logger wrappers.
+    /// </summary>
+    public void CopyFrom(LoggingConfig other)
+    {
+        EnableDebug = other.EnableDebug;
+        EnableNotification = other.EnableNotification;
+        EnableWarning = other.EnableWarning;
+        EnableError = other.EnableError;
+        EnableEvent = other.EnableEvent;
+        EnableBuild = other.EnableBuild;
+        EnableChat = other.EnableChat;
+        ExcludedCategories = new HashSet<string>(other.ExcludedCategories);
+        IncludedCategories = new HashSet<string>(other.IncludedCategories);
+    }
 }

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -92,8 +92,10 @@ public class DivineAscensionModSystem : ModSystem
     public override void Start(ICoreAPI api)
     {
         base.Start(api);
-        // Initialize logging service FIRST (before any logging occurs)
-        var loggingConfig = LoggingConfig.Default(); // or LoggingConfig.Silent()
+        // Initialize logging service FIRST (before any logging occurs). Starts fully enabled for
+        // early bootstrap; the admin's GameBalanceConfig logging toggles are applied below once
+        // ConfigLib has loaded the config.
+        var loggingConfig = LoggingConfig.Default();
         LoggingService.Instance.Initialize(api.Logger, loggingConfig);
 
         // ModSystem startup intentionally logs through the raw api.Logger: these lines run
@@ -141,8 +143,18 @@ public class DivineAscensionModSystem : ModSystem
         catch (Exception ex)
         {
             api.Logger.Error($"[DivineAscension] Config validation failed: {ex.Message}. Using defaults.");
-            _gameBalanceConfig = new GameBalanceConfig(); // Reset to defaults
+            // Reset values IN PLACE — never replace the instance, ConfigLib holds a reference to it
+            // and writes GUI changes into it. Swapping it strands every later config change.
+            _gameBalanceConfig.CopyFrom(new GameBalanceConfig());
         }
+
+        // Apply the admin-selected logging levels now that ConfigLib (if present) has populated
+        // the config. Early bootstrap above logs at full verbosity since the toggles aren't known yet.
+        LoggingService.Instance.ApplyConfig(_gameBalanceConfig.BuildLoggingConfig());
+        api.Logger.Notification(
+            $"[DivineAscension] Logging levels — Debug:{_gameBalanceConfig.EnableDebugLogs} " +
+            $"Notification:{_gameBalanceConfig.EnableNotificationLogs} Warning:{_gameBalanceConfig.EnableWarningLogs} " +
+            $"Error:{_gameBalanceConfig.EnableErrorLogs}");
 
         // Register network channel and message types
         api.Network.RegisterChannel(NETWORK_CHANNEL)
@@ -504,9 +516,9 @@ public class DivineAscensionModSystem : ModSystem
                 "divineascension", // domain (string)
                 _gameBalanceConfig, // configObject (object)
                 null, // path (string?) - optional, use default
-                null, // onSyncedFromServer (Action?) - optional
+                (Action)OnConfigReloaded, // onSyncedFromServer - re-apply logging after a server sync
                 (Action<string>)OnConfigChanged, // onSettingChanged (Action<string>?) - our callback
-                null // onConfigSaved (Action?) - optional
+                (Action)OnConfigReloaded // onConfigSaved - re-apply logging after a GUI save
             });
 
             api.Logger.Notification(
@@ -520,10 +532,25 @@ public class DivineAscensionModSystem : ModSystem
     }
 
     /// <summary>
+    /// Called by ConfigLib after the config is saved (GUI edit) or synced from the server.
+    /// Re-applies logging levels regardless of which callback ConfigLib uses for the change.
+    /// </summary>
+    private void OnConfigReloaded()
+    {
+        LoggingService.Instance.ApplyConfig(_gameBalanceConfig.BuildLoggingConfig());
+    }
+
+    /// <summary>
     /// Called by ConfigLib when configuration settings change at runtime.
     /// </summary>
     private void OnConfigChanged(string settingCode)
     {
+        // Re-apply logging levels FIRST and unconditionally. Logging is independent of balance
+        // validation, so an invalid balance value (e.g. out-of-order thresholds changed in the same
+        // save) must not throw past this and leave the logs un-silenced. ApplyConfig mutates the
+        // shared LoggingConfig in place, so loggers already handed out pick up the change live.
+        LoggingService.Instance.ApplyConfig(_gameBalanceConfig.BuildLoggingConfig());
+
         try
         {
             foreach (var adjustment in _gameBalanceConfig.ClampBlessingSlots())

--- a/DivineAscension/Services/LoggingService.cs
+++ b/DivineAscension/Services/LoggingService.cs
@@ -39,6 +39,21 @@ public class LoggingService
     }
 
     /// <summary>
+    ///     The current logging configuration. Wrappers read this live on every call, so config
+    ///     changes (or a re-Initialize from the other game side) take effect immediately.
+    /// </summary>
+    internal LoggingConfig CurrentConfig => _config;
+
+    /// <summary>
+    ///     Applies new logging settings to the live configuration, mutating the current config
+    ///     instance in place so loggers already handed out reflect the change without a restart.
+    /// </summary>
+    public void ApplyConfig(LoggingConfig source)
+    {
+        _config.CopyFrom(source ?? throw new ArgumentNullException(nameof(source)));
+    }
+
+    /// <summary>
     ///     Create a logger wrapper for a specific category.
     /// </summary>
     public ILoggerWrapper CreateLogger(string category)
@@ -48,7 +63,7 @@ public class LoggingService
             throw new InvalidOperationException("LoggingService must be initialized before creating loggers");
         }
 
-        return new LoggerWrapper(_logger, _config, category);
+        return new LoggerWrapper(this, _logger, category);
     }
 
     /// <summary>
@@ -79,76 +94,88 @@ public interface ILoggerWrapper
 /// </summary>
 internal class LoggerWrapper : ILoggerWrapper
 {
+    private readonly LoggingService _service;
     private readonly ILogger _logger;
-    private readonly LoggingConfig _config;
     private readonly string _category;
 
-    public LoggerWrapper(ILogger logger, LoggingConfig config, string category)
+    public LoggerWrapper(LoggingService service, ILogger logger, string category)
     {
+        _service = service;
         _logger = logger;
-        _config = config;
         _category = category;
     }
 
+    // Read the config LIVE on every call instead of snapshotting it at construction. The service
+    // is a process-wide singleton that both the client and server ModSystem initialize, and runtime
+    // config changes mutate it — a captured reference would go stale and ignore those updates.
+    private LoggingConfig Config => _service.CurrentConfig;
+
     public void Debug(string message)
     {
-        if (!_config.EnableDebug) return;
-        if (IsFilteredOut()) return;
+        var config = Config;
+        if (!config.EnableDebug) return;
+        if (IsFilteredOut(config)) return;
         _logger.Debug(message);
     }
 
     public void Notification(string message)
     {
-        if (!_config.EnableNotification) return;
-        if (IsFilteredOut()) return;
+        var config = Config;
+        if (!config.EnableNotification) return;
+        if (IsFilteredOut(config)) return;
         _logger.Notification(message);
     }
 
     public void Warning(string message)
     {
-        if (!_config.EnableWarning) return;
-        if (IsFilteredOut()) return;
+        var config = Config;
+        if (!config.EnableWarning) return;
+        if (IsFilteredOut(config)) return;
         _logger.Warning(message);
     }
 
     public void Error(string message)
     {
-        if (!_config.EnableError) return;
-        if (IsFilteredOut()) return;
+        var config = Config;
+        if (!config.EnableError) return;
+        if (IsFilteredOut(config)) return;
         _logger.Error(message);
     }
 
     public void Event(string message)
     {
-        if (!_config.EnableEvent) return;
-        if (IsFilteredOut()) return;
+        var config = Config;
+        if (!config.EnableEvent) return;
+        if (IsFilteredOut(config)) return;
         _logger.Event(message);
     }
 
     public void Build(string message)
     {
-        if (!_config.EnableBuild) return;
-        if (IsFilteredOut()) return;
+        var config = Config;
+        if (!config.EnableBuild) return;
+        if (IsFilteredOut(config)) return;
         _logger.Build(message);
     }
 
     public void Chat(string message)
     {
-        if (!_config.EnableChat) return;
-        if (IsFilteredOut()) return;
+        var config = Config;
+        if (!config.EnableChat) return;
+        if (IsFilteredOut(config)) return;
         _logger.Chat(message);
     }
 
-    private bool IsFilteredOut()
+    private bool IsFilteredOut(LoggingConfig config)
     {
         // Check if this category is in the excluded categories list
-        if (_config.ExcludedCategories.Contains(_category))
+        if (config.ExcludedCategories.Contains(_category))
         {
             return true;
         }
 
         // Check if this category is in the included categories list (if list is not empty)
-        if (_config.IncludedCategories.Count > 0 && !_config.IncludedCategories.Contains(_category))
+        if (config.IncludedCategories.Count > 0 && !config.IncludedCategories.Contains(_category))
         {
             return true;
         }

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -101,6 +101,17 @@ Rate-limits destructive operations to prevent griefing.
 
 ---
 
+## Logging
+
+Control how much the mod logs with four per-level toggles in
+`ModConfig/divineascension.yaml` (requires [ConfigLib](https://mods.vintagestory.at/configlib)):
+`EnableDebugLogs`, `EnableNotificationLogs`, `EnableWarningLogs`, `EnableErrorLogs`
+(all default `true`). Uncheck all four for complete silence. Changes made via the
+ConfigLib GUI apply live. See
+[topics/configuration/logging.md](topics/configuration/logging.md) for details.
+
+---
+
 ## Data Files
 
 Customize blessings, offerings, and rituals via JSON files in `assets/divineascension/config/`.

--- a/docs/topics/configuration/logging.md
+++ b/docs/topics/configuration/logging.md
@@ -1,339 +1,140 @@
 # Logging Configuration Guide
 
-This guide explains how to control Divine Ascension's logging output using the new `LoggingService`.
+Divine Ascension routes its logging through a central `LoggingService` so server
+admins can dial verbosity up or down without editing source. This guide covers
+the admin-facing knob and the developer internals behind it.
 
-## Overview
+## For server admins
 
-Divine Ascension has extensive logging (~550+ log statements) for debugging and monitoring. The `LoggingService` provides centralized control over what gets logged without modifying individual log statements.
+### The logging toggles
 
-## Quick Start
+Logging is controlled by four per-level checkboxes in the mod's
+ConfigLib-managed config (`ModConfig/divineascension.yaml`):
 
-### 1. Disable ALL Logging (Complete Silence)
+| Setting                  | What it controls                         |
+|--------------------------|------------------------------------------|
+| `EnableDebugLogs`        | Verbose debug logs (highest volume)      |
+| `EnableNotificationLogs` | Startup and major events                 |
+| `EnableWarningLogs`      | Warnings                                 |
+| `EnableErrorLogs`        | Errors                                   |
 
-```csharp
-// In DivineAscensionModSystem.Start()
-LoggingService.Instance.Initialize(api.Logger, LoggingConfig.Silent());
+All default to `true`, so existing worlds and no-config setups keep full
+logging. **Uncheck all four for complete silence.** Common combos:
+
+- **Drop debug noise:** `EnableDebugLogs: false`, rest `true`.
+- **Errors only:** only `EnableWarningLogs` + `EnableErrorLogs` `true`.
+- **Silent:** all four `false`.
+
+(The rarely-used Event/Build/Chat levels follow `EnableNotificationLogs`.)
+
+### Changing it
+
+- **With [ConfigLib](https://mods.vintagestory.at/configlib) installed:** toggle
+  the checkboxes in the in-game config GUI, or edit
+  `ModConfig/divineascension.yaml`. GUI changes apply **live** — no restart.
+- **Without ConfigLib:** the mod uses the all-on defaults. ConfigLib owns the
+  YAML file and GUI, so it's required to change the values.
+
+```yaml
+# ModConfig/divineascension.yaml — errors and warnings only
+EnableDebugLogs: false
+EnableNotificationLogs: false
+EnableWarningLogs: true
+EnableErrorLogs: true
 ```
 
-### 2. Only Log Errors and Warnings
+> Note: a handful of bootstrap lines (mod loaded, Harmony patches, ConfigLib
+> status) are emitted very early in startup, before the toggles have been read,
+> and always print. Everything logged after initialization honors the toggles.
 
-```csharp
-LoggingService.Instance.Initialize(api.Logger, LoggingConfig.ErrorsOnly());
-```
+## How it works
 
-### 3. Disable Debug Logs Only (Recommended)
+`LoggingService` wraps Vintage Story's `ILogger`. Each system is handed an
+`ILoggerWrapper` (created via `LoggingService.Instance.CreateLogger("Category")`)
+that checks a shared `LoggingConfig` before forwarding to the underlying logger,
+so disabled levels short-circuit before any string formatting or I/O.
 
-```csharp
-LoggingService.Instance.Initialize(api.Logger, LoggingConfig.NoDebug());
-```
+`DivineAscensionModSystem.Start()` initializes the service with full logging (so
+early bootstrap works), then calls
+`LoggingService.Instance.ApplyConfig(_gameBalanceConfig.BuildLoggingConfig())`
+once ConfigLib has populated the config. `ApplyConfig` **mutates the shared
+`LoggingConfig` in place** rather than swapping the reference, so loggers already
+handed out pick up the change — this is what makes the live update in
+`OnConfigChanged` work.
 
-### 4. Custom Configuration
+> The toggles are plain booleans on purpose: ConfigLib renders them as
+> checkboxes and round-trips them through YAML reliably. (An earlier enum-based
+> "verbosity preset" field didn't get an editable control in the ConfigLib GUI,
+> so live changes never reached the config.)
 
-```csharp
-var config = new LoggingConfig
-{
-    EnableDebug = false,           // Disable verbose debug logs
-    EnableNotification = true,     // Keep startup/major events
-    EnableWarning = true,          // Keep warnings
-    EnableError = true,            // Always keep errors (recommended)
-    ExcludedCategories = new HashSet<string> { "FavorSystem", "GUI" } // Silence specific systems
-};
+### Category filtering (code-level)
 
-LoggingService.Instance.Initialize(api.Logger, config);
-```
-
-## Integration Steps
-
-### Phase 1: Initialize LoggingService (No Code Changes Required)
-
-**File:** `DivineAscension/DivineAscensionModSystem.cs`
-
-Add to `Start()` method:
-
-```csharp
-public override void Start(ICoreAPI api)
-{
-    base.Start(api);
-
-    // Initialize logging service FIRST (before any logging occurs)
-    var loggingConfig = LoggingConfig.NoDebug(); // or LoggingConfig.Silent()
-    LoggingService.Instance.Initialize(api.Logger, loggingConfig);
-
-    api.Logger.Notification("[DivineAscension] Mod loaded!");
-    // ... rest of Start() method
-}
-```
-
-**Benefits of Phase 1:**
-- ✅ LoggingService is initialized and ready
-- ✅ Can be configured via code
-- ⚠️ Existing `_logger` and `api.Logger` calls still bypass the service
-
-### Phase 2: Migrate Systems to Use LoggingService (Gradual Refactor)
-
-Replace `ILogger` constructor parameters with `ILoggerWrapper`:
-
-**Before:**
-```csharp
-public class ReligionManager
-{
-    private readonly ILogger _logger;
-
-    public ReligionManager(ILogger logger, ...)
-    {
-        _logger = logger;
-    }
-
-    public void Initialize()
-    {
-        _logger.Notification("[DivineAscension] Initializing Religion Manager...");
-        _logger.Debug($"[DivineAscension] Loaded {count} religions");
-    }
-}
-```
-
-**After:**
-```csharp
-public class ReligionManager
-{
-    private readonly ILoggerWrapper _logger;
-
-    public ReligionManager(ILoggerWrapper logger, ...)
-    {
-        _logger = logger;
-    }
-
-    public void Initialize()
-    {
-        _logger.Notification("[DivineAscension] Initializing Religion Manager...");
-        _logger.Debug($"[DivineAscension] Loaded {count} religions");
-    }
-}
-```
-
-**Update initialization in `DivineAscensionSystemInitializer.cs`:**
-
-```csharp
-// Create wrapped logger for each manager
-var religionLogger = LoggingService.Instance.CreateLogger("ReligionManager");
-var favorLogger = LoggingService.Instance.CreateLogger("FavorSystem");
-var guiLogger = LoggingService.Instance.CreateLogger("GUI");
-
-var religionManager = new ReligionManager(
-    religionLogger,  // ILoggerWrapper instead of ILogger
-    eventService,
-    persistenceService,
-    worldService
-);
-
-var favorSystem = new FavorSystem(
-    favorLogger,
-    eventService,
-    worldService,
-    // ...
-);
-```
-
-**Benefits of Phase 2:**
-- ✅ Full logging control at category level
-- ✅ Zero runtime overhead when logging is disabled
-- ✅ Can filter by system (e.g., silence GUI but keep ReligionManager)
-- ⚠️ Requires changing ~50 constructor signatures
-
-### Phase 3: Add ConfigLib Integration (Optional)
-
-Make logging configurable via in-game GUI:
-
-**File:** `DivineAscension/Configuration/GameBalanceConfig.cs`
-
-```csharp
-public class GameBalanceConfig
-{
-    // ... existing config fields ...
-
-    [Category("Logging")]
-    [Description("Enable debug logs (verbose, may impact performance)")]
-    public bool EnableDebugLogs { get; set; } = false;
-
-    [Category("Logging")]
-    [Description("Enable notification logs (startup, major events)")]
-    public bool EnableNotificationLogs { get; set; } = true;
-
-    [Category("Logging")]
-    [Description("Enable warning logs")]
-    public bool EnableWarningLogs { get; set; } = true;
-
-    [Category("Logging")]
-    [Description("Enable error logs (highly recommended to keep enabled)")]
-    public bool EnableErrorLogs { get; set; } = true;
-}
-```
-
-**Update `OnConfigChanged()` in `DivineAscensionModSystem.cs`:**
-
-```csharp
-private void OnConfigChanged(string settingCode)
-{
-    try
-    {
-        _gameBalanceConfig.Validate();
-
-        // Update logging configuration dynamically
-        if (settingCode.StartsWith("Enable") && settingCode.EndsWith("Logs"))
-        {
-            var loggingConfig = new LoggingConfig
-            {
-                EnableDebug = _gameBalanceConfig.EnableDebugLogs,
-                EnableNotification = _gameBalanceConfig.EnableNotificationLogs,
-                EnableWarning = _gameBalanceConfig.EnableWarningLogs,
-                EnableError = _gameBalanceConfig.EnableErrorLogs
-            };
-
-            LoggingService.Instance.UpdateConfig(loggingConfig);
-            _sapi?.Logger.Notification($"[DivineAscension] Logging configuration updated");
-        }
-
-        _sapi?.Logger.Notification($"[DivineAscension] Configuration updated: {settingCode}");
-    }
-    catch (Exception ex)
-    {
-        _sapi?.Logger.Error($"[DivineAscension] Config validation failed after update: {ex.Message}");
-    }
-}
-```
-
-**Benefits of Phase 3:**
-- ✅ In-game configuration via ConfigLib GUI
-- ✅ Runtime changes without restart
-- ✅ Per-world settings
-- ⚠️ Requires ConfigLib mod installed
-
-## Configuration Examples
-
-### Example 1: Production Server (Minimal Logging)
-
-```csharp
-var config = new LoggingConfig
-{
-    EnableDebug = false,       // No verbose logs
-    EnableNotification = false, // No startup spam
-    EnableWarning = true,      // Keep warnings
-    EnableError = true         // Always log errors
-};
-```
-
-### Example 2: Debug Specific System
+`LoggingConfig` also supports per-category whitelist/blacklist filtering via
+`IncludedCategories` / `ExcludedCategories`. These are not yet surfaced in the
+ConfigLib GUI (presets only); they're available to code and tests:
 
 ```csharp
 var config = new LoggingConfig
 {
     EnableDebug = true,
-    IncludedCategories = new HashSet<string> { "ReligionManager", "HolySiteManager" }
-    // Only these two systems will produce debug logs
+    ExcludedCategories = new HashSet<string> { "GUI", "FavorSystem" } // silence the noisiest
 };
+LoggingService.Instance.UpdateConfig(config);
 ```
 
-### Example 3: Silence Noisy Systems
+## Performance
 
-```csharp
-var config = new LoggingConfig
-{
-    EnableDebug = true,
-    ExcludedCategories = new HashSet<string> { "GUI", "FavorSystem", "NetworkHandler" }
-    // Everything except these will log
-};
-```
+When a level is disabled the wrapper returns before formatting the message, so a
+silenced log statement costs almost nothing (no string allocation, no I/O).
 
-## Performance Impact
+| Configuration | Log statements/sec | Log file growth |
+|---------------|--------------------|-----------------|
+| `Default`     | ~50–200            | ~1–5 MB/hour    |
+| `NoDebug`     | ~10–30             | ~100–500 KB/hour|
+| `ErrorsOnly`  | ~0–5               | ~10–50 KB/hour  |
+| `Silent`      | 0                  | 0               |
 
-### Without LoggingService
-- All log statements execute string formatting and I/O
-- ~550 log statements active every session
-- Debug logs can spam console (especially favor tracking)
+## Category names reference
 
-### With LoggingService (Logging Disabled)
-- Zero overhead: early return before string formatting
-- No I/O operations
-- No string allocations
-- Estimated performance gain: 2-5% CPU reduction on busy servers
+Useful category names for `IncludedCategories` / `ExcludedCategories` filtering:
 
-### Benchmarks (Estimated)
-
-| Configuration | Log Statements/sec | CPU Impact | Log File Growth |
-|--------------|-------------------|------------|-----------------|
-| All Enabled | ~50-200 | Moderate | ~1-5 MB/hour |
-| NoDebug | ~10-30 | Low | ~100-500 KB/hour |
-| ErrorsOnly | ~0-5 | Minimal | ~10-50 KB/hour |
-| Silent | 0 | None | 0 |
-
-## Migration Checklist
-
-- [ ] Phase 1: Initialize `LoggingService` in `DivineAscensionModSystem.Start()`
-- [ ] Choose initial configuration (`Silent()`, `NoDebug()`, etc.)
-- [ ] Test that mod still loads and functions
-- [ ] (Optional) Phase 2: Migrate high-volume systems first (FavorSystem, GUI)
-- [ ] (Optional) Phase 2: Migrate remaining systems
-- [ ] (Optional) Phase 3: Add ConfigLib integration for in-game config
-
-## Category Names Reference
-
-Common category names for filtering:
-
-| Category | Description | Typical Volume |
+| Category | Description | Typical volume |
 |----------|-------------|----------------|
 | `ReligionManager` | Religion CRUD operations | Medium |
-| `FavorSystem` | Favor tracking and rewards | **Very High** |
-| `FavorTracker` | Individual favor trackers | **Very High** |
+| `FavorSystem` | Favor tracking and rewards | **Very high** |
 | `BlessingEffectSystem` | Blessing stat modifiers | Medium |
-| `HolySiteManager` | Holy site management | Low-Medium |
+| `HolySiteManager` | Holy site management | Low–medium |
 | `CivilizationManager` | Civilization operations | Low |
-| `GUI` | ImGui UI rendering | **Very High** |
-| `NetworkHandler` | Network packet handling | High |
+| `ReligionNetworkHandler` | Religion network packets | High |
 | `AltarPrayerHandler` | Prayer/offering events | Medium |
-| `RitualProgressManager` | Ritual tracking | Low-Medium |
-
-**Recommendation:** Start by excluding `FavorSystem`, `FavorTracker`, and `GUI` categories to see the biggest reduction in log spam.
+| `RitualProgressManager` | Ritual tracking | Low–medium |
 
 ## Troubleshooting
 
-### Q: Logging still occurs after setting `Silent()`
+**Q: I unchecked everything but a few `[DivineAscension]` lines still print at startup.**
+A: Expected. The earliest bootstrap lines log through the raw `api.Logger` before
+the toggles are read; they're intentionally not gated. All category-logger output
+past initialization is suppressed.
 
-**A:** Phase 1 only initializes the service. Existing code still uses `ILogger` directly. You need to either:
-1. Wait for Phase 2 migration, or
-2. Temporarily wrap the base `api.Logger` (advanced, requires Vintage Story API knowledge)
+**Q: My toggle changes aren't taking effect.**
+A: Confirm ConfigLib is installed — without it the mod always uses the all-on
+defaults and there is no YAML/GUI to change. With ConfigLib, GUI checkbox changes
+apply live; manual YAML edits apply on next load.
 
-### Q: How to completely disable logging without code changes?
+**Q: Does this affect Vintage Story's own logging?**
+A: No — only Divine Ascension's log statements. VS core logging is unaffected.
 
-**A:** Not possible without Phase 2 migration. The cleanest approach is:
-1. Set `LoggingConfig.Silent()` in Phase 1
-2. Gradually migrate high-volume systems in Phase 2
+## Best practices
 
-### Q: Can I disable logging for specific methods?
+1. Keep `EnableErrorLogs` on in production — errors are critical for triage.
+2. Turn off `EnableDebugLogs` to cut the bulk of the noise while keeping
+   startup/major events, warnings, and errors.
+3. Reach for code-level category filtering when one subsystem is drowning out the
+   rest.
 
-**A:** Not directly. Filtering is per-category (class-level). You could:
-1. Create more granular categories (e.g., `ReligionManager.CreateReligion`)
-2. Use conditional compilation (`#if DEBUG`)
-3. Manually comment out specific log statements
+## Future enhancements
 
-### Q: Does this affect Vintage Story's own logging?
-
-**A:** No. This only affects Divine Ascension's log statements. Vintage Story's core logging is unaffected.
-
-## Best Practices
-
-1. **Always keep error logging enabled** - Critical for troubleshooting
-2. **Disable debug logs in production** - Reduces noise and improves performance
-3. **Use category filtering for debugging** - More precise than disabling all logs
-4. **Test configuration changes** - Ensure critical logs still appear when needed
-5. **Document your configuration** - Help other admins understand logging settings
-
-## Future Enhancements
-
-Potential improvements for future versions:
-
-- [ ] Per-player logging levels (debug mode for specific admins)
-- [ ] Log level inheritance (e.g., "FavorSystem.*" matches all favor trackers)
-- [ ] Regex category patterns
-- [ ] Log message sampling (e.g., log only 1 in 10 debug messages)
-- [ ] Performance metrics (track time spent in logging code)
-- [ ] Chat command to change logging at runtime (`/da logging set debug off`)
+- Surface the category whitelist/blacklist filters in the ConfigLib GUI (the GUI
+  exposes the per-level toggles today; category filtering is code-only).
+- Chat command to change levels at runtime (`/da logging set debug off`).
+- Per-player debug mode for admins.


### PR DESCRIPTION
## Summary

Closes #620.

Lets server admins control Divine Ascension's logging from the ConfigLib config (`ModConfig/divineascension.yaml` or the in-game GUI) without editing source.

- Adds four per-level toggles to the ConfigLib-managed `GameBalanceConfig`: `EnableDebugLogs`, `EnableNotificationLogs`, `EnableWarningLogs`, `EnableErrorLogs` (all default `true`). Unchecking all four = full silence.
- Booleans on purpose: ConfigLib renders them as checkboxes and round-trips them through YAML reliably (an enum "verbosity preset" did not get an editable GUI control).
- `GameBalanceConfig.BuildLoggingConfig()` maps the toggles to a `LoggingConfig`; `LoggingService.ApplyConfig()` applies it to the shared config in place.
- `ModSystem` applies the toggles at startup and re-applies on every ConfigLib change/save. Falls back to all-on when ConfigLib is absent.

### Correctness fixes found while getting a live change to actually reach the loggers
- **`LoggerWrapper` now reads the config live** from the service per call instead of snapshotting it at construction. Single-player runs the client and server `ModSystem`s in one process, both initializing the shared `LoggingService` singleton; the second `Initialize` swapped the config instance and stranded loggers created against the first.
- **`ModSystem` no longer replaces `_gameBalanceConfig`** on a validation failure (`GameBalanceConfig.CopyFrom` resets in place). ConfigLib holds a reference to the registered instance and writes GUI edits into it, so swapping it orphaned every later change.
- **`OnConfigChanged` applies logging before validating balance**, and the previously-null `onConfigSaved` / `onSyncedFromServer` ConfigLib callbacks now re-apply logging too.

## Test plan

- `dotnet build DivineAscension.sln`: 0 errors.
- `dotnet test`: 2539 passed, 0 failed. New tests:
  - `LoggingServiceTests` — `ApplyConfig` suppresses an already-created logger; survives a re-`Initialize` from the other game side (regression for the snapshot bug); errors-only and back-to-default.
  - `LoggingConfigTests` — toggle→level mapping, all-off is fully silent, independence from balance validation.
  - `GameBalanceConfigResetTests` — `CopyFrom` resets in place for existing reference holders (orphan-instance regression).
- Manually verified in-game (single-player, debug): unchecking `EnableDebugLogs` in the ConfigLib GUI stops the server `[FavorSystem]` debug spam live.

## Known gap (follow-up)

Client-side classes (network client, GUI presenters/state managers) still log through the raw `_capi.Logger` and aren't covered by the toggles — the client mirror of #619, tracked separately.
