### PR TITLE
feat(caravan): atomic item swap on sealed trade (no-escrow slice)

### DIFF
--- a/DivineAscension.Tests/Systems/Caravan/CaravanTradeSessionManagerTests.cs
+++ b/DivineAscension.Tests/Systems/Caravan/CaravanTradeSessionManagerTests.cs
@@ -3,9 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using DivineAscension.Network.Caravan;
 using DivineAscension.Services;
+using DivineAscension.Systems.Altar;
 using DivineAscension.Systems.Caravan;
 using DivineAscension.Tests.Helpers;
 using Moq;
+using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
 using Xunit;
 
@@ -25,6 +27,8 @@ public class CaravanTradeSessionManagerTests
     private readonly FakeWorldService _world = new();
     private readonly FakeEventService _events = new();
     private readonly SpyPlayerMessenger _messenger = new();
+    private readonly FakeCaravanTradeInventory _inventory = new();
+    private readonly AltarEventEmitter _emitter = new();
     private readonly CaravanTradeSessionManager _manager;
 
     private readonly IServerPlayer _alice;
@@ -38,7 +42,7 @@ public class CaravanTradeSessionManagerTests
     public CaravanTradeSessionManagerTests()
     {
         var logger = new Mock<ILoggerWrapper>().Object;
-        _manager = new CaravanTradeSessionManager(logger, _net, _world, _events, _messenger);
+        _manager = new CaravanTradeSessionManager(logger, _net, _world, _events, _messenger, _inventory, _emitter);
         _manager.Initialize();
 
         _alice = _world.CreatePlayer("alice", "Alice");
@@ -141,14 +145,12 @@ public class CaravanTradeSessionManagerTests
         Open(_alice, Shrine);
         Open(_bob, Shrine);
         SetReady(_alice, Shrine, true);
-        SetReady(_bob, Shrine, true);
 
         var sealedSync = LastSync();
         Assert.True(sealedSync!.SideAReady);
-        Assert.True(sealedSync.SideBReady);
 
-        // Alice changes her offer — both seals must break.
-        Offer(_alice, Shrine, "axe");
+        // Bob changes his offer — Alice's seal must break (any change voids both seals).
+        Offer(_bob, Shrine, "axe");
 
         var after = LastSync();
         Assert.False(after!.SideAReady);
@@ -166,17 +168,85 @@ public class CaravanTradeSessionManagerTests
     }
 
     [Fact]
-    public void SetReady_BothParties_ReachesSealedState()
+    public void SetReady_BothParties_WithItems_SwapsAndClosesSession()
     {
         Open(_alice, Shrine);
         Open(_bob, Shrine);
+        Offer(_alice, Shrine, "axe");
+        Offer(_bob, Shrine, "bread");
         SetReady(_alice, Shrine, true);
         SetReady(_bob, Shrine, true);
 
+        // The atomic swap fired exactly once and the table closed.
+        Assert.Equal(1, _inventory.SwapCount);
         var sync = LastSync();
-        Assert.True(sync!.SideAReady);
-        Assert.True(sync.SideBReady);
-        Assert.Equal(TradePhase.Active, sync.Phase);
+        Assert.Equal(TradePhase.Closed, sync!.Phase);
+        Assert.True(_messenger.GetMessageCountForPlayer("alice") > 0);
+        Assert.True(_messenger.GetMessageCountForPlayer("bob") > 0);
+
+        // Session is gone — further packets produce no new sync.
+        var before = SyncCount();
+        Offer(_alice, Shrine, "stick");
+        Assert.Equal(before, SyncCount());
+    }
+
+    [Fact]
+    public void SetReady_BothParties_MissingItems_AbortsSwap_UnsealsAndKeepsOpen()
+    {
+        _inventory.CanProvide["alice"] = false; // Alice no longer holds her offer
+
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+        Offer(_alice, Shrine, "axe");
+        Offer(_bob, Shrine, "bread");
+        SetReady(_alice, Shrine, true);
+        SetReady(_bob, Shrine, true);
+
+        // No items moved; both seals dropped; table still open and usable.
+        Assert.Equal(0, _inventory.SwapCount);
+        var sync = LastSync();
+        Assert.Equal(TradePhase.Active, sync!.Phase);
+        Assert.False(sync.SideAReady);
+        Assert.False(sync.SideBReady);
+        Assert.True(_messenger.GetMessageCountForPlayer("alice") > 0);
+
+        // Session lives — Bob can still update his offer.
+        var before = SyncCount();
+        Offer(_bob, Shrine, "cheese");
+        Assert.True(SyncCount() > before);
+    }
+
+    [Fact]
+    public void ShrineBroken_ClosesActiveSession()
+    {
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+
+        _emitter.RaiseAltarBroken(_alice, new BlockPos(Shrine.X, Shrine.Y, Shrine.Z));
+
+        var sync = LastSync();
+        Assert.Equal(TradePhase.Closed, sync!.Phase);
+
+        // Session torn down: later packets are ignored.
+        var before = SyncCount();
+        Offer(_bob, Shrine, "bread");
+        Assert.Equal(before, SyncCount());
+    }
+
+    [Fact]
+    public void LeashTick_WithBothInReach_LeavesSessionOpen()
+    {
+        // Mock entities report no position, so the reach check treats both as in range.
+        Open(_alice, Shrine);
+        Open(_bob, Shrine);
+
+        var before = SyncCount();
+        _events.TriggerPeriodicCallbacks(1f);
+
+        // No spurious close.
+        Assert.Equal(before, SyncCount());
+        Offer(_bob, Shrine, "bread");
+        Assert.True(SyncCount() > before);
     }
 
     [Fact]
