### PR TITLE
fix(blocks): guard BlockBehaviorStone.GetDrops against null player (RustboundMagic crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.8.1] - 2026-01-14
+
+### Fixed
+- Guard BlockBehaviorStone.GetDrops against null player/entity (fixes crash with RustboundMagic spell dig pulses)
+
 ## [4.8.0] - 2026-01-14
 
 ### Added

--- a/DivineAscension/Blocks/BlockBehaviorStone.cs
+++ b/DivineAscension/Blocks/BlockBehaviorStone.cs
@@ -37,7 +37,11 @@ public class BlockBehaviorStone : BlockBehavior
     
     
     /// <summary>
-    /// Intercepts GetDrops
+    /// Intercepts GetDrops to apply the StoneYield blessing bonus to the drop
+    /// chance multiplier. The player, its entity, or its stats may be null
+    /// when a block is broken by a non-player source (e.g. RustboundMagic
+    /// spell dig pulses, gravity, explosions). In those cases we skip the
+    /// bonus and fall through to the base drops instead of crashing.
     /// </summary>
     public override ItemStack[] GetDrops(
         IWorldAccessor world,
@@ -46,7 +50,8 @@ public class BlockBehaviorStone : BlockBehavior
         ref float dropChanceMultiplier,
         ref EnumHandling handling)
     {
-        if (world.Side == EnumAppSide.Server)
+        if (world.Side == EnumAppSide.Server
+            && byPlayer?.Entity?.Stats != null)
         {
             // Apply stone yield bonus to drop multiplier
             var stoneYieldBonus = byPlayer.Entity.Stats.GetBlended(VintageStoryStats.StoneYield);


### PR DESCRIPTION
## Problem

Players using **RustboundMagic** experience a server crash when casting dig spells (e.g. `Dig1`) on stone blocks:

```
[Server Error] Exception: Object reference not set to an instance of an object.
  at DivineAscension.Blocks.BlockBehaviorStone.GetDrops(...)
  at Vintagestory.API.Common.Block.GetDrops_Patch1(...)
  ...
  at rustboundmagic.src.system.interfaces.SpellBase.<>c__DisplayClass150_0.<TriggerDigPulse>b__0(...)
  at Vintagestory.Common.BlockAccessorBase.WalkBlocks(...)
  at rustboundmagic.src.system.interfaces.SpellBase.TriggerDigPulse(...)
```

## Root Cause

`BlockBehaviorStone.GetDrops` dereferences `byPlayer.Entity.Stats` **without any null checks**:

```csharp
var stoneYieldBonus = byPlayer.Entity.Stats.GetBlended(VintageStoryStats.StoneYield);
```

When RustboundMagic's `TriggerDigPulse` breaks stone blocks via `BlockAccessor.BreakBlock` → `WalkBlocks`, the `byPlayer` passed to `GetDrops` can be `null` (or have a null `Entity`/`Stats`), because the spell — not a real player — is doing the digging. The same applies to gravity, explosions, and other non-player block-breaking sources.

The companion `OnBlockBroken` handler in `StoneFavorTracker` already guarded against null players (`if (player == null) return;`), but `GetDrops` was missing the same protection.

## Fix

Changed the guard from `if (world.Side == EnumAppSide.Server)` to:

```csharp
if (world.Side == EnumAppSide.Server
    && byPlayer?.Entity?.Stats != null)
```

When the player/entity/stats are unavailable, the StoneYield blessing bonus is simply skipped and the method falls through to `base.GetDrops(...)` — the block still drops normally, just without the yield multiplier. This is correct since the bonus only makes sense for a real player with active blessings.

## Testing

- ✅ Project builds cleanly (0 errors)
- ✅ All 2546 unit tests pass