### PR TITLE
fix(blessings): apply max-health bonuses to the entity

### DIFF
--- a/DivineAscension.Tests/Systems/BlessingEffectSystemTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingEffectSystemTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
 using DivineAscension.Data;
 using DivineAscension.Models.Enum;
 using DivineAscension.Services;
@@ -718,6 +719,38 @@ public class BlessingEffectSystemTests
         _mockPlayerReligionDataManager.VerifyAdd(
             m => m.OnPlayerLeavesReligion += It.IsAny<PlayerProgressionDataManager.PlayerReligionDataChangedDelegate>(),
             Times.Once());
+    }
+
+    #endregion
+
+    #region TranslateHealthModifier Tests
+
+    [Fact]
+    public void TranslateHealthModifier_ConvertsHealthMultiplierToFlatPoints()
+    {
+        // Arrange - VS EntityBehaviorHealth only reads "maxhealthExtraPoints", never the
+        // "maxhealthExtraMultiplier" key the blessing data uses. 10% of a 15 HP base = +1.5 points.
+        const float baseMaxHealth = 15f;
+
+        // Act
+        var (statName, value) = BlessingEffectSystem.TranslateHealthModifier(
+            VintageStoryStats.MaxHealthExtraMultiplier, 0.10f, baseMaxHealth);
+
+        // Assert
+        Assert.Equal(VintageStoryStats.MaxHealthExtraPoints, statName);
+        Assert.Equal(1.5f, value, 3);
+    }
+
+    [Fact]
+    public void TranslateHealthModifier_LeavesOtherStatsUnchanged()
+    {
+        // Act
+        var (statName, value) = BlessingEffectSystem.TranslateHealthModifier(
+            VintageStoryStats.WalkSpeed, 0.10f, 15f);
+
+        // Assert - non-health stats pass through verbatim
+        Assert.Equal(VintageStoryStats.WalkSpeed, statName);
+        Assert.Equal(0.10f, value, 3);
     }
 
     #endregion

--- a/DivineAscension/Systems/BlessingEffectSystem.cs
+++ b/DivineAscension/Systems/BlessingEffectSystem.cs
@@ -187,6 +187,9 @@ public class BlessingEffectSystem : IBlessingEffectSystem
         // Remove old modifiers first
         RemoveBlessingsFromPlayer(player);
 
+        // Resolve health behavior up front so we can translate health modifiers below.
+        var healthBehavior = agent.GetBehavior<EntityBehaviorHealth>();
+
         // Apply new modifiers
         var appliedCount = 0;
         var appliedSet = new HashSet<string>();
@@ -199,6 +202,14 @@ public class BlessingEffectSystem : IBlessingEffectSystem
             // Use namespaced modifier ID to avoid conflicts
             var modifierId = string.Format(SystemConstants.ModifierIdFormat, player.PlayerUID);
             var value = modifier.Value;
+
+            // VS EntityBehaviorHealth.UpdateMaxHealth() only consumes "maxhealthExtraPoints"
+            // (flat HP added to base); it never reads "maxhealthExtraMultiplier". Blessing data
+            // expresses max-health bonuses as a fractional multiplier, so convert that into flat
+            // extra points relative to the entity's base max health. Otherwise the value is stored
+            // in Stats (and echoed by the command) but never reaches the character sheet.
+            if (healthBehavior != null)
+                (statName, value) = TranslateHealthModifier(statName, value, healthBehavior.BaseMaxHealth);
 
             try
             {
@@ -225,7 +236,6 @@ public class BlessingEffectSystem : IBlessingEffectSystem
         _appliedModifiers[player.PlayerUID] = appliedSet;
 
         // Force health recalculation after applying stats
-        var healthBehavior = agent.GetBehavior<EntityBehaviorHealth>();
         if (healthBehavior != null)
         {
             var beforeHealth = healthBehavior.MaxHealth;
@@ -244,6 +254,22 @@ public class BlessingEffectSystem : IBlessingEffectSystem
         if (appliedCount > 0)
             _logger.Notification(
                 $"{SystemConstants.LogPrefix} {string.Format(SystemConstants.SuccessAppliedModifiersFormat, appliedCount, player.PlayerName)}");
+    }
+
+    /// <summary>
+    ///     Translates a raw blessing stat modifier into the key/value the VS engine actually reads.
+    ///     Max-health blessings are authored as a fractional multiplier ("maxhealthExtraMultiplier"),
+    ///     but <c>EntityBehaviorHealth.UpdateMaxHealth()</c> only honors flat "maxhealthExtraPoints"
+    ///     (added to base health). Convert the multiplier into flat points relative to base max health.
+    ///     All other stats pass through unchanged.
+    /// </summary>
+    internal static (string statName, float value) TranslateHealthModifier(string statName, float value,
+        float baseMaxHealth)
+    {
+        if (statName == VintageStoryStats.MaxHealthExtraMultiplier)
+            return (VintageStoryStats.MaxHealthExtraPoints, baseMaxHealth * value);
+
+        return (statName, value);
     }
 
     /// <summary>
@@ -386,6 +412,10 @@ public class BlessingEffectSystem : IBlessingEffectSystem
         if (player.Entity == null || player.Entity.Stats == null) return;
 
         var stats = player.Entity.Stats;
+
+        // Max health: blessings store a multiplier but it is applied as flat extra points
+        // (see ApplyBlessingsToPlayer). WeightedSum base 1 so GetBlended-1 yields the points.
+        RegisterStatIfNeeded(stats, VintageStoryStats.MaxHealthExtraPoints, EnumStatBlendType.WeightedSum);
 
         // Craft (Forge & Craft) - Most are percentage modifiers
         // ToolDurability uses FlatSum (base 0) since we want the raw bonus value in our patch


### PR DESCRIPTION
## Problem

Player report: blessings that grant health show a bonus in the `/blessing` command but the character sheet never changes.

## Root cause

Health blessings store the stat key `maxhealthExtraMultiplier`, but Vintage Story's `EntityBehaviorHealth.UpdateMaxHealth()` only reads `maxhealthExtraPoints` (flat HP). The value was written into `entity.Stats` — so the command echoed it — but `UpdateMaxHealth()` ignored it, so the actual max health never moved.

Introduced by `9dc84dfc` ("fix: use maxhealthExtraMultiplier for percentage health bonuses"), which switched health blessings from `maxhealthExtraPoints` to the multiplier key on the assumption that VS honors a percentage stat. It does not, so the bonus became a no-op. The later JSON migration carried the same key into `assets/.../blessings/*.json`.

| State | Key / value | Character sheet |
|---|---|---|
| Original | `maxhealthExtraPoints` = `1.10f` | +1.1 flat HP (wrong magnitude) |
| `9dc84dfc` | `maxhealthExtraMultiplier` = `0.10f` | nothing (key unread by VS) |
| This PR | translated → flat points | actual +10% |

## Fix

- New `TranslateHealthModifier(statName, value, baseMaxHealth)` converts the fractional multiplier into flat extra points relative to the entity's base max health (e.g. `0.10` on a 15 HP base → `+1.5` points). Applied at the apply boundary, so it covers both the JSON data and any legacy source.
- `ApplyBlessingsToPlayer` resolves the health behavior once up front and runs each modifier through the translation.
- Register `maxhealthExtraPoints` explicitly (WeightedSum, base 1 → `GetBlended − 1` yields exactly the points set).

The command display is unchanged (still shows `+10%`) — that value is now actually applied.

## Tests

- Two regression tests for `TranslateHealthModifier` (multiplier→points conversion; pass-through for other stats).
- `BlessingEffectSystemTests`: 36/36 pass.