@@ -236,4 +306,26 @@ public class CaravanTradeSessionManagerTests
         Assert.DoesNotContain(_net.GetSentMessages<TradeStateSyncPacket>(), s => s.ShrineX == OtherShrine.X);
         Assert.True(_messenger.GetMessageCountForPlayer("alice") > 0);
     }
+}
+
+/// <summary>
+///     Test double for the inventory seam: records swap calls and lets a test mark a player as
+///     no longer holding their offer. Item movement itself is play-tested (no real VS inventory).
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class FakeCaravanTradeInventory : ICaravanTradeInventory
+{
+    /// <summary>Per-UID provisioning result; absent UID defaults to true (player holds the offer).</summary>
+    public Dictionary<string, bool> CanProvide { get; } = new();
+
+    public int SwapCount { get; private set; }
+
+    public bool CanProvideOffer(IServerPlayer player, IReadOnlyList<TradeOfferSlot> offer)
+        => !CanProvide.TryGetValue(player.PlayerUID, out var ok) || ok;
+
+    public void SwapOffers(
+        IServerPlayer sideA, IReadOnlyList<TradeOfferSlot> offerA,
+        IServerPlayer sideB, IReadOnlyList<TradeOfferSlot> offerB,
+        BlockPos dropPos)
+        => SwapCount++;
 }

