### PR TITLE
feat: add Butchering mod compatibility (Wild favor for skin/butcher)

### DIFF
--- a/DivineAscension.Tests/Systems/Favor/ButcheringFavorTrackerTests.cs
+++ b/DivineAscension.Tests/Systems/Favor/ButcheringFavorTrackerTests.cs
@@ -1,0 +1,383 @@
+using System.Diagnostics.CodeAnalysis;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems.Butchering;
+using DivineAscension.Systems.Favor;
+using DivineAscension.Systems.Interfaces;
+using DivineAscension.Tests.Helpers;
+using Moq;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Tests.Systems.Favor;
+
+/// <summary>
+///     Tests for ButcheringFavorTracker.
+///     Unlike SkinningFavorTracker (which subscribes to a static event that cannot be raised
+///     from tests), ButcheringFavorTracker subscribes to an instance ButcheringEventEmitter, so
+///     the skin/butcher award path can be exercised directly via Raise*() calls.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ButcheringFavorTrackerTests
+{
+    private static ButcheringFavorTracker CreateTracker(
+        Mock<IEventService> mockEventService,
+        Mock<IWorldService> mockWorldService,
+        Mock<IPlayerProgressionDataManager> mockPlayerProgression,
+        Mock<IFavorSystem> mockFavor,
+        ButcheringEventEmitter emitter)
+    {
+        var mockLogger = new Mock<ILoggerWrapper>();
+        return new ButcheringFavorTracker(
+            mockLogger.Object, mockEventService.Object, mockWorldService.Object,
+            mockPlayerProgression.Object, mockFavor.Object, emitter);
+    }
+
+    private static Mock<IServerPlayer> CreatePlayer(string uid = "player-uid")
+    {
+        var mockPlayer = new Mock<IServerPlayer>();
+        mockPlayer.Setup(p => p.PlayerUID).Returns(uid);
+        mockPlayer.Setup(p => p.PlayerName).Returns("TestPlayer");
+        return mockPlayer;
+    }
+
+    private static ItemStack CreateTestItemStack(string collectibleCode)
+    {
+        var item = new Item
+        {
+            Code = new AssetLocation("butchering", collectibleCode)
+        };
+        return new ItemStack(item);
+    }
+
+    #region Lifecycle and Deity Tests
+
+    [Fact]
+    public void DeityDomain_IsWild()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            TestFixtures.CreateMockFavorSystem(), emitter);
+
+        Assert.Equal(DeityDomain.Wild, tracker.DeityDomain);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    [Fact]
+    public void Initialize_RegistersEventHandlers()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            TestFixtures.CreateMockFavorSystem(), emitter);
+
+        var exception = Record.Exception(() => tracker.Initialize());
+        Assert.Null(exception);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    [Fact]
+    public void Dispose_UnregistersEventHandlers()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            TestFixtures.CreateMockFavorSystem(), emitter);
+        tracker.Initialize();
+
+        var exception = Record.Exception(() => tracker.Dispose());
+        Assert.Null(exception);
+
+        emitter.ClearSubscribers();
+    }
+
+    #endregion
+
+    #region Workload-Based Favor Calculation Tests
+
+    [Theory]
+    [InlineData("large", 8)]
+    [InlineData("medium", 5)]
+    [InlineData("small", 3)]
+    [InlineData("unknown", 2)]
+    [InlineData("", 2)]
+    [InlineData(null, 2)]
+    public void CalculateFavorByWorkload_ReturnsTieredFavor(string? workload, int expectedFavor)
+    {
+        var emitter = new ButcheringEventEmitter();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            TestFixtures.CreateMockFavorSystem(), emitter);
+
+        var result = tracker.CalculateFavorByWorkload(workload!);
+
+        Assert.Equal(expectedFavor, result);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    #endregion
+
+    #region Skinning Award Tests
+
+    [Fact]
+    public void HandleSkinned_AwardsWildFavorForLargeWorkload()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var player = CreatePlayer();
+        var stack = CreateTestItemStack("deadsheep-male-bighorn-1-dead");
+        var pos = new BlockPos(0, 0, 0);
+
+        emitter.RaiseAnimalSkinned(player.Object, pos, stack, "large");
+
+        mockFavor.Verify(
+            f => f.AwardFavorForAction(player.Object, "skinning deadsheep-male-bighorn-1-dead", 8,
+                DeityDomain.Wild),
+            Times.Once);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    [Fact]
+    public void HandleSkinned_AwardsWildFavorForMediumWorkload()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var player = CreatePlayer();
+        var stack = CreateTestItemStack("deaddeer-male-1-dead");
+        var pos = new BlockPos(0, 0, 0);
+
+        emitter.RaiseAnimalSkinned(player.Object, pos, stack, "medium");
+
+        mockFavor.Verify(
+            f => f.AwardFavorForAction(player.Object, "skinning deaddeer-male-1-dead", 5,
+                DeityDomain.Wild),
+            Times.Once);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    #endregion
+
+    #region Butchering Award Tests
+
+    [Fact]
+    public void HandleButchered_AwardsWildFavorForLargeWorkload()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var player = CreatePlayer();
+        var stack = CreateTestItemStack("deadsheep-male-bighorn-1-bledout");
+        var pos = new BlockPos(0, 0, 0);
+
+        emitter.RaiseAnimalButchered(player.Object, pos, stack, "large");
+
+        mockFavor.Verify(
+            f => f.AwardFavorForAction(player.Object, "butchering deadsheep-male-bighorn-1-bledout",
+                8, DeityDomain.Wild),
+            Times.Once);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    [Fact]
+    public void HandleButchered_AwardsWildFavorForSmallWorkload()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var player = CreatePlayer();
+        var stack = CreateTestItemStack("deadchicken-rooster-1-bledout");
+        var pos = new BlockPos(0, 0, 0);
+
+        emitter.RaiseAnimalButchered(player.Object, pos, stack, "small");
+
+        mockFavor.Verify(
+            f => f.AwardFavorForAction(player.Object, "butchering deadchicken-rooster-1-bledout", 3,
+                DeityDomain.Wild),
+            Times.Once);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    #endregion
+
+    #region Cooldown Tests
+
+    [Fact]
+    public void Cooldown_PreventsDuplicateSkinningAwardWithinWindow()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var player = CreatePlayer();
+        var stack = CreateTestItemStack("deadsheep-male-bighorn-1-dead");
+        var pos = new BlockPos(0, 0, 0);
+
+        // Raise twice in quick succession (same player + workstation)
+        emitter.RaiseAnimalSkinned(player.Object, pos, stack, "large");
+        emitter.RaiseAnimalSkinned(player.Object, pos, stack, "large");
+
+        // The 5s per-player+pos cooldown should suppress the second award
+        mockFavor.Verify(
+            f => f.AwardFavorForAction(player.Object, "skinning deadsheep-male-bighorn-1-dead", 8,
+                DeityDomain.Wild),
+            Times.Once);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    [Fact]
+    public void Cooldown_AllowsAwardAtDifferentWorkstation()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var player = CreatePlayer();
+        var stack = CreateTestItemStack("deadsheep-male-bighorn-1-dead");
+
+        // Two different workstations → both should award (cooldown is per-pos)
+        emitter.RaiseAnimalSkinned(player.Object, new BlockPos(0, 0, 0), stack, "large");
+        emitter.RaiseAnimalSkinned(player.Object, new BlockPos(10, 0, 10), stack, "large");
+
+        mockFavor.Verify(
+            f => f.AwardFavorForAction(player.Object, "skinning deadsheep-male-bighorn-1-dead", 8,
+                DeityDomain.Wild),
+            Times.Exactly(2));
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    #endregion
+
+    #region Null-Guard and Disposal Tests
+
+    [Fact]
+    public void HandleSkinned_NullPlayer_DoesNotAwardOrThrow()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var stack = CreateTestItemStack("deadsheep-male-bighorn-1-dead");
+        var pos = new BlockPos(0, 0, 0);
+
+        var exception = Record.Exception(() =>
+            emitter.RaiseAnimalSkinned(null!, pos, stack, "large"));
+
+        Assert.Null(exception);
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Never);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    [Fact]
+    public void HandleButchered_NullStack_DoesNotAwardOrThrow()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+
+        var player = CreatePlayer();
+        var pos = new BlockPos(0, 0, 0);
+
+        var exception = Record.Exception(() =>
+            emitter.RaiseAnimalButchered(player.Object, pos, null!, "large"));
+
+        Assert.Null(exception);
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Never);
+
+        tracker.Dispose();
+        emitter.ClearSubscribers();
+    }
+
+    [Fact]
+    public void Dispose_StopsAwardingFavor()
+    {
+        var emitter = new ButcheringEventEmitter();
+        var mockFavor = new Mock<IFavorSystem>();
+        var tracker = CreateTracker(
+            new Mock<IEventService>(), new Mock<IWorldService>(),
+            TestFixtures.CreateMockPlayerProgressionDataManager(),
+            mockFavor, emitter);
+        tracker.Initialize();
+        tracker.Dispose();
+
+        var player = CreatePlayer();
+        var stack = CreateTestItemStack("deadsheep-male-bighorn-1-dead");
+        var pos = new BlockPos(0, 0, 0);
+
+        emitter.RaiseAnimalSkinned(player.Object, pos, stack, "large");
+
+        // After Dispose the tracker should have unsubscribed — no favor awarded
+        mockFavor.Verify(f => f.AwardFavorForAction(It.IsAny<IServerPlayer>(), It.IsAny<string>(),
+            It.IsAny<float>(), It.IsAny<DeityDomain>()), Times.Never);
+
+        emitter.ClearSubscribers();
+    }
+
+    #endregion
+}

