### PR TITLE
fix(logging): silence release builds and honor persisted config opt-out

### DIFF
--- a/DivineAscension.Tests/Configuration/LoggingConfigTests.cs
+++ b/DivineAscension.Tests/Configuration/LoggingConfigTests.cs
@@ -9,7 +9,8 @@ public class LoggingConfigTests
     [Fact]
     public void GameBalanceConfig_DefaultsToAllLevelsEnabled()
     {
-        // No-config / legacy worlds must keep full logging.
+        // Defaults are all-on; these toggles drive Debug builds (Release suppresses wrapper logging
+        // entirely regardless — see LoggingService.DebugBuild).
         var config = new GameBalanceConfig();
 
         Assert.True(config.EnableDebugLogs);

--- a/DivineAscension.Tests/Services/LoggingServiceTests.cs
+++ b/DivineAscension.Tests/Services/LoggingServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using DivineAscension.Configuration;
 using DivineAscension.Services;
@@ -14,6 +15,11 @@ namespace DivineAscension.Tests.Services;
 [ExcludeFromCodeCoverage]
 public class LoggingServiceTests
 {
+    // A level that the config leaves enabled emits once in Debug builds, but never in Release —
+    // the wrapper suppresses every level in Release regardless of config (LoggingService.DebugBuild).
+    private static readonly Func<Times> EmittedWhenEnabled =
+        LoggingService.DebugBuild ? Times.Once : Times.Never;
+
     [Fact]
     public void ApplyConfig_Silent_SuppressesAlreadyCreatedLogger()
     {
@@ -23,7 +29,7 @@ public class LoggingServiceTests
         // Logger handed out BEFORE the config change (mirrors systems built at startup).
         var logger = LoggingService.Instance.CreateLogger("FavorSystem");
         logger.Notification("before");
-        underlying.Verify(l => l.Notification("before"), Times.Once);
+        underlying.Verify(l => l.Notification("before"), EmittedWhenEnabled);
 
         LoggingService.Instance.ApplyConfig(LoggingConfig.Silent());
 
@@ -57,7 +63,7 @@ public class LoggingServiceTests
         logger.Error("e");
 
         underlying.Verify(l => l.Debug("d"), Times.Never);
-        underlying.Verify(l => l.Error("e"), Times.Once);
+        underlying.Verify(l => l.Error("e"), EmittedWhenEnabled);
     }
 
     [Fact]
@@ -93,6 +99,6 @@ public class LoggingServiceTests
 
         logger.Notification("restored");
 
-        underlying.Verify(l => l.Notification("restored"), Times.Once);
+        underlying.Verify(l => l.Notification("restored"), EmittedWhenEnabled);
     }
 }

--- a/DivineAscension/Configuration/GameBalanceConfig.cs
+++ b/DivineAscension/Configuration/GameBalanceConfig.cs
@@ -218,20 +218,24 @@ public class GameBalanceConfig
     // === LOGGING ===
     //
     // Per-level toggles for the mod's category loggers. Booleans render as checkboxes in the
-    // ConfigLib GUI and round-trip reliably through YAML. Defaults are all-on, matching prior
-    // behaviour. Uncheck all four for complete silence. Applied at startup and re-applied live
-    // when changed via the ConfigLib GUI. Event/Build/Chat levels follow the notification toggle.
+    // ConfigLib GUI and round-trip reliably through YAML. Defaults are all-on. Uncheck levels for
+    // less output. Applied at startup and re-applied live when changed via the ConfigLib GUI.
+    // Event/Build/Chat levels follow the notification toggle.
+    //
+    // These toggles only take effect in Debug builds. Release builds suppress all wrapper logging
+    // regardless of these values (see LoggingService.DebugBuild) — a shipped install logs only its
+    // one-shot bootstrap lines.
 
-    /// <summary>Enable Debug-level logs — verbose, highest volume (default: true).</summary>
+    /// <summary>Enable Debug-level logs — verbose, highest volume (default: true; Debug builds only).</summary>
     public bool EnableDebugLogs { get; set; } = true;
 