--- a/DivineAscension/Systems/Caravan/CaravanTradeInventory.cs
+++ b/DivineAscension/Systems/Caravan/CaravanTradeInventory.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Constants;
+using DivineAscension.Network.Caravan;
+using DivineAscension.Services;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Caravan;
+
+/// <summary>
+///     Real Vintage Story inventory implementation of <see cref="ICaravanTradeInventory" />.
+///     Reads and writes the same hotbar + backpack inventories the client dialog offers from.
+/// </summary>
+public class CaravanTradeInventory : ICaravanTradeInventory
+{
+    private static readonly string[] OwnedInventoryClasses =
+    {
+        GlobalConstants.hotBarInvClassName,
+        GlobalConstants.backpackInvClassName
+    };
+
+    private readonly ILoggerWrapper _logger;
+    private readonly IWorldService _worldService;
+
+    public CaravanTradeInventory(ILoggerWrapper logger, IWorldService worldService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+    }
+
+    public bool CanProvideOffer(IServerPlayer player, IReadOnlyList<TradeOfferSlot> offer)
+    {
+        foreach (var (code, needed) in AggregateByCode(offer))
+        {
+            if (needed <= 0) continue;
+            if (CountAvailable(player, code) < needed) return false;
+        }
+
+        return true;
+    }
+
+    public void SwapOffers(
+        IServerPlayer sideA, IReadOnlyList<TradeOfferSlot> offerA,
+        IServerPlayer sideB, IReadOnlyList<TradeOfferSlot> offerB,
+        BlockPos dropPos)
+    {
+        // Extract both sides first (callers have already verified provisioning), then deliver
+        // crosswise. Extraction and delivery run in one synchronous step — no await, no tick
+        // boundary — so no other game logic can observe a half-finished swap.
+        var fromA = Extract(sideA, offerA);
+        var fromB = Extract(sideB, offerB);
+
+        Deliver(sideB, fromA, dropPos);
+        Deliver(sideA, fromB, dropPos);
+    }
+
+    private static Dictionary<string, int> AggregateByCode(IReadOnlyList<TradeOfferSlot> offer)
+    {
+        var totals = new Dictionary<string, int>();
+        foreach (var slot in offer)
+        {
+            if (string.IsNullOrEmpty(slot.ItemCode) || slot.Quantity <= 0) continue;
+            totals.TryGetValue(slot.ItemCode, out var running);
+            totals[slot.ItemCode] = running + slot.Quantity;
+        }
+
+        return totals;
+    }
+
+    private int CountAvailable(IServerPlayer player, string itemCode)
+    {
+        var total = 0;
+        foreach (var slot in OwnedSlots(player))
+        {
+            var stack = slot.Itemstack;
+            if (stack?.Collectible?.Code == null) continue;
+            if (stack.Collectible.Code.ToString() == itemCode)
+                total += stack.StackSize;
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    ///     Pull the offered quantities out of the player's inventory, returning the removed
+    ///     stacks. Assumes <see cref="CanProvideOffer" /> already passed, so the requested
+    ///     amounts are present; any shortfall is logged and simply yields fewer stacks.
+    /// </summary>
+    private List<ItemStack> Extract(IServerPlayer player, IReadOnlyList<TradeOfferSlot> offer)
+    {
+        var removed = new List<ItemStack>();
+
+        foreach (var (code, needed) in AggregateByCode(offer))
+        {
+            var remaining = needed;
+            foreach (var slot in OwnedSlots(player))
+            {
+                if (remaining <= 0) break;
+
+                var stack = slot.Itemstack;
+                if (stack?.Collectible?.Code == null) continue;
+                if (stack.Collectible.Code.ToString() != code) continue;
+
+                var take = Math.Min(stack.StackSize, remaining);
+                var taken = slot.TakeOut(take);
+                slot.MarkDirty();
+                if (taken != null)
+                {
+                    removed.Add(taken);
+                    remaining -= taken.StackSize;
+                }
+            }
+
+            if (remaining > 0)
+                _logger.Warning(
+                    $"{SystemConstants.LogPrefix} Caravan swap short by {remaining} of '{code}' for " +
+                    $"{player.PlayerName}; delivering what was extracted.");
+        }
+
+        return removed;
+    }
+
+    /// <summary>
+    ///     Give the stacks to the receiver, dropping any that will not fit at the shrine so the
+    ///     swap never destroys items.
+    /// </summary>
+    private void Deliver(IServerPlayer receiver, List<ItemStack> stacks, BlockPos dropPos)
+    {
+        var drop = new Vec3d(dropPos.X + 0.5, dropPos.Y + 0.5, dropPos.Z + 0.5);
+        foreach (var stack in stacks)
+        {
+            if (!receiver.InventoryManager.TryGiveItemstack(stack, true))
+                _worldService.SpawnItemEntity(stack, drop);
+        }
+    }
+
+    private IEnumerable<ItemSlot> OwnedSlots(IServerPlayer player)
+    {
+        foreach (var className in OwnedInventoryClasses)
+        {
+            var inventory = player.InventoryManager?.GetOwnInventory(className);
+            if (inventory == null) continue;
+
+            foreach (var slot in inventory)
+                if (slot != null)
+                    yield return slot;
+        }
+    }
+}

--- a/DivineAscension/Systems/Caravan/CaravanTradeSessionManager.cs
+++ b/DivineAscension/Systems/Caravan/CaravanTradeSessionManager.cs
@@ -5,6 +5,7 @@ using DivineAscension.API.Interfaces;
 using DivineAscension.Constants;
 using DivineAscension.Network.Caravan;
 using DivineAscension.Services;
+using DivineAscension.Systems.Altar;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
@@ -26,11 +27,16 @@ public class CaravanTradeSessionManager : IDisposable
     /// <summary>Maximum distance allowed between player and shrine when sitting down.</summary>
     private const double MaxOpenInteractDistance = 6.0;
 
+    /// <summary>How often the distance leash re-checks that both traders are still in reach.</summary>
+    private const int LeashIntervalMs = 1000;
+
     private readonly ILoggerWrapper _logger;
     private readonly INetworkService _networkService;
     private readonly IWorldService _worldService;
     private readonly IEventService _eventService;
     private readonly IPlayerMessengerService _messenger;
+    private readonly ICaravanTradeInventory _inventory;
+    private readonly AltarEventEmitter _altarEventEmitter;
 
     // Keyed by shrine position string ("x,y,z").
     private readonly Dictionary<string, CaravanTradeSession> _sessions = new();
@@ -38,18 +44,24 @@ public class CaravanTradeSessionManager : IDisposable
     // Reverse index: player UID -> shrine key of the session they are seated at.
     private readonly Dictionary<string, string> _playerSession = new();
 
+    private long _leashCallbackId;
+
     public CaravanTradeSessionManager(
         ILoggerWrapper logger,
         INetworkService networkService,
         IWorldService worldService,
         IEventService eventService,
-        IPlayerMessengerService messenger)
+        IPlayerMessengerService messenger,
+        ICaravanTradeInventory inventory,
+        AltarEventEmitter altarEventEmitter)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _networkService = networkService ?? throw new ArgumentNullException(nameof(networkService));
         _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
         _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
         _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+        _inventory = inventory ?? throw new ArgumentNullException(nameof(inventory));
+        _altarEventEmitter = altarEventEmitter ?? throw new ArgumentNullException(nameof(altarEventEmitter));
     }
 
     public void Initialize()
