### PR TITLE
fix(blessings): stop overwriting trait/other-mod max health

### DIFF
--- a/DivineAscension.Tests/Systems/BlessingEffectSystemTests.cs
+++ b/DivineAscension.Tests/Systems/BlessingEffectSystemTests.cs
@@ -754,4 +754,40 @@ public class BlessingEffectSystemTests
     }
 
     #endregion
+
+    #region RegisterStatIfNeeded Tests
+
+    [Fact]
+    public void RegisterStatIfNeeded_PreservesExistingForeignModifiers()
+    {
+        // Arrange - simulate a VS character trait (e.g. a +15 HP "beefy" trait) that already wrote
+        // a flat-points modifier under "maxhealthExtraPoints" via Stats.Set(..., "trait", ...).
+        var stats = new EntityStats(null!);
+        var traitStat = new EntityFloatStats();
+        traitStat.Set("trait", 15f, true);
+        stats[VintageStoryStats.MaxHealthExtraPoints] = traitStat;
+
+        // Act - re-registering the stat (as happens on every player join) must not clobber the trait.
+        BlessingEffectSystem.RegisterStatIfNeeded(
+            stats, VintageStoryStats.MaxHealthExtraPoints, EnumStatBlendType.WeightedSum);
+
+        // Assert - WeightedSum of base(1) + trait(15) survives; the trait's +15 is intact.
+        Assert.Equal(16f, stats.GetBlended(VintageStoryStats.MaxHealthExtraPoints), 3);
+    }
+
+    [Fact]
+    public void RegisterStatIfNeeded_RegistersStatWhenAbsent()
+    {
+        // Arrange - fresh stats with nothing registered.
+        var stats = new EntityStats(null!);
+
+        // Act
+        BlessingEffectSystem.RegisterStatIfNeeded(
+            stats, VintageStoryStats.MaxHealthExtraPoints, EnumStatBlendType.WeightedSum);
+
+        // Assert - newly registered stat carries the default base value of 1.
+        Assert.Equal(1f, stats.GetBlended(VintageStoryStats.MaxHealthExtraPoints), 3);
+    }
+
+    #endregion
 }

--- a/DivineAscension/Systems/BlessingEffectSystem.cs
+++ b/DivineAscension/Systems/BlessingEffectSystem.cs
@@ -484,18 +484,13 @@ public class BlessingEffectSystem : IBlessingEffectSystem
     /// <summary>
     ///     Helper to register a stat only if it doesn't already exist
     /// </summary>
-    private void RegisterStatIfNeeded(EntityStats stats, string statName, EnumStatBlendType blendType)
+    internal static void RegisterStatIfNeeded(EntityStats stats, string statName, EnumStatBlendType blendType)
     {
-        try
-        {
-            // Check if stat already exists by attempting to get it
-            // If it doesn't exist, Register it
-            stats.Register(statName, blendType);
-        }
-        catch (Exception)
-        {
-            // Stat already registered, ignore
-        }
+        foreach (var existing in stats)
+            if (existing.Key == statName)
+                return;
+
+        stats.Register(statName, blendType);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

A player reported that a +15 HP character trait (from another mod) disappeared after choosing the **Iron Will** blessing, and the blessing's +10% then applied only to bare base health (~22 HP).

## Root cause

VS `EntityStats.Register()` **unconditionally replaces** a stat with a fresh `base=1` entry and never throws when the stat already exists:

```csharp
public EntityStats Register(string category, ...) {
    floatStats[category] = new EntityFloatStats(); // wipes existing modifiers
    ...
}
```

`BlessingEffectSystem.RegisterStatIfNeeded` wrapped `Register()` in a `try/catch` that assumed it throws when already registered — dead code. So on **every player join** DA re-registered each custom stat, blowing away modifiers other systems had set.

VS character traits write flat HP via `Stats.Set("maxhealthExtraPoints", "trait", <points>, persistent: true)` (`CharacterSystem.applyTraitAttributes`). Re-registering `maxhealthExtraPoints` deleted the `"trait"` key, so the trait's +15 HP (and any other mod's contributions to shared stats) vanished. `EntityBehaviorHealth.UpdateMaxHealth()` then computed `BaseMaxHealth + (GetBlended − 1)` over the now-empty stat, leaving only the blessing's small bonus.

## Fix

Register a stat only when it does not already exist, so foreign contributions survive.

## Tests

- `RegisterStatIfNeeded_PreservesExistingForeignModifiers` — reproduces the trait wipe; asserts base(1)+trait(15) survives.
- `RegisterStatIfNeeded_RegistersStatWhenAbsent` — still registers when the stat is missing.

Full blessing suite passes (38).