-    /// <summary>Enable Notification-level logs — startup and major events (default: true).</summary>
+    /// <summary>Enable Notification-level logs — startup and major events (default: true; Debug builds only).</summary>
     public bool EnableNotificationLogs { get; set; } = true;
 
-    /// <summary>Enable Warning-level logs (default: true).</summary>
+    /// <summary>Enable Warning-level logs (default: true; Debug builds only).</summary>
     public bool EnableWarningLogs { get; set; } = true;
 
-    /// <summary>Enable Error-level logs — recommended to keep on (default: true).</summary>
+    /// <summary>Enable Error-level logs (default: true; Debug builds only).</summary>
     public bool EnableErrorLogs { get; set; } = true;
 
     /// <summary>

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -89,6 +89,14 @@ public class DivineAscensionModSystem : ModSystem
 
     public string ModName => "divineascension";
 
+    // One-shot bootstrap notifications. These run before the per-category ILoggerWrapper instances
+    // exist, so they use the raw logger and are NOT build-gated: they are deliberately the only logs
+    // a Release install emits (everything routed through the wrapper is suppressed in Release).
+    private static void BootNotify(ILogger logger, string message)
+    {
+        logger.Notification(message);
+    }
+
     public override void Start(ICoreAPI api)
     {
         base.Start(api);
@@ -101,7 +109,7 @@ public class DivineAscensionModSystem : ModSystem
         // ModSystem startup intentionally logs through the raw api.Logger: these lines run
         // during Start/StartServerSide bootstrap, where the per-category ILoggerWrapper
         // instances aren't created yet. Everything past initialization uses ILoggerWrapper.
-        api.Logger.Notification("[DivineAscension] Mod loaded!");
+        BootNotify(api.Logger, "[DivineAscension] Mod loaded!");
 
         // Initialize profanity filter service
         ProfanityFilterService.Instance.Initialize(api);
@@ -111,7 +119,7 @@ public class DivineAscensionModSystem : ModSystem
         {
             _harmony = new Harmony("com.divineascension.patches");
             _harmony.PatchAll(Assembly.GetExecutingAssembly());
-            api.Logger.Notification("[DivineAscension] Harmony patches registered.");
+            BootNotify(api.Logger, "[DivineAscension] Harmony patches registered.");
         }
 
         // Register BlockBehavior classes
@@ -123,7 +131,7 @@ public class DivineAscensionModSystem : ModSystem
         api.RegisterBlockBehaviorClass("DivineAscensionOre", typeof(BlockBehaviorOre));
         api.RegisterBlockBehaviorClass("DivineAscensionBlessedCrop", typeof(BlockBehaviorBlessedCrop));
         api.RegisterCollectibleBehaviorClass("ChiselTracking", typeof(CollectibleBehaviorChiselTracking));
-        api.Logger.Notification("[DivineAscension] Block and Collectible behavior classes registered");
+        BootNotify(api.Logger, "[DivineAscension] Block and Collectible behavior classes registered");
 
         // Register with ConfigLib if available
         TryRegisterWithConfigLib(api);
@@ -151,7 +159,7 @@ public class DivineAscensionModSystem : ModSystem
         // Apply the admin-selected logging levels now that ConfigLib (if present) has populated
         // the config. Early bootstrap above logs at full verbosity since the toggles aren't known yet.
         LoggingService.Instance.ApplyConfig(_gameBalanceConfig.BuildLoggingConfig());
-        api.Logger.Notification(
+        BootNotify(api.Logger,
             $"[DivineAscension] Logging levels — Debug:{_gameBalanceConfig.EnableDebugLogs} " +
             $"Notification:{_gameBalanceConfig.EnableNotificationLogs} Warning:{_gameBalanceConfig.EnableWarningLogs} " +
             $"Error:{_gameBalanceConfig.EnableErrorLogs}");
@@ -244,6 +252,17 @@ public class DivineAscensionModSystem : ModSystem
         base.AssetsFinalize(api);
 
         // Block behaviors are now applied via JSON patches in assets/divineascension/patches/
+
+        // Re-apply the admin's logging toggles now that ConfigLib has loaded the YAML.
+        //
+        // ConfigLib only writes a saved value into _gameBalanceConfig when that setting *changes*
+        // (its SettingChanged -> AssignSettingValue handler), and it loads the file during its own
+        // AssetsLoaded — AFTER our Start() ran the first ApplyConfig against the all-on defaults.
+        // It also only fires onSyncedFromServer (-> OnConfigReloaded) on the client side, so a server
+        // booting from a persisted "logging off" YAML never re-synced the LoggingService and kept
+        // logging at full volume until the admin toggled a setting. AssetsFinalize runs after every
+        // mod's AssetsLoaded on both sides, so _gameBalanceConfig reflects the disk values here.
+        LoggingService.Instance.ApplyConfig(_gameBalanceConfig.BuildLoggingConfig());
     }
 
     public override void StartServerSide(ICoreServerAPI api)
@@ -309,13 +328,13 @@ public class DivineAscensionModSystem : ModSystem
             SaveModConfig);
         configCommands.RegisterCommands();
 
