### PR TITLE
fix(logging): keep Warning/Error logging in Release builds

### DIFF
--- a/DivineAscension.Tests/Services/LoggingServiceTests.cs
+++ b/DivineAscension.Tests/Services/LoggingServiceTests.cs
@@ -15,8 +15,9 @@ namespace DivineAscension.Tests.Services;
 [ExcludeFromCodeCoverage]
 public class LoggingServiceTests
 {
-    // A level that the config leaves enabled emits once in Debug builds, but never in Release —
-    // the wrapper suppresses every level in Release regardless of config (LoggingService.DebugBuild).
+    // A build-gated noisy level (Debug/Notification/Event/Build/Chat) emits once in Debug builds but
+    // never in Release — the wrapper suppresses those levels in Release regardless of config
+    // (LoggingService.DebugBuild). Warning/Error are NOT build-gated and assert Times.Once directly.
     private static readonly Func<Times> EmittedWhenEnabled =
         LoggingService.DebugBuild ? Times.Once : Times.Never;
 
@@ -63,7 +64,8 @@ public class LoggingServiceTests
         logger.Error("e");
 
         underlying.Verify(l => l.Debug("d"), Times.Never);
-        underlying.Verify(l => l.Error("e"), EmittedWhenEnabled);
+        // Error is not build-gated — it emits in both Debug and Release when the toggle is on.
+        underlying.Verify(l => l.Error("e"), Times.Once);
     }
 
     [Fact]

--- a/DivineAscension/Configuration/GameBalanceConfig.cs
+++ b/DivineAscension/Configuration/GameBalanceConfig.cs
@@ -222,9 +222,10 @@ public class GameBalanceConfig
     // less output. Applied at startup and re-applied live when changed via the ConfigLib GUI.
     // Event/Build/Chat levels follow the notification toggle.
     //
-    // These toggles only take effect in Debug builds. Release builds suppress all wrapper logging
-    // regardless of these values (see LoggingService.DebugBuild) — a shipped install logs only its
-    // one-shot bootstrap lines.
+    // Debug/Notification (and the Event/Build/Chat that follow it) only take effect in Debug builds;
+    // Release suppresses those noisy levels regardless of these values (see LoggingService.DebugBuild).
+    // Warning and Error take effect in BOTH builds so a shipped server keeps a repro trail — their
+    // toggles still apply, so unchecking them silences even Release.
 
     /// <summary>Enable Debug-level logs — verbose, highest volume (default: true; Debug builds only).</summary>
     public bool EnableDebugLogs { get; set; } = true;
@@ -232,10 +233,10 @@ public class GameBalanceConfig
     /// <summary>Enable Notification-level logs — startup and major events (default: true; Debug builds only).</summary>
     public bool EnableNotificationLogs { get; set; } = true;
 
-    /// <summary>Enable Warning-level logs (default: true; Debug builds only).</summary>
+    /// <summary>Enable Warning-level logs (default: true; applies in Debug and Release).</summary>
     public bool EnableWarningLogs { get; set; } = true;
 
-    /// <summary>Enable Error-level logs (default: true; Debug builds only).</summary>
+    /// <summary>Enable Error-level logs — recommended to keep on (default: true; applies in Debug and Release).</summary>
     public bool EnableErrorLogs { get; set; } = true;
 
     /// <summary>

--- a/DivineAscension/Services/LoggingService.cs
+++ b/DivineAscension/Services/LoggingService.cs
@@ -12,9 +12,10 @@ public class LoggingService
 {
     /// <summary>
     ///     True only when the mod is compiled in a Debug configuration. In Release builds the logger
-    ///     wrappers suppress every level — errors included — regardless of the ConfigLib toggles, so a
-    ///     shipped install emits nothing beyond the one-shot bootstrap lines. In Debug builds the
-    ///     per-level config toggles apply normally.
+    ///     wrappers suppress the noisy levels (Debug/Notification/Event/Build/Chat) regardless of the
+    ///     ConfigLib toggles, so a shipped install stays quiet. Warning and Error always evaluate (in
+    ///     both builds) so a production server keeps a repro trail; they still honor their config
+    ///     toggles. In Debug builds every level's config toggle applies normally.
     /// </summary>
     internal static readonly bool DebugBuild =
 #if DEBUG
@@ -123,10 +124,10 @@ internal class LoggerWrapper : ILoggerWrapper
     // config changes mutate it — a captured reference would go stale and ignore those updates.
     private LoggingConfig Config => _service.CurrentConfig;
 
-    // Release builds emit nothing through the wrapper — every level, errors included, is suppressed
-    // (LoggingService.DebugBuild == false) regardless of the ConfigLib toggles. The only logs a
-    // shipped install produces are the one-shot bootstrap lines (see DivineAscensionModSystem). In
-    // Debug builds the per-level config toggles apply normally.
+    // In Release the noisy levels (Debug/Notification/Event/Build/Chat) are build-gated off
+    // regardless of the ConfigLib toggles, keeping a shipped install quiet. Warning and Error are
+    // NOT build-gated — they always evaluate so a production server keeps a repro trail — but they
+    // still honor their config toggles. In Debug builds every level's config toggle applies.
 
     public void Debug(string message)
     {
@@ -148,7 +149,6 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Warning(string message)
     {
-        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableWarning) return;
         if (IsFilteredOut(config)) return;
@@ -157,7 +157,6 @@ internal class LoggerWrapper : ILoggerWrapper
 
     public void Error(string message)
     {
-        if (!LoggingService.DebugBuild) return;
         var config = Config;
         if (!config.EnableError) return;
         if (IsFilteredOut(config)) return;


### PR DESCRIPTION
## Problem

The release gate (merged on master) suppressed **every** wrapper level — Warning and Error included — via `if (!DebugBuild) return;` at the top of each `LoggerWrapper` method. Since commit `77f801ad` routed all ~70 logging sites through `ILoggerWrapper`, a shipped server logged nothing past the bootstrap lines. A player hits a bug on a Release server → empty log → no repro trail.

## Fix

- Build-gate only the noisy levels: **Debug / Notification / Event / Build / Chat**.
- **Warning** and **Error** now evaluate in both Debug and Release, still honoring their `EnableWarningLogs` / `EnableErrorLogs` config toggles (admin can still mute them).
- Doc-comments in `GameBalanceConfig` corrected — Warning/Error checkboxes are live in Release again, no longer dead controls.
- Tests: Error case asserts `Times.Once` (always emits when enabled); build-gated levels keep the `EmittedWhenEnabled` helper.

## Result

Release install stays quiet for routine spam but keeps a repro trail for real errors/warnings. Verified: Debug build clean, 10/10 logging tests pass.