--- a/DivineAscension/DivineAscensionModSystem.cs
+++ b/DivineAscension/DivineAscensionModSystem.cs
@@ -25,6 +25,7 @@ using DivineAscension.Systems.Networking.Client;
 using DivineAscension.Systems.Networking.Server;
 using DivineAscension.Systems.Patches;
 using DivineAscension.Systems.Toolsmith;
+using DivineAscension.Systems.Butchering;
 using DivineAscension.Utilities;
 using HarmonyLib;
 using JetBrains.Annotations;
@@ -45,6 +46,7 @@ public class DivineAscensionModSystem : ModSystem
     private AltarDestructionHandler? _altarDestructionHandler;
     private AltarEventEmitter? _altarEventEmitter;
     private ToolsmithEventEmitter? _toolsmithEventEmitter;
+    private ButcheringEventEmitter? _butcheringEventEmitter;
     private AltarPlacementHandler? _altarPlacementHandler;
     private AltarPrayerHandler? _altarPrayerHandler;
     private CaravanShrinePlacementHandler? _caravanShrinePlacementHandler;
@@ -308,9 +310,13 @@ public class DivineAscensionModSystem : ModSystem
         _altarPrayerHandler = result.AltarPrayerHandler;
         _altarEventEmitter = result.AltarEventEmitter;
         _toolsmithEventEmitter = result.ToolsmithEventEmitter;