-        api.Logger.Notification("[DivineAscension] Server-side initialization complete");
+        BootNotify(api.Logger, "[DivineAscension] Server-side initialization complete");
     }
 
     public override void StartClientSide(ICoreClientAPI api)
     {
         base.StartClientSide(api);
-        api.Logger.Notification("[DivineAscension] Initializing client-side systems...");
+        BootNotify(api.Logger, "[DivineAscension] Initializing client-side systems...");
 
         // Initialize thread safety utilities for telemetry
         ThreadSafetyUtils.Initialize(api);
@@ -333,7 +352,7 @@ public class DivineAscensionModSystem : ModSystem
         NetworkClient.RegisterHandlers(clientChannel);
         UiService = new UiService(NetworkClient);
 
-        api.Logger.Notification("[DivineAscension] Client-side initialization complete");
+        BootNotify(api.Logger, "[DivineAscension] Client-side initialization complete");
     }
 
     public override void Dispose()
@@ -448,12 +467,12 @@ public class DivineAscensionModSystem : ModSystem
     {
         if (!api.ModLoader.IsModEnabled("configlib"))
         {
-            api.Logger.Notification(
+            BootNotify(api.Logger,
                 "[DivineAscension] ConfigLib not installed. Using hardcoded default configuration. Install ConfigLib for in-game configuration GUI.");
             return;
         }
 
-        api.Logger.Notification("[DivineAscension] ConfigLib is enabled. Config file: ModConfig/divineascension.yaml");
+        BootNotify(api.Logger, "[DivineAscension] ConfigLib is enabled. Config file: ModConfig/divineascension.yaml");
 
         try
         {
@@ -521,13 +540,13 @@ public class DivineAscensionModSystem : ModSystem
                 (Action)OnConfigReloaded // onConfigSaved - re-apply logging after a GUI save
             });
 
-            api.Logger.Notification(
+            BootNotify(api.Logger,
                 "[DivineAscension] ConfigLib integration enabled. Config file: ModConfig/divineascension.yaml");
         }
         catch (Exception ex)
         {
             api.Logger.Error($"[DivineAscension] Failed to register with ConfigLib: {ex.Message}");
-            api.Logger.Notification("[DivineAscension] Using hardcoded default configuration");
+            BootNotify(api.Logger, "[DivineAscension] Using hardcoded default configuration");
         }
     }
 