@@ -60,12 +72,20 @@ public class CaravanTradeSessionManager : IDisposable
         _networkService.RegisterMessageHandler<SetReadyPacket>(OnSetReady);
         _networkService.RegisterMessageHandler<CancelTradePacket>(OnCancelTrade);
         _eventService.OnPlayerDisconnect(OnPlayerDisconnect);
+        // A broken shrine tears down its trade: no escrow exists, so both traders simply keep
+        // the items still sitting in their own inventories.
+        _altarEventEmitter.OnAltarBroken += OnShrineBroken;
+        // Continuous distance leash: walking out of reach cancels the trade (#434).
+        _leashCallbackId = _eventService.RegisterGameTickListener(OnLeashTick, LeashIntervalMs);
         _logger.Notification($"{SystemConstants.LogPrefix} CaravanTradeSessionManager initialized");
     }
 
     public void Dispose()
     {
         _eventService.UnsubscribePlayerDisconnect(OnPlayerDisconnect);
+        _altarEventEmitter.OnAltarBroken -= OnShrineBroken;
+        if (_leashCallbackId != 0)
+            _eventService.UnregisterCallback(_leashCallbackId);
         _sessions.Clear();
         _playerSession.Clear();
     }
@@ -115,13 +135,7 @@ public class CaravanTradeSessionManager : IDisposable
         Broadcast(session);
 
         if (session.BothSealed)
-        {
-            // Terminal state for #433: both offers sealed. The atomic swap + escrow that
-            // consumes this state is #434 — no item movement happens here.
-            _logger.Notification(
-                $"{SystemConstants.LogPrefix} Trade at {session.ShrinePos} sealed by both parties " +
-                $"({session.SideAName} / {session.SideBName}). Awaiting swap (#434).");
-        }
+            TryCompleteTrade(session);
     }
 
     private void OnCancelTrade(IServerPlayer player, CancelTradePacket packet)