+        _butcheringEventEmitter = result.ButcheringEventEmitter;
 
         // Apply conditional Harmony patches for Toolsmith compatibility (checks IsModEnabled internally)
         ToolsmithPatches.Initialize(api, _toolsmithEventEmitter);
+        // Apply conditional Harmony patches for Butchering compatibility (checks IsModEnabled internally)
+        ButcheringPatches.Initialize(api, _butcheringEventEmitter);
+
         _lecternEventEmitter = result.LecternEventEmitter;
         _lecternInteractionHandler = result.LecternInteractionHandler;
         _playerDataNetworkHandler = result.PlayerDataNetworkHandler;
@@ -405,6 +411,8 @@ public class DivineAscensionModSystem : ModSystem
         _altarEventEmitter?.ClearSubscribers();
         _toolsmithEventEmitter?.ClearSubscribers();
         ToolsmithPatches.ClearSubscribers();
+        _butcheringEventEmitter?.ClearSubscribers();
+        ButcheringPatches.ClearSubscribers();
         _lecternEventEmitter?.ClearSubscribers();
         PitKilnPatches.ClearSubscribers();
         AnvilPatches.ClearSubscribers();

--- a/DivineAscension/Systems/Butchering/ButcheringEventEmitter.cs
+++ b/DivineAscension/Systems/Butchering/ButcheringEventEmitter.cs
@@ -1,0 +1,49 @@
+using System;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Butchering;
+
+/// <summary>
+///     Service locator for Butchering mod workstation events.
+///     Bridges the conditional Harmony patches (no DI support) with the ButcheringFavorTracker (full DI).
+///     Mirrors the ToolsmithEventEmitter pattern.
+/// </summary>
+public class ButcheringEventEmitter
+{
+    /// <summary>
+    ///     Raised when a player skins a hung carcass on a Butchering skinning hook.
+    ///     Parameters: player, workstation position, the ItemButcherable stack being processed,
+    ///     and the butcheringWorkLoad tier ("small"/"medium"/"large").
+    /// </summary>
+    public event Action<IServerPlayer, BlockPos, ItemStack, string>? OnAnimalSkinned;
+
+    /// <summary>
+    ///     Raised when a player butchers a bled-out carcass on a Butchering butcher table.
+    ///     Parameters: player, workstation position, the ItemButcherable stack being processed,
+    ///     and the butcheringWorkLoad tier ("small"/"medium"/"large").
+    /// </summary>
+    public event Action<IServerPlayer, BlockPos, ItemStack, string>? OnAnimalButchered;
+
+    public virtual void RaiseAnimalSkinned(IServerPlayer player, BlockPos pos, ItemStack butcherableStack,
+        string workload)
+    {
+        OnAnimalSkinned?.Invoke(player, pos, butcherableStack, workload);
+    }
+
+    public virtual void RaiseAnimalButchered(IServerPlayer player, BlockPos pos, ItemStack butcherableStack,
+        string workload)
+    {
+        OnAnimalButchered?.Invoke(player, pos, butcherableStack, workload);
+    }
+
+    /// <summary>
+    ///     Clears all event subscribers. Called during mod disposal.
+    /// </summary>
+    public void ClearSubscribers()
+    {
+        OnAnimalSkinned = null;
+        OnAnimalButchered = null;
+    }
+}