--- a/DivineAscension/Services/LoggingService.cs
+++ b/DivineAscension/Services/LoggingService.cs
@@ -10,6 +10,19 @@ namespace DivineAscension.Services;
 /// </summary>
 public class LoggingService
 {
+    /// <summary>
+    ///     True only when the mod is compiled in a Debug configuration. In Release builds the logger
+    ///     wrappers suppress every level — errors included — regardless of the ConfigLib toggles, so a
+    ///     shipped install emits nothing beyond the one-shot bootstrap lines. In Debug builds the
+    ///     per-level config toggles apply normally.
+    /// </summary>
+    internal static readonly bool DebugBuild =
+#if DEBUG
+        true;
+#else
+        false;
+#endif
+
     private static readonly Lazy<LoggingService> _instance = new(() => new LoggingService());
 
     private ILogger? _logger;
@@ -110,8 +123,14 @@ internal class LoggerWrapper : ILoggerWrapper
     // config changes mutate it — a captured reference would go stale and ignore those updates.
     private LoggingConfig Config => _service.CurrentConfig;
 
+    // Release builds emit nothing through the wrapper — every level, errors included, is suppressed
+    // (LoggingService.DebugBuild == false) regardless of the ConfigLib toggles. The only logs a
+    // shipped install produces are the one-shot bootstrap lines (see DivineAscensionModSystem). In
+    // Debug builds the per-level config toggles apply normally.
+
     public void Debug(string message)
     {
+        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableDebug) return;
         if (IsFilteredOut(config)) return;
@@ -120,6 +139,7 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Notification(string message)
     {
+        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableNotification) return;
         if (IsFilteredOut(config)) return;
@@ -128,6 +148,7 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Warning(string message)
     {
+        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableWarning) return;
         if (IsFilteredOut(config)) return;
@@ -136,6 +157,7 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Error(string message)
     {
+        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableError) return;
         if (IsFilteredOut(config)) return;
@@ -144,6 +166,7 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Event(string message)
     {
+        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableEvent) return;
         if (IsFilteredOut(config)) return;
@@ -152,6 +175,7 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Build(string message)
     {
+        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableBuild) return;
         if (IsFilteredOut(config)) return;
@@ -160,6 +184,7 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Chat(string message)
     {
+        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableChat) return;
         if (IsFilteredOut(config)) return;


### PR DESCRIPTION
## Problem

Users reported two logging defects:

1. **ConfigLib opt-out non-functional.** Disabling logging via config didn't take effect at boot — you had to toggle a setting off→on→off in-game to make it stick.
2. **Too much logging in shipped builds.** Request: a release build should be quiet aside from the boot lines.

## Root cause (opt-out)

ConfigLib only writes a setting back into `GameBalanceConfig` when its value *changes* (its `SettingChanged → AssignSettingValue` handler); the bulk `AssignSettingsValues` is never called. It loads the YAML during its own `AssetsLoaded`, which runs **after** our `Start()` already ran `ApplyConfig` against the all-on defaults. And `onSyncedFromServer → OnConfigReloaded` is wired **client-side only**, so a server booting from a persisted "logging off" YAML never re-synced `LoggingService` and kept logging at full volume — until a real change event fired (the off→on→off dance).

## Changes

- **Opt-out fix:** re-apply `BuildLoggingConfig()` in `AssetsFinalize`, which runs after every mod's `AssetsLoaded` on both client and server, so `GameBalanceConfig` reflects the persisted disk values by then.
- **Release gate:** the logger wrapper now suppresses **every level — errors included** — in Release builds, regardless of the ConfigLib toggles (`LoggingService.DebugBuild`). A shipped install emits only the one-shot bootstrap notifications. Debug builds behave as before, with the per-level config toggles fully in effect.

## Behavior

| Build | Output |
|-------|--------|
| Release (shipped) | Bootstrap lines only — nothing through the wrapper |
| Debug | Config toggles control levels; persisted opt-out now applies at startup |

## Tests

`LoggingServiceTests` "enabled" expectations are build-aware (resolve to `Times.Never` in Release). Full suite passes in **both** Debug and Release (2539/2539).