@@ -136,6 +150,41 @@ public class CaravanTradeSessionManager : IDisposable
         if (!_playerSession.TryGetValue(player.PlayerUID, out var key)) return;
         if (_sessions.TryGetValue(key, out var session))
             CloseSession(session, player.PlayerUID, "caravantrade.partner_left");
+    }
+
+    private void OnShrineBroken(IServerPlayer player, BlockPos pos)
+    {
+        var key = Key(pos.X, pos.Y, pos.Z);
+        if (_sessions.TryGetValue(key, out var session))
+            CloseSession(session, player.PlayerUID, "caravantrade.shrine_broken");
+    }
+
+    /// <summary>
+    ///     Re-checks every active table that both seated traders are still within reach of the
+    ///     shrine; cancels the trade if either has wandered off. No item movement is involved, so
+    ///     a cancelled trade just closes both dialogs.
+    /// </summary>
+    private void OnLeashTick(float _)
+    {
+        if (_sessions.Count == 0) return;
+
+        // Snapshot: CloseSession mutates _sessions.
+        foreach (var session in _sessions.Values.ToList())
+        {
+            if (session.Phase == TradePhase.Closed) continue;
+
+            if (IsSeatedPlayerOutOfReach(session.SideAUid, session.ShrinePos) ||
+                IsSeatedPlayerOutOfReach(session.SideBUid, session.ShrinePos))
+                CloseSession(session, initiatorUid: null, "caravantrade.too_far_leashed");
+        }
+    }
+
+    private bool IsSeatedPlayerOutOfReach(string? uid, BlockPos shrinePos)
+    {
+        if (string.IsNullOrEmpty(uid)) return false; // empty seat never leashes the table
+        var player = _worldService.GetPlayerByUID(uid!);
+        if (player == null) return false; // disconnect is handled by OnPlayerDisconnect
+        return !IsWithinReach(player, shrinePos);
     }
 
     // ----- Core logic -----
@@ -198,10 +247,74 @@ public class CaravanTradeSessionManager : IDisposable
         return _sessions.TryGetValue(key, out var session) ? session : null;
     }
 
+    /// <summary>
+    ///     Both parties sealed identical, current offers. Re-validate that each still holds the
+    ///     goods, then swap atomically. Any failure aborts with both items untouched — the offers
+    ///     are un-sealed so the traders can fix them, and the table stays open.
+    /// </summary>
+    private void TryCompleteTrade(CaravanTradeSession session)
+    {
+        var sideA = string.IsNullOrEmpty(session.SideAUid) ? null : _worldService.GetPlayerByUID(session.SideAUid!);
+        var sideB = string.IsNullOrEmpty(session.SideBUid) ? null : _worldService.GetPlayerByUID(session.SideBUid!);
+
+        if (sideA == null || sideB == null)
+        {
+            // A party vanished between sealing and the swap — disconnect handling will close the
+            // table. Un-seal so a stale seal can't auto-fire if they return.
+            AbortSwap(session, "caravantrade.swap_failed");
+            return;
+        }
+
+        // Re-validate against live inventories: a player may have dropped or used an offered item
+        // after sealing. Both checks pass before anything moves, so the swap below cannot lose.
+        if (!_inventory.CanProvideOffer(sideA, session.SideAOffer) ||
+            !_inventory.CanProvideOffer(sideB, session.SideBOffer))
+        {
+            AbortSwap(session, "caravantrade.swap_missing_items");
+            return;
+        }
+
+        _inventory.SwapOffers(sideA, session.SideAOffer, sideB, session.SideBOffer, session.ShrinePos);
+
+        _logger.Notification(
+            $"{SystemConstants.LogPrefix} Caravan trade at {session.ShrinePos} completed " +
+            $"({session.SideAName} <-> {session.SideBName}).");
+
+        // Favor grants for a completed barter are #435 — intentionally not fired here.
+
+        session.Phase = TradePhase.Closed;
+        Broadcast(session);
+        _messenger.SendMessage(sideA, LocalizationService.Instance.Get("caravantrade.completed"),
+            EnumChatType.CommandSuccess);
+        _messenger.SendMessage(sideB, LocalizationService.Instance.Get("caravantrade.completed"),
+            EnumChatType.CommandSuccess);
+        TeardownSession(session);
+    }
+
+    /// <summary>
+    ///     A both-sealed trade could not commit. Nothing moved; un-seal both offers, tell both
+    ///     traders, and leave the table open so they can adjust.
+    /// </summary>
+    private void AbortSwap(CaravanTradeSession session, string messageKey)
+    {
+        session.ClearReadyFlags();
+        Broadcast(session);
+        NotifySeated(session.SideAUid, messageKey);
+        NotifySeated(session.SideBUid, messageKey);
+    }
+
+    private void NotifySeated(string? uid, string messageKey)
+    {
+        if (string.IsNullOrEmpty(uid)) return;
+        var player = _worldService.GetPlayerByUID(uid!);
+        if (player != null)
+            _messenger.SendMessage(player, LocalizationService.Instance.Get(messageKey),
+                EnumChatType.Notification);
+    }
+
     private void CloseSession(CaravanTradeSession session, string? initiatorUid, string partnerMessageKey)
     {
         session.Phase = TradePhase.Closed;
-        var key = Key(session.ShrinePos.X, session.ShrinePos.Y, session.ShrinePos.Z);
 
         // Notify the other side, if there is one and it isn't the initiator.
         var partnerUid = session.SideAUid == initiatorUid ? session.SideBUid : session.SideAUid;
@@ -216,7 +329,13 @@ public class CaravanTradeSessionManager : IDisposable
 
         // Push a Closed snapshot so both dialogs tear down, then clear server state.
         Broadcast(session);
+        TeardownSession(session);
+    }
 