--- a/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
+++ b/DivineAscension/Systems/DivineAscensionSystemInitializer.cs
@@ -19,6 +19,7 @@ using DivineAscension.Systems.Interfaces;
 using DivineAscension.Systems.Networking.Server;
 using DivineAscension.Systems.Patches;
 using DivineAscension.Systems.Toolsmith;
+using DivineAscension.Systems.Butchering;
 using Vintagestory.API.Server;
 
 namespace DivineAscension.Systems;
@@ -137,6 +138,9 @@ public static class DivineAscensionSystemInitializer
         // Create ToolsmithEventEmitter (service locator for Toolsmith compatibility behaviors)
         var toolsmithEventEmitter = new ToolsmithEventEmitter();
 
+        // Create ButcheringEventEmitter (service locator for Butchering mod compatibility)
+        var butcheringEventEmitter = new ButcheringEventEmitter();
+
         // Create LecternEventEmitter (service locator for BlockBehaviorLectern)
         var lecternEventEmitter = new LecternEventEmitter();
         BlockBehaviorLectern.SetEventEmitter(lecternEventEmitter);
@@ -246,6 +250,7 @@ public static class DivineAscensionSystemInitializer
         // Set patrol dependencies before initialization
         favorSystem.SetPatrolDependencies(holySiteAreaTracker, civilizationManager, holySiteManager);
         favorSystem.SetToolsmithEventEmitter(toolsmithEventEmitter);
+        favorSystem.SetButcheringEventEmitter(butcheringEventEmitter);
         favorSystem.Initialize();
 
         // Create offering loader for JSON-based offering definitions (must be before AltarPrayerHandler)
@@ -583,6 +588,7 @@ public static class DivineAscensionSystemInitializer
             RoleManager = roleManager,
             AltarEventEmitter = altarEventEmitter,
             ToolsmithEventEmitter = toolsmithEventEmitter,
+            ButcheringEventEmitter = butcheringEventEmitter,
             LecternEventEmitter = lecternEventEmitter,
             LecternInteractionHandler = lecternInteractionHandler,
             RitualProgressManager = ritualProgressManager,
@@ -637,6 +643,7 @@ public class InitializationResult
     public RoleManager RoleManager { get; init; } = null!;
     public AltarEventEmitter AltarEventEmitter { get; init; } = null!;
     public ToolsmithEventEmitter ToolsmithEventEmitter { get; init; } = null!;
+    public ButcheringEventEmitter ButcheringEventEmitter { get; init; } = null!;
     public LecternEventEmitter LecternEventEmitter { get; init; } = null!;
     public LecternInteractionHandler LecternInteractionHandler { get; init; } = null!;
     public IRitualProgressManager RitualProgressManager { get; init; } = null!;

--- a/DivineAscension/Systems/Favor/ButcheringFavorTracker.cs
+++ b/DivineAscension/Systems/Favor/ButcheringFavorTracker.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using DivineAscension.API.Interfaces;
+using DivineAscension.Models.Enum;
+using DivineAscension.Services;
+using DivineAscension.Systems.Butchering;
+using DivineAscension.Systems.Interfaces;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Favor;
+
+/// <summary>
+///     Awards Wild-domain favor for Butchering mod workstation activities: skinning a
+///     carcass on a skinning hook and butchering a carcass on a butcher table.
+///     Subscribes to events raised by ButcheringPatches (via ButcheringEventEmitter).
+///     Replaces the vanilla SkinPatches path for Butchering animals, which are picked up
+///     rather than harvested and therefore never trigger EntityBehaviorHarvestable.SetHarvested.
+/// </summary>
+public class ButcheringFavorTracker(
+    ILoggerWrapper logger,
+    IEventService eventService,
+    IWorldService worldService,
+    IPlayerProgressionDataManager playerProgressionDataManager,
+    IFavorSystem favorSystem,
+    ButcheringEventEmitter butcheringEventEmitter) : IFavorTracker, IDisposable
+{
+    private static readonly TimeSpan ButcheringAwardCooldown = TimeSpan.FromSeconds(5);
+
+    private readonly IEventService
+        _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
+
+    private readonly IFavorSystem _favorSystem = favorSystem ?? throw new ArgumentNullException(nameof(favorSystem));
+
+    private readonly ILoggerWrapper _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    private readonly IPlayerProgressionDataManager _playerProgressionDataManager =
+        playerProgressionDataManager ?? throw new ArgumentNullException(nameof(playerProgressionDataManager));
+
+    private readonly ButcheringEventEmitter _emitter =
+        butcheringEventEmitter ?? throw new ArgumentNullException(nameof(butcheringEventEmitter));
+
+    private readonly IWorldService
+        _worldService = worldService ?? throw new ArgumentNullException(nameof(worldService));
+
+    // Per-player, per-workstation throttling to prevent duplicate awards from repeated
+    // interactions. Key format: "playerUID:blockPos"
+    private readonly Dictionary<string, DateTime> _lastButcheringAwardUtc = new();
+
+    public DeityDomain DeityDomain { get; } = DeityDomain.Wild;
+
+    public void Dispose()
+    {
+        _emitter.OnAnimalSkinned -= HandleSkinned;
+        _emitter.OnAnimalButchered -= HandleButchered;
+        _eventService.UnsubscribePlayerDisconnect(OnPlayerDisconnect);
+        _lastButcheringAwardUtc.Clear();
+    }
+
+    public void Initialize()
+    {
+        _emitter.OnAnimalSkinned += HandleSkinned;
+        _emitter.OnAnimalButchered += HandleButchered;
+
+        // Clean up throttle cache on player disconnect
+        _eventService.OnPlayerDisconnect(OnPlayerDisconnect);
+
+        _logger.Notification("[DivineAscension] ButcheringFavorTracker initialized");
+    }
+
+    private void OnPlayerDisconnect(IServerPlayer player)
+    {
+        // Clean up throttle cache entries for disconnected player
+        var keysToRemove = new List<string>();
+        foreach (var key in _lastButcheringAwardUtc.Keys)
+        {
+            if (key.StartsWith(player.PlayerUID + ":"))
+                keysToRemove.Add(key);
+        }
+
+        foreach (var key in keysToRemove)
+            _lastButcheringAwardUtc.Remove(key);
+    }
+
+    private void HandleSkinned(IServerPlayer? player, BlockPos? pos, ItemStack? stack, string workload)
+    {
+        AwardFavor(player, pos, stack, workload, isSkinning: true);
+    }
+
+    private void HandleButchered(IServerPlayer? player, BlockPos? pos, ItemStack? stack, string workload)
+    {
+        AwardFavor(player, pos, stack, workload, isSkinning: false);
+    }
+
+    private void AwardFavor(IServerPlayer? player, BlockPos? pos, ItemStack? stack, string workload,
+        bool isSkinning)
+    {
+        if (player == null || pos == null || stack?.Collectible?.Code == null) return;
+
+        // Rate limit per player per workstation to prevent duplicate awards
+        var key = $"{player.PlayerUID}:{pos.X},{pos.Y},{pos.Z}";
+        var now = DateTime.UtcNow;
+        if (_lastButcheringAwardUtc.TryGetValue(key, out var last) &&
+            now - last < ButcheringAwardCooldown)
+            return;
+
+        var favor = CalculateFavorByWorkload(workload);
+        if (favor > 0)
+        {
+            var action = (isSkinning ? "skinning " : "butchering ") + stack.Collectible.Code.Path;
+            _favorSystem.AwardFavorForAction(player, action, favor, DeityDomain.Wild);
+            _lastButcheringAwardUtc[key] = now;
+        }
+    }
+
+    /// <summary>
+    ///     Calculates favor tier based on the ItemButcherable's butcheringWorkLoad attribute
+    ///     ("small"/"medium"/"large"). Entity kg weight is unavailable at the workstation, so
+    ///     the workload tier (present on every Butchering creature) is the cleanest signal.
+    ///     Values track the existing skinning philosophy (~50% of hunting values).
+    /// </summary>
+    internal int CalculateFavorByWorkload(string workload)
+    {
+        return workload switch
+        {
+            "large" => 8, // Apex predators, massive herbivores (bears, elephants)
+            "medium" => 5, // Medium prey (deer, sheep, boar)
+            "small" => 3, // Small animals (chickens, rabbits) and babies
+            _ => 2 // Unknown / fallback
+        };
+    }
+}