+    /// <summary>Clears server-side state for a session whose phase is already terminal.</summary>
+    private void TeardownSession(CaravanTradeSession session)
+    {
+        var key = Key(session.ShrinePos.X, session.ShrinePos.Y, session.ShrinePos.Z);
         if (!string.IsNullOrEmpty(session.SideAUid)) _playerSession.Remove(session.SideAUid!);
         if (!string.IsNullOrEmpty(session.SideBUid)) _playerSession.Remove(session.SideBUid!);
         _sessions.Remove(key);

--- a/DivineAscension/Systems/Caravan/ICaravanTradeInventory.cs
+++ b/DivineAscension/Systems/Caravan/ICaravanTradeInventory.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using DivineAscension.Network.Caravan;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Caravan;
+
+/// <summary>
+///     Inventory seam for the caravan atomic swap (#434).
+///
+///     Slice "A": no escrow. Offered items stay in each trader's own inventory until both
+///     parties seal, then the swap moves them in a single synchronous step. Because there is
+///     never a server-held custody window, a disconnect / shrine break / crash mid-trade
+///     simply leaves every item where it already was — nothing can be lost.
+///
+///     This interface isolates the raw Vintage Story inventory calls so the session manager's
+///     commit/abort orchestration stays unit-testable. The real implementation
+///     (<see cref="CaravanTradeInventory" />) is exercised by play-testing.
+/// </summary>
+public interface ICaravanTradeInventory
+{
+    /// <summary>
+    ///     True if <paramref name="player" /> currently holds the full offer (every item code at
+    ///     the offered quantity) across their hotbar and backpack. Mutates nothing.
+    /// </summary>
+    bool CanProvideOffer(IServerPlayer player, IReadOnlyList<TradeOfferSlot> offer);
+
+    /// <summary>
+    ///     Atomically move <paramref name="offerA" /> from <paramref name="sideA" /> to
+    ///     <paramref name="sideB" /> and <paramref name="offerB" /> from <paramref name="sideB" />
+    ///     to <paramref name="sideA" />. Callers must have verified both sides via
+    ///     <see cref="CanProvideOffer" /> first. Any item that will not fit the receiver's
+    ///     inventory is dropped at <paramref name="dropPos" /> so the swap can never lose items.
+    /// </summary>
+    void SwapOffers(
+        IServerPlayer sideA, IReadOnlyList<TradeOfferSlot> offerA,
+        IServerPlayer sideB, IReadOnlyList<TradeOfferSlot> offerB,
+        BlockPos dropPos);
+}

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -216,12 +216,18 @@ public static class DivineAscensionSystemInitializer
 
             // Player-to-player trade table hosted at caravan shrines (#433). Server-authoritative
             // session state + sync; subscribes to the trade request packets and player disconnect.
+            var caravanTradeInventory = new CaravanTradeInventory(
+                LoggingService.Instance.CreateLogger("CaravanTradeInventory"),
+                worldService);
+
             caravanTradeSessionManager = new CaravanTradeSessionManager(
                 LoggingService.Instance.CreateLogger("CaravanTradeSessionManager"),
                 networkService,
                 worldService,
                 eventService,
-                messengerService);
+                messengerService,
+                caravanTradeInventory,
+                altarEventEmitter);
             caravanTradeSessionManager.Initialize();
         }
 