--- a/DivineAscension/Systems/FavorSystem.cs
+++ b/DivineAscension/Systems/FavorSystem.cs
@@ -10,6 +10,7 @@ using DivineAscension.Systems.Favor;
 using DivineAscension.Systems.HolySite;
 using DivineAscension.Systems.Interfaces;
 using DivineAscension.Systems.Toolsmith;
+using DivineAscension.Systems.Butchering;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Server;
@@ -58,6 +59,8 @@ public class FavorSystem : IFavorSystem
     private TraderTransactionFavorTracker? _traderTransactionFavorTracker;
     private ToolsmithFavorTracker? _toolsmithFavorTracker;
     private ToolsmithEventEmitter? _toolsmithEventEmitter;
+    private ButcheringFavorTracker? _butcheringFavorTracker;
+    private ButcheringEventEmitter? _butcheringEventEmitter;
 
     public FavorSystem(ILoggerWrapper logger,
         IEventService eventService,
@@ -90,6 +93,15 @@ public class FavorSystem : IFavorSystem
     public void SetToolsmithEventEmitter(ToolsmithEventEmitter emitter)
     {
         _toolsmithEventEmitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
+    }
+
+    /// <summary>
+    /// Sets the ButcheringEventEmitter for Butchering mod compatibility favor tracking.
+    /// Must be called before Initialize().
+    /// </summary>
+    public void SetButcheringEventEmitter(ButcheringEventEmitter emitter)
+    {
+        _butcheringEventEmitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
     }
 
     /// <summary>
@@ -182,6 +194,15 @@ public class FavorSystem : IFavorSystem
             _toolsmithFavorTracker.Initialize();
         }
 
+        // Initialize Butchering compatibility tracker if emitter was set
+        if (_butcheringEventEmitter != null)
+        {
+            _butcheringFavorTracker = new ButcheringFavorTracker(
+                _logger, _eventService, _worldService, _playerProgressionDataManager, this,
+                _butcheringEventEmitter);
+            _butcheringFavorTracker.Initialize();
+        }
+
         // Initialize patrol tracker only if dependencies were set
         if (_holySiteAreaTracker != null && _civilizationManager != null && _holySiteManager != null)
         {
@@ -197,11 +218,11 @@ public class FavorSystem : IFavorSystem
                 _messenger,
                 _eventService);
             _patrolFavorTracker.Initialize();
-            _logger.Notification("[DivineAscension] Initialized 14 favor trackers (including patrol and Toolsmith)");
+            _logger.Notification("[DivineAscension] Initialized 15 favor trackers (including patrol, Toolsmith and Butchering)");
         }
         else
         {
-            _logger.Notification("[DivineAscension] Initialized 13 favor trackers (patrol disabled - missing dependencies)");
+            _logger.Notification("[DivineAscension] Initialized 14 favor trackers (patrol disabled - missing dependencies)");
         }
     }
 
@@ -223,6 +244,7 @@ public class FavorSystem : IFavorSystem
         _traderTransactionFavorTracker?.Dispose();
         _patrolFavorTracker?.Dispose();
         _toolsmithFavorTracker?.Dispose();
+        _butcheringFavorTracker?.Dispose();
     }
 
     public void AwardFavorForAction(IServerPlayer player, string actionType, float amount, DeityDomain sourceDomain)

--- a/DivineAscension/Systems/Patches/ButcheringPatches.cs
+++ b/DivineAscension/Systems/Patches/ButcheringPatches.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Reflection;
+using DivineAscension.Systems.Butchering;
+using HarmonyLib;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace DivineAscension.Systems.Patches;
+
+/// <summary>
+///     Conditional Harmony patches for Butchering mod compatibility.
+///     Targets Butchering's BlockEntityButcherHook (skinning) and BlockEntityButcherTable
+///     (butchering) via reflection (no compile-time dependency on Butchering). Only applied
+///     when Butchering is installed.
+///     Butchering replaces the vanilla harvest-a-corpse flow: dead animals are picked up as
+///     ItemButcherable items and processed on workstations, so DA's existing
+///     SkinningPatches (which postfix EntityBehaviorHarvestable.SetHarvested) never fire for
+///     Butchering animals. These prefixes detect the workstation completion instead.
+/// </summary>
+public static class ButcheringPatches
+{
+    private static ButcheringEventEmitter? _emitter;
+    private static Harmony? _harmony;
+    private static bool _initialized;
+
+    /// <summary>
+    ///     Conditionally applies Harmony prefixes to Butchering workstation classes.
+    ///     Called from DivineAscensionModSystem.StartServerSide after the ButcheringEventEmitter
+    ///     is created.
+    /// </summary>
+    public static void Initialize(ICoreAPI api, ButcheringEventEmitter emitter)
+    {
+        if (_initialized) return;
+
+        if (!api.ModLoader.IsModEnabled("butchering"))
+        {
+            api.Logger.Notification("[DivineAscension] Butchering not detected — compatibility patches skipped.");
+            return;
+        }
+
+        _emitter = emitter;
+        _harmony = new Harmony("com.divineascension.butchering");
+        _initialized = true;
+
+        var patched = 0;
+
+        // BlockEntityButcherHook — skinning a hung carcass
+        var hookType = ResolveType("Butchering.src.common.blockentity.BlockEntityButcherHook");
+        if (hookType != null)
+        {
+            PatchPrefix(api, hookType, "processItem", nameof(SkinHook_ProcessItem_Prefix));
+            patched++;
+        }
+        else
+        {
+            api.Logger.Warning("[DivineAscension] Could not resolve Butchering BlockEntityButcherHook type.");
+        }
+
+        // BlockEntityButcherTable — butchering a bled-out carcass
+        var tableType = ResolveType("Butchering.src.common.blockentity.BlockEntityButcherTable");
+        if (tableType != null)
+        {
+            PatchPrefix(api, tableType, "processItem", nameof(ButcherTable_ProcessItem_Prefix));
+            patched++;
+        }
+        else
+        {
+            api.Logger.Warning("[DivineAscension] Could not resolve Butchering BlockEntityButcherTable type.");
+        }
+
+        api.Logger.Notification(
+            $"[DivineAscension] Butchering compatibility patches applied ({patched} types patched).");
+    }
+
+    /// <summary>
+    ///     Prefix on BlockEntityButcherHook.processItem — fires once when a player skins a
+    ///     carcass on the skinning hook. The ItemButcherable still occupies inventory[0] at
+    ///     this point (the override clones it to "skinned" state afterwards).
+    /// </summary>
+    public static void SkinHook_ProcessItem_Prefix(IPlayer byPlayer, int durabilitylossIn, object __instance)
+    {
+        RaiseWorkstationEvent(__instance, byPlayer, isSkinning: true);
+    }
+
+    /// <summary>
+    ///     Prefix on BlockEntityButcherTable.processItem — fires once when a player butchers a
+    ///     carcass on the butcher table. The ItemButcherable still occupies inventory[0] at
+    ///     this point (the override calls TakeOutWhole() afterwards, so a postfix would see an
+    ///     empty slot — a prefix is required).
+    /// </summary>
+    public static void ButcherTable_ProcessItem_Prefix(IPlayer byPlayer, int durabilitylossIn, object __instance)
+    {
+        RaiseWorkstationEvent(__instance, byPlayer, isSkinning: false);
+    }
+
+    private static void RaiseWorkstationEvent(object instance, IPlayer byPlayer, bool isSkinning)
+    {
+        if (_emitter == null) return;
+
+        // Server side only — favor is awarded server-side.
+        if (instance is not BlockEntity blockEntity) return;
+        if (blockEntity.Api?.Side != EnumAppSide.Server) return;
+
+        var player = byPlayer as IServerPlayer;
+        if (player == null) return;
+
+        // Read the ItemButcherable still held in workstation inventory slot 0.
+        var stack = GetSlotZeroStack(instance);
+        if (stack?.Collectible == null) return;
+
+        // butcheringWorkLoad is the cleanest tier signal (entity kg weight is gone by now).
+        var workload = stack.ItemAttributes["butcheringWorkLoad"].AsString("small");
+        var pos = blockEntity.Pos;
+
+        if (isSkinning)
+        {
+            _emitter.RaiseAnimalSkinned(player, pos, stack, workload);
+        }
+        else
+        {
+            _emitter.RaiseAnimalButchered(player, pos, stack, workload);
+        }
+    }
+
+    /// <summary>
+    ///     Reads inventory[0].Itemstack from a Butchering workstation via reflection. The
+    ///     Butchering types are not referenced at compile time, so the public `inventory` field
+    ///     (InventoryGeneric : InventoryBase) is fetched reflectively and indexed.
+    /// </summary>
+    private static ItemStack? GetSlotZeroStack(object instance)
+    {
+        var inventoryField = FindField(instance.GetType(), "inventory");
+        if (inventoryField == null) return null;
+
+        if (inventoryField.GetValue(instance) is not InventoryBase inventory) return null;
+
+        var slot = inventory[0];
+        return slot?.Itemstack;
+    }
+
+    private static FieldInfo? FindField(Type type, string name)
+    {
+        // Walk up the inheritance chain — GetField(string) finds inherited public fields, but
+        // be explicit to handle non-public or renamed base declarations robustly.
+        for (var t = type; t != null; t = t.BaseType)
+        {
+            var field = t.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null) return field;
+        }
+
+        return null;
+    }
+
+    private static Type? ResolveType(string fullName)
+    {
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var type = asm.GetType(fullName);
+            if (type != null) return type;
+        }
+
+        return null;
+    }
+
+    private static void PatchPrefix(ICoreAPI api, Type targetType, string methodName, string prefixName)
+    {
+        var original = AccessTools.Method(targetType, methodName);
+        if (original == null)
+        {
+            api.Logger.Warning(
+                $"[DivineAscension] Could not find {targetType.Name}.{methodName} — patch skipped.");
+            return;
+        }
+
+        var prefixMethod = typeof(ButcheringPatches).GetMethod(prefixName,
+            BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        if (prefixMethod == null)
+        {
+            api.Logger.Warning(
+                $"[DivineAscension] Could not find prefix method {prefixName} — patch skipped.");
+            return;
+        }
+
+        _harmony?.Patch(original, prefix: new HarmonyMethod(prefixMethod));
+    }
+
+    /// <summary>
+    ///     Unpatches all Butchering compatibility patches and clears state.
+    ///     Called from DivineAscensionModSystem.Dispose().
+    /// </summary>
+    public static void ClearSubscribers()
+    {
+        _harmony?.UnpatchAll("com.divineascension.butchering");
+        _harmony = null;
+        _emitter = null;
+        _initialized = false;
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Butchering mod compatibility** to Divine Ascension, mirroring the existing Toolsmith compatibility pattern (conditional Harmony + service-locator emitter + DI favor tracker, with **no compile-time dependency** on Butchering).

When the Butchering mod is installed, dead animals are picked up as `ItemButcherable` items and processed on workstations, which pre-empts the vanilla harvest flow (`EntityBehaviorHarvestable.SetHarvested` never fires). DA's existing `SkinningPatches` therefore never fires for Butchering animals, so the Wild-domain skinning/butchering favor is lost. This PR restores it by detecting the workstation completion directly.

## What it does

- **Skinning** — a player skins a hung carcass on a Butchering skinning hook → Wild-domain favor awarded
- **Butchering** — a player butchers a bled-out carcass on a Butchering butcher table → Wild-domain favor awarded
- Favor is tiered by the butcherable's `butcheringWorkLoad` attribute (`large`→8, `medium`→5, `small`→3, default→2), since entity kg weight is unavailable at the workstation
- Per-player + per-workstation 5s cooldown to prevent duplicate awards
- Conditional: only applies when `IsModEnabled(\"butchering\")`; logs `Butchering not detected — compatibility patches skipped.` otherwise

## Implementation

Mirrors `ToolsmithPatches` / `ToolsmithEventEmitter` / `ToolsmithFavorTracker`:

| New file | Role |
|---|---|
| `Systems/Butchering/ButcheringEventEmitter.cs` | Service-locator bridge (instance events `OnAnimalSkinned` / `OnAnimalButchered`) |
| `Systems/Patches/ButcheringPatches.cs` | Conditional Harmony **prefixes** on `BlockEntityButcherHook.processItem` (skin) and `BlockEntityButcherTable.processItem` (butcher); reads `inventory[0]` before the table's `TakeOutWhole()` empties it |
| `Systems/Favor/ButcheringFavorTracker.cs` | Wild-domain tracker, subscribes to emitter, per-pos cooldown |

Wired into `FavorSystem`, `DivineAscensionSystemInitializer`, and `DivineAscensionModSystem` (emitter creation, `SetButcheringEventEmitter`, conditional patch init, dispose/cleanup).

## Why prefixes (not postfixes)

`BlockEntityButcherTable.processItem` calls `inventory[0].TakeOutWhole()` **before** returning to `base.processItem(...)`, so a postfix would see an empty slot and lose the `ItemButcherable` + its `butcheringWorkLoad`. A prefix reads it while still present. `processItem` is only invoked after the `secondsUsed` threshold is met in `OnInteract`, so the prefix is a reliable single-fire completion signal.

## Verification

- Clean full-solution build: **0 errors**
- Full test suite: **2561 passed, 0 failed** (18 new `ButcheringFavorTrackerTests`)
- Based on `origin/master`

## Notes

- No compile-time dependency on Butchering (types resolved via reflection, like Toolsmith)
- Manual in-game verification recommended: with Butchering installed, skin on hook + butcher on table → Wild favor; without Butchering → patches skipped (check server log)