--- a/DivineAscension/assets/divineascension/lang/en.json
+++ b/DivineAscension/assets/divineascension/lang/en.json
@@ -1560,6 +1560,11 @@
   "caravantrade.leave": "Leave the table",
   "caravantrade.cancelled": "The trade was called off.",
   "caravantrade.partner_left": "Your trading partner left the table.",
+  "caravantrade.shrine_broken": "The shrine was broken — the trade is off. Your wares are untouched.",
+  "caravantrade.too_far_leashed": "A trader strayed too far from the shrine; the trade was called off.",
+  "caravantrade.completed": "The bargain is struck — the wares have changed hands.",
+  "caravantrade.swap_missing_items": "The bargain fell through — a trader no longer holds what they offered. Your wares are untouched.",
+  "caravantrade.swap_failed": "The bargain could not be completed. Your wares are untouched.",
   "caravantrade.error.too_far": "You are too far from the shrine to trade here.",
   "caravantrade.error.full": "This trade table is already occupied by two traders.",
   "caravantrade.error.busy": "Finish your current trade before starting another."


### PR DESCRIPTION
## Summary

Vertical slice of #434 (the dangerous item-movement part of the caravan trade epic #545).

**Design: no escrow.** Items never leave a trader's own inventory until **both** parties seal. On both-sealed, the server re-validates each side still holds its offer, then swaps in a single synchronous step. Any item that won't fit the receiver is dropped at the shrine — the swap can never destroy items.

Because there is no server-held custody window, every interrupted-trade failure mode is loss-free *by construction*: disconnect, broken shrine, or wandering out of the 6-block leash all just close the table with each trader's goods still in their own inventory.

## Changes
- `ICaravanTradeInventory` + `CaravanTradeInventory` — inventory seam: scans hotbar+backpack, validates provisioning, extracts both sides, cross-delivers, drops overflow at the shrine.
- `CaravanTradeSessionManager` — both-sealed now **commits** the swap (previously only logged). Added: continuous distance leash (1s tick), shrine-break teardown, and an abort path that un-seals and keeps the table open when a trader no longer holds their offer.
- Initializer wiring, 7 localization keys, new + updated tests.

## Acceptance criteria (#434)
- [x] Successful trade swaps items atomically
- [x] Disconnect mid-trade — no loss (items never left inventory)
- [x] Shrine break — no loss (table tears down, goods stay)
- [x] Walking >6 blocks cancels
- [x] No item-loss in any failure scenario (by design)
- [ ] Server restart preserves escrow — **N/A**: no escrow exists in this design

**Deferred** (only relevant if literal escrow is ever wanted): persistent blockentity escrow + crash-recovery-across-restart. Favor grants on a completed barter remain #435.

## Test plan
- `dotnet test` — 2544 pass (39 caravan).
- Orchestration (commit / abort-on-missing-items / shrine-break / leash) is unit-tested via a faked inventory seam.
- ⚠️ Real `ItemStack` movement is **play-tested**, not unit-tested (no VS inventory in the test harness — same stance as the existing proximity check). Recommend an in-game two-player swap check before merge.

